### PR TITLE
Convert build.properties to a template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+psm-app/build.properties

--- a/psm-app/build.properties
+++ b/psm-app/build.properties
@@ -1,8 +1,0 @@
-jboss.home=/home/owenja/Documents/work/OpenTechStrategies/wildfly-10.1.0.Final
-jBPM.home=/home/apps/jbpm-5.3.0.Final-bin
-
-jboss.config=default
-
-jdbc.url=jdbc:postgresql:owenja
-jdbc.user=owenja
-jdbc.pass=owenja

--- a/psm-app/build.properties.template
+++ b/psm-app/build.properties.template
@@ -1,0 +1,8 @@
+jboss.home=__PATH_TO__/wildfly-10.1.0.Final
+jBPM.home=__PATH_TO__/jbpm-5.3.0.Final-bin
+
+jboss.config=default
+
+jdbc.url=jdbc:postgresql:__DB_NAME__
+jdbc.user=__DB_USER__
+jdbc.pass=__DB_PASSWORD__


### PR DESCRIPTION
Remove installation-specific information, and add that file to .gitignore, so we don't accidentally check in secrets in the future.