### PR TITLE
Add the ability to login with enter

### DIFF
--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -882,7 +882,14 @@ $(document).ready(function() {
 	});
 	
 	
-	// Login
+       // Login
+        $("input").keypress(function (event) {
+            if (event.which == 13) {
+                $("#loginForm").submit();
+                return false;
+            }
+        });
+
 	$("#btnLogin").click(function(){
 		$('#loginForm').submit();
 		return false;	


### PR DESCRIPTION
Submit the login form by hitting enter in one of the input fields
(instead of only by clicking the login button).  Mouse-free navigation
is nice.

There is certainly a more complete way to do this, perhaps as part of
https://github.com/OpenTechStrategies/psm/milestone/9.  This is just to
make login work for now.

Let me know if this behavior is *not* desired by others!