### PR TITLE
disable LDAP and MN-ITS authentication methods

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
@@ -58,8 +58,11 @@
    
 	<s:authentication-manager alias="authenticationManagerAlias">
 		<s:authentication-provider ref="PrimaryDatabaseProvider" />
+<!-- todo: dive deep into user authentication; see issue #34
+     https://github.com/OpenTechStrategies/psm/issues/34
 		<s:authentication-provider ref="PrimaryLdapProvider" />
 		<s:authentication-provider ref="MNITSAuthenticationProvider" />
+-->
 	</s:authentication-manager>
 
 	<context:property-placeholder location="classpath:cms.properties" />

--- a/psm-app/services/src/main/resources/cms.properties
+++ b/psm-app/services/src/main/resources/cms.properties
@@ -221,7 +221,7 @@ max.upload.size=512000000
 
 #LDAP settings
 ldap.java.naming.factory.initial=com.sun.jndi.ldap.LdapCtxFactory
-ldap.java.naming.provider.url=ldap://54.234.188.236:10389
+ldap.java.naming.provider.url=ldap://ldap.example.com:389
 #ldap.java.naming.security.authentication=simple
 #ldap.java.naming.security.principal=uid=admin,ou=system
 #ldap.java.naming.security.credentials=secret


### PR DESCRIPTION
If you try to log in with a missing account or incorrect password, the application quickly checks the database, then times out trying to talk to an LDAP server that once existed on AWS.

Disable LDAP and, while we're at it, the MN-ITS authentication methods. We'll want to look more closely into the MN-ITS integration later, but for now, just disable it without altering or removing it.