### PR TITLE
Allow user sign in / sign up

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -295,6 +295,12 @@ EOF
    If you have a previous build deployed already, you can replace the
    deployment in the UI or add the `--force` switch after `deploy`.
 
+1. Create database schema and initial data. Use the seed data to create tables:
+
+  ```ShellSession
+  $ psql -h localhost -U psm psm < /path/to/psm/psm-app/db/seed.sql
+  ```
+
 1. To check that the app is running, navigate to
    http://localhost:8080/cms/login.  You should see a login screen.
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -197,7 +197,7 @@ public class RegistrationServiceBean extends BaseService implements Registration
             throw new IllegalArgumentException("email is required by this implementation.");
         }
 
-        String userId = createUser(null, SystemId.CMS_ONLINE, registrant);
+        String userId = createUser(null, registrant);
 
         String password = passwordGenerator.nextString();
         identityProvider.provisionUser(registrant, password);
@@ -225,7 +225,7 @@ public class RegistrationServiceBean extends BaseService implements Registration
         throws PortalServiceException {
 
         // create only in database (no LDAP account)
-        String userId = createUser(null, systemId, registrant);
+        String userId = createUser(null, registrant);
 
         ExternalAccountLink link = new ExternalAccountLink();
         link.setSystemId(systemId);
@@ -456,15 +456,12 @@ public class RegistrationServiceBean extends BaseService implements Registration
      * Creates the user in the database.
      *
      * @param actor the user id performing the action (null for self registration)
-     * @param system the system id for the user
      * @param registrant the entity to be created
      * @return the generated user id string
      */
-    private String createUser(String actor, SystemId system, CMSUser registrant) {
-        // generate new ID
-        String userId = getSequence().getNextSystemValue(system, Sequences.USER_ID);
-
-        registrant.setUserId(userId);
+    private String createUser(String actor, CMSUser registrant) {
+        // ensure we get a generated ID
+        registrant.setUserId(null);
 
         // active by default
         registrant.setStatus(UserStatus.ACTIVE);
@@ -476,14 +473,15 @@ public class RegistrationServiceBean extends BaseService implements Registration
             registrant.setRole(findLookupByDescription(Role.class, registrant.getRole().getDescription()));
         }
 
+        getEm().persist(registrant);
+
         if (actor == null) {
-            actor = userId; // self registration
+            actor = registrant.getUserId(); // self registration
         }
 
-        getEm().persist(registrant);
         // audit because user is not a versioned object.
         auditNewUser(actor, registrant);
-        return userId;
+        return registrant.getUserId();
     }
 
     /**
@@ -846,7 +844,7 @@ public class RegistrationServiceBean extends BaseService implements Registration
             throw new IllegalArgumentException("email is required by this implementation.");
         }
 
-        String userId = createUser(actor.getUserId(), SystemId.CMS_ONLINE, registrant);
+        String userId = createUser(actor.getUserId(), registrant);
         if (password == null) {
             password = passwordGenerator.nextString();
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -329,7 +329,6 @@ public class RegistrationServiceBean extends BaseService implements Registration
      */
     private void auditUserChange(String actor, CMSUser updated, CMSUser original) {
         AuditRecord audit = new AuditRecord();
-        audit.setId(getSequence().getNextValue(Sequences.AUDIT_ID));
         audit.setSystemId(SystemId.CMS_ONLINE.value());
         audit.setAction("A");
 
@@ -359,7 +358,6 @@ public class RegistrationServiceBean extends BaseService implements Registration
         for (AuditDetail auditDetail : lst) {
             if (auditDetail != null) {
                 auditDetail.setAuditRecordId(audit.getId());
-                auditDetail.setId(getSequence().getNextValue(Sequences.AUDIT_DETAIL_ID));
                 getEm().persist(auditDetail);
             }
         }
@@ -433,7 +431,6 @@ public class RegistrationServiceBean extends BaseService implements Registration
     private void auditNewAccountLink(String userId, ExternalAccountLink link) {
         // audit account link
         AuditRecord audit = new AuditRecord();
-        audit.setId(getSequence().getNextValue(Sequences.AUDIT_ID));
         audit.setSystemId(SystemId.CMS_ONLINE.value());
         audit.setAction("A");
         audit.setDate(Calendar.getInstance().getTime());
@@ -450,7 +447,6 @@ public class RegistrationServiceBean extends BaseService implements Registration
         for (AuditDetail auditDetail : lst) {
             if (auditDetail != null) {
                 auditDetail.setAuditRecordId(audit.getId());
-                auditDetail.setId(getSequence().getNextValue(Sequences.AUDIT_DETAIL_ID));
                 getEm().persist(auditDetail);
             }
         }
@@ -542,7 +538,6 @@ public class RegistrationServiceBean extends BaseService implements Registration
 
         // audit status change
         AuditRecord audit = new AuditRecord();
-        audit.setId(getSequence().getNextValue(Sequences.AUDIT_ID));
         audit.setSystemId(SystemId.CMS_ONLINE.value());
         audit.setAction("U");
         audit.setDate(Calendar.getInstance().getTime());
@@ -555,7 +550,6 @@ public class RegistrationServiceBean extends BaseService implements Registration
 
         String tbl = TBL_CMS_USER;
         AuditDetail auditDetail = new AuditDetail();
-        auditDetail.setId(getSequence().getNextValue(Sequences.AUDIT_DETAIL_ID));
         auditDetail.setTableName(tbl);
         auditDetail.setColumnName("STATUS");
         auditDetail.setOldValue(oldValue.name());

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/SequenceGeneratorBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/SequenceGeneratorBean.java
@@ -15,13 +15,12 @@
  */
 package gov.medicaid.services.impl;
 
-import gov.medicaid.entities.SystemId;
 import gov.medicaid.services.SequenceGenerator;
-import gov.medicaid.services.util.Util;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.id.MultipleHiLoPerTableGenerator;
+import org.hibernate.type.LongType;
 
 import javax.ejb.Local;
 import javax.ejb.Stateless;
@@ -31,14 +30,9 @@ import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
-import org.hibernate.Session;
-import org.hibernate.cfg.EJB3NamingStrategy;
-import org.hibernate.cfg.NamingStrategy;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.id.MultipleHiLoPerTableGenerator;
-import org.hibernate.type.LongType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 
 /**
@@ -128,17 +122,5 @@ public class SequenceGeneratorBean implements SequenceGenerator {
         }
         Session sess = (Session) em.getDelegate();
         return ((Number) generator.generate((SessionImplementor) sess, null)).longValue();
-    }
-
-    /**
-     * Creates a unique 28 character string by combining a sequence and the system name.
-     *
-     * @param system the system name to prepend to the unique value
-     * @param sequenceName the name of the sequence
-     * @return the next value for the named sequence
-     */
-    public String getNextSystemValue(SystemId system, String sequenceName) {
-        return Util.pad(system.value(), SYSTEM_ID_LENGTH, 'X')
-            + Util.pad("" + getNextValue(sequenceName), SEQ_LENGTH, '0');
     }
 }

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -2,15 +2,6 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                    "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-lazy="false">
-	<class name="gov.medicaid.entities.Authentication" table="CMS_AUTHENTICATION">
-		<id name="username" type="string">
-			<column name="USERNAME" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="password" type="string">
-			<column name="PASSWORD" not-null="true" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.Enrollment" table="TICKET">
 		<id name="ticketId" type="long">
 			<column name="TICKET_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -969,46 +969,6 @@
 			<column name="CREATE_TS" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.CMSUser" table="CMS_USER">
-		<id name="userId" type="string">
-			<column name="USER_ID" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="username"
-			type="string">
-			<column name="USER_NAME" />
-		</property>
-		<property generated="never" lazy="false" name="firstName"
-			type="string">
-			<column name="FIRST_NAME" />
-		</property>
-		<property generated="never" lazy="false" name="lastName"
-			type="string">
-			<column name="LAST_NAME" />
-		</property>
-		<property generated="never" lazy="false" name="middleName"
-			type="string">
-			<column name="MIDDLE_NAME" />
-		</property>
-		<property generated="never" lazy="false" name="phoneNumber"
-			type="string">
-			<column name="PHONE_NUMBER" />
-		</property>
-		<property generated="never" lazy="false" name="email" type="string">
-			<column name="EMAIL" />
-		</property>
-		<property generated="never" lazy="false" name="status">
-			<column name="STATUS" />
-			<type name="org.hibernate.type.EnumType">
-				<param name="type">12</param>
-				<param name="enumClass">gov.medicaid.entities.UserStatus</param>
-			</type>
-		</property>
-		<many-to-one class="gov.medicaid.entities.Role" fetch="join"
-			name="role">
-			<column name="ROLE_CD" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.ExternalAccountLink" table="EXTERNAL_ACCOUNT_LINK">
 		<id name="id" type="long">
 			<column name="EXTERNAL_ACCOUNT_LINK_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -1050,38 +1050,6 @@
 			<column name="EXTERNAL_PROFILE_ID" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.AuditRecord" table="AUDIT_RECORD">
-		<id column="AUDIT_RECORD_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property column="USERNAME" generated="never" lazy="false"
-			length="45" name="username" type="string" />
-		<property column="AUDIT_TS" generated="never" lazy="false"
-			name="date" type="timestamp" />
-		<property column="SYSTEM_ID" generated="never" lazy="false"
-			length="8" name="systemId" type="string" />
-		<bag name="details" table="AUDIT_DETAIL">
-			<key>
-				<column name="AUDIT_RECORD_ID" not-null="true" />
-			</key>
-			<one-to-many class="gov.medicaid.entities.AuditDetail" />
-		</bag>
-	</class>
-	<class name="gov.medicaid.entities.AuditDetail" table="AUDIT_DETAIL">
-		<id column="AUDIT_DETAIL_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property column="AUDIT_RECORD_ID" generated="never" lazy="false"
-			name="auditRecordId" type="long" />
-		<property column="TABLE_NAME" generated="never" lazy="false"
-			length="200" name="tableName" type="string" />
-		<property column="COLUMN_NAME" generated="never" lazy="false"
-			length="200" name="columnName" type="string" />
-		<property column="OLD_DATA" generated="never" lazy="false"
-			length="500" name="oldValue" type="string" />
-		<property column="NEW_DATA" generated="never" lazy="false"
-			length="500" name="newValue" type="string" />
-	</class>
 	<class abstract="true" name="gov.medicaid.entities.BeneficialOwner"
 		table="BENEFICIAL_OWNER">
 		<id column="BENEFICIAL_OWNER_ID" name="id" type="long">

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -43,6 +43,7 @@
 
     <class>gov.medicaid.entities.AuditDetail</class>
     <class>gov.medicaid.entities.AuditRecord</class>
+    <class>gov.medicaid.entities.CMSUser</class>
 
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -1,42 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<persistence version="2.0" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_1_0.xsd" xmlns:orm="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/persistence">
-	<persistence-unit name="cms" transaction-type="JTA">
-		<provider>org.hibernate.ejb.HibernatePersistence</provider>
-		<jta-data-source>jdbc/MitaDS</jta-data-source>
-		<non-jta-data-source>jdbc/TaskServiceDS</non-jta-data-source>
-		<mapping-file>META-INF/JBPMorm-JPA2.xml</mapping-file>
-		<mapping-file>META-INF/ormTasks.xml</mapping-file>
-        <class>org.drools.persistence.info.SessionInfo</class>
-        <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
-        <class>org.drools.persistence.info.WorkItemInfo</class>
+<persistence
+  version="2.0"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_1_0.xsd"
+  xmlns:orm="http://java.sun.com/xml/ns/persistence/orm"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://java.sun.com/xml/ns/persistence">
+  <persistence-unit name="cms" transaction-type="JTA">
+    <provider>org.hibernate.ejb.HibernatePersistence</provider>
 
-		<class>org.jbpm.task.Attachment</class>
-		<class>org.jbpm.task.Content</class>
-		<class>org.jbpm.task.BooleanExpression</class>
-		<class>org.jbpm.task.Comment</class>
-		<class>org.jbpm.task.Deadline</class>
-		<class>org.jbpm.task.Comment</class>
-		<class>org.jbpm.task.Deadline</class>
-		<class>org.jbpm.task.Delegation</class>
-		<class>org.jbpm.task.Escalation</class>
-		<class>org.jbpm.task.Group</class>
-		<class>org.jbpm.task.I18NText</class>
-		<class>org.jbpm.task.Notification</class>
-		<class>org.jbpm.task.EmailNotification</class>
-		<class>org.jbpm.task.EmailNotificationHeader</class>
-		<class>org.jbpm.task.PeopleAssignments</class>
-		<class>org.jbpm.task.Reassignment</class>
-		<class>org.jbpm.task.Status</class>
-		<class>org.jbpm.task.Task</class>
-		<class>org.jbpm.task.TaskData</class>
-		<class>org.jbpm.task.SubTasksStrategy</class>
-		<class>org.jbpm.task.OnParentAbortAllSubTasksEndStrategy</class>
-		<class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
-		<class>org.jbpm.task.User</class>
-		<properties>
-			<property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
-			<property name="hibernate.hbm2ddl.auto" value="none" />
-			<property name="hibernate.show_sql" value="true" />
-		</properties>
-	</persistence-unit>
+    <jta-data-source>jdbc/MitaDS</jta-data-source>
+    <non-jta-data-source>jdbc/TaskServiceDS</non-jta-data-source>
+
+    <mapping-file>META-INF/JBPMorm-JPA2.xml</mapping-file>
+    <mapping-file>META-INF/ormTasks.xml</mapping-file>
+
+    <class>org.drools.persistence.info.SessionInfo</class>
+    <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+    <class>org.drools.persistence.info.WorkItemInfo</class>
+    <class>org.jbpm.task.Attachment</class>
+    <class>org.jbpm.task.Content</class>
+    <class>org.jbpm.task.BooleanExpression</class>
+    <class>org.jbpm.task.Comment</class>
+    <class>org.jbpm.task.Deadline</class>
+    <class>org.jbpm.task.Comment</class>
+    <class>org.jbpm.task.Deadline</class>
+    <class>org.jbpm.task.Delegation</class>
+    <class>org.jbpm.task.Escalation</class>
+    <class>org.jbpm.task.Group</class>
+    <class>org.jbpm.task.I18NText</class>
+    <class>org.jbpm.task.Notification</class>
+    <class>org.jbpm.task.EmailNotification</class>
+    <class>org.jbpm.task.EmailNotificationHeader</class>
+    <class>org.jbpm.task.PeopleAssignments</class>
+    <class>org.jbpm.task.Reassignment</class>
+    <class>org.jbpm.task.Status</class>
+    <class>org.jbpm.task.Task</class>
+    <class>org.jbpm.task.TaskData</class>
+    <class>org.jbpm.task.SubTasksStrategy</class>
+    <class>org.jbpm.task.OnParentAbortAllSubTasksEndStrategy</class>
+    <class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
+    <class>org.jbpm.task.User</class>
+
+    <properties>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
+      <property name="hibernate.hbm2ddl.auto" value="none" />
+      <property name="hibernate.show_sql" value="true" />
+    </properties>
+  </persistence-unit>
 </persistence>

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -43,6 +43,7 @@
 
     <class>gov.medicaid.entities.AuditDetail</class>
     <class>gov.medicaid.entities.AuditRecord</class>
+    <class>gov.medicaid.entities.Authentication</class>
     <class>gov.medicaid.entities.CMSUser</class>
 
     <properties>

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -41,6 +41,9 @@
     <class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
     <class>org.jbpm.task.User</class>
 
+    <class>gov.medicaid.entities.AuditDetail</class>
+    <class>gov.medicaid.entities.AuditRecord</class>
+
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
       <property name="hibernate.hbm2ddl.auto" value="none" />

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -1,0 +1,69 @@
+DROP SEQUENCE IF EXISTS
+  hibernate_sequence
+CASCADE;
+DROP TABLE IF EXISTS
+  audit_details,
+  audit_records,
+  cms_authentication,
+  cms_user,
+  lu_role,
+  persistent_logins
+CASCADE;
+
+CREATE SEQUENCE hibernate_sequence;
+
+CREATE TABLE persistent_logins (
+  series VARCHAR(64) PRIMARY KEY,
+  username VARCHAR(64) NOT NULL,
+  token VARCHAR(64) NOT NULL,
+  last_used TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE TABLE lu_role (
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT
+);
+INSERT INTO lu_role VALUES ('R1', 'Provider');
+INSERT INTO lu_role VALUES ('R2', 'Service Agent');
+INSERT INTO lu_role VALUES ('R3', 'Service Administrator');
+INSERT INTO lu_role VALUES ('R4', 'System Administrator');
+
+CREATE TABLE cms_user (
+  user_id TEXT PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  first_name TEXT,
+  middle_name TEXT,
+  last_name TEXT,
+  phone_number TEXT,
+  email TEXT,
+  status TEXT,
+  role_code CHARACTER VARYING(2) REFERENCES lu_role(code)
+);
+
+
+INSERT INTO cms_user(user_id, username, first_name, last_name, email, status, role_code)
+VALUES('SYSTEM', 'system', 'system', 'system', 'system@example.com', 'ACTIVE', 'R4');
+
+CREATE TABLE cms_authentication(
+  username TEXT PRIMARY KEY,
+  password TEXT NOT NULL
+);
+
+INSERT INTO cms_authentication (username, password)
+VALUES ('system', '{SHA}MX8edh8vqo2ngaR2K53MLFytIJo='); -- password: system
+
+CREATE TABLE audit_records(
+  audit_record_id BIGINT PRIMARY KEY,
+  action TEXT,
+  date TIMESTAMP WITH TIME ZONE,
+  system_id TEXT,
+  username TEXT
+);
+CREATE TABLE audit_details(
+  audit_detail_id BIGINT PRIMARY KEY,
+  audit_record_id BIGINT NOT NULL REFERENCES audit_records(audit_record_id),
+  table_name TEXT,
+  column_name TEXT,
+  old_value TEXT,
+  new_value TEXT
+);

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
@@ -15,43 +15,74 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
 /**
  * Audit record details.
  *
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class AuditDetail extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "audit_details")
+public class AuditDetail {
+
+    @Id
+    @GeneratedValue(
+        strategy = GenerationType.AUTO
+    )
+    @Column(name = "audit_detail_id")
+    private long id;
 
     /**
      * The header record id.
      */
+    @NotNull
+    @Column(name = "audit_record_id")
     private long auditRecordId;
 
     /**
      * The table name.
      */
+    @Column(name = "table_name")
     private String tableName;
 
     /**
      * The column name.
      */
+    @Column(name = "column_name")
     private String columnName;
 
     /**
      * The old value.
      */
+    @Column(name = "old_value")
     private String oldValue;
 
     /**
      * The new value.
      */
+    @Column(name = "new_value")
     private String newValue;
 
     /**
      * Empty constructor.
      */
     public AuditDetail() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
@@ -15,6 +15,12 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.util.Date;
 import java.util.List;
 
@@ -24,7 +30,15 @@ import java.util.List;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class AuditRecord extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "audit_records")
+public class AuditRecord {
+    @Id
+    @GeneratedValue(
+            strategy = GenerationType.AUTO
+    )
+    @Column(name = "audit_record_id")
+    private long id;
 
     /**
      * User name.
@@ -44,17 +58,27 @@ public class AuditRecord extends IdentifiableEntity {
     /**
      * The system that made the changes.
      */
+    @Column(name = "system_id")
     private String systemId;
 
     /**
      * Change details.
      */
+    @OneToMany(mappedBy = "auditRecordId")
     private List<AuditDetail> details;
 
     /**
      * Default empty constructor.
      */
     public AuditRecord() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
@@ -15,6 +15,9 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 
 /**
@@ -23,16 +26,16 @@ import java.io.Serializable;
  * @author TCSASSEMBLER
  * @version 1.0
  */
+@javax.persistence.Entity
+@Table(name = "cms_authentication")
 public class Authentication implements Serializable {
-
-    /**
-     * The user name.
-     */
+    @Id
     private String username;
 
     /**
      * The hashed password.
      */
+    @NotNull
     private String password;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -16,7 +16,16 @@
 package gov.medicaid.entities;
 
 import gov.medicaid.binders.BinderUtils;
+import org.hibernate.annotations.GenericGenerator;
 
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
 import java.io.Serializable;
 
 /**
@@ -25,89 +34,69 @@ import java.io.Serializable;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class CMSUser implements Serializable {
 
-    /**
-     * The user identifier (generated).
-     */
+@javax.persistence.Entity
+@Table(name = "cms_user")
+public class CMSUser implements Serializable {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @Column(name = "user_id")
     private String userId;
 
-    /**
-     * The user name.
-     */
     private String username;
 
-    /**
-     * The first name.
-     */
+    @Column(name = "first_name")
     private String firstName;
 
-    /**
-     * The last name.
-     */
+    @Column(name = "last_name")
     private String lastName;
 
-    /**
-     * The middle name.
-     */
+    @Column(name = "middle_name")
     private String middleName;
 
-    /**
-     * Phone number.
-     */
+    @Column(name = "phone_number")
     private String phoneNumber;
 
-    /**
-     * Transient fields for display.
-     */
+    @Transient
     private String businessPhonePart1;
 
-    /**
-     * Transient fields for display.
-     */
+    @Transient
     private String businessPhonePart2;
 
-    /**
-     * Transient fields for display.
-     */
+    @Transient
     private String businessPhonePart3;
 
-    /**
-     * Transient fields for display.
-     */
+    @Transient
     private String businessPhoneExt;
 
-    /**
-     * Email address.
-     */
     private String email;
 
-    /**
-     * User status.
-     */
+    @Enumerated(EnumType.STRING)
     private UserStatus status;
 
-    /**
-     * The user role.
-     */
+    @ManyToOne
     private Role role;
-    
+
     /**
      * Employer or Self.
      * If employer, it should have a proxyForUserId
      */
+    @Transient
     private RoleView externalRoleView;
-    
+
     /**
      * The NPI that is being proxied, will only have a value if
      */
+    @Transient
     private String proxyForNPI;
-    
+
     /**
      * The external account information.
      */
+    @Transient
     private ExternalAccountLink externalAccountLink;
-    
+
     /**
      * Empty constructor.
      */

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -44,6 +44,7 @@ public class CMSUser implements Serializable {
     @Column(name = "user_id")
     private String userId;
 
+    @Column(unique = true)
     private String username;
 
     @Column(name = "first_name")

--- a/psm-app/services/src/main/java/gov/medicaid/services/SequenceGenerator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/SequenceGenerator.java
@@ -15,8 +15,6 @@
  */
 package gov.medicaid.services;
 
-import gov.medicaid.entities.SystemId;
-
 /**
  * This defines a sequence generation interface used by the persistence implementation to maintain unique references.
  *
@@ -32,14 +30,4 @@ public interface SequenceGenerator {
      * @return the next value for the named sequence
      */
     long getNextValue(String sequenceName);
-
-    /**
-     * Creates a unique string by combining a sequence and the system name.
-     *
-     * @param system the system name to prepend to the unique value
-     * @param sequenceName the name of the sequence
-     * @return the next value for the named sequence
-     */
-    String getNextSystemValue(SystemId system, String sequenceName);
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -94,16 +94,6 @@ public class Sequences {
     public static final String ACOUNT_LINK_SEQ = "ACOUNT_LINK_SEQ";
 
     /**
-     * Used for audits.
-     */
-    public static final String AUDIT_ID = "AUDIT_ID";
-
-    /**
-     * Used for audit details.
-     */
-    public static final String AUDIT_DETAIL_ID = "AUDIT_DETAIL_ID";
-
-    /**
      * The agreements accepted.
      */
     public static final String AGREEMENT_SEQ = "AGREEMENT_SEQ";

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -84,11 +84,6 @@ public class Sequences {
     public static final String PROVIDER_NUMBER_SEQ = "PROVIDER_NUMBER_SEQ";
 
     /**
-     * Used for each user.
-     */
-    public static final String USER_ID = "CMS_USER_SEQ";
-
-    /**
      * Used for each account link.
      */
     public static final String ACOUNT_LINK_SEQ = "ACOUNT_LINK_SEQ";


### PR DESCRIPTION
Update audit logs and users to use JPA annotations rather than Hibernate XML. With these classes converted, and the seed data / schema, users can sign up and sign in!

Once again, there is an XML file that was using mixed tabs and spaces. I reformatted it to make editing it easier; here is the [whitespace-ignoring diff](https://github.com/OpenTechStrategies/psm/commit/efbf5413e509bc073f95f2bf775f4e7d9761a35c?w=1) of that commit.

Newly generated user IDs will be UUIDs; I haven't found any problems with this approach yet, but I also [don't understand why they were something else in the first place](https://github.com/OpenTechStrategies/psm/issues/32).

I updated the INSTALL instructions; once the application is deployed and the seed data is inserted, you should be able to sign in with `system` / `system`, create and delete users as the system user, sign out, sign in with newly created users, and self register (note that it sends the password as an email - you'll need to have mailcatcher or whatever running to receive the email).

@slifty pls to code review!
@cecilia-donnelly and/or @brainwane: pls to verify that you can deploy, log in, and create users.

Issue #36 Use Hibernate 5, instead of 4