### PR TITLE
Use tini to launch the JVM

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ change to the docker directory and:
     $ docker-compose -p psm up --build
 
 Then point your browser at
-[172:20.128.3:8080/cms/login](http://172:20.128.3:8080/cms/login)
+[172:20.128.3/cms/login](http://172:20.128.3/cms/login)
 		
 ## Installing Docker
 

--- a/docker/wildfly/Dockerfile
+++ b/docker/wildfly/Dockerfile
@@ -25,7 +25,11 @@ RUN yum localinstall -y /pgdg-centos96-9.6-3.noarch.rpm \
 		&& yum install -y ant nc postgresql96-server \
 		&& rm /pgdg-centos96-9.6-3.noarch.rpm
 
-RUN mkdir -p /root/bin
+# Install Tini to use as subreaper in Docker container to adopt zombie
+# processes.  Basically, the JVM makes a poor PID 1
+ENV TINI_SHA 066ad710107dc7ee05d3aa6e4974f01dc98f3888
+RUN curl -fL https://github.com/krallin/tini/releases/download/v0.5.0/tini-static -o /bin/tini && chmod +x /bin/tini \
+                 && echo "$TINI_SHA /bin/tini" | sha1sum -c -
 
 # We touch the file here to use as a newness flag later.  If our
 # config is newer than the somewhat randomly-chosen bin/product.conf,
@@ -43,9 +47,9 @@ RUN mv /opt/jboss/wildfly /opt/jboss/wildfly.static
 ## script builds the ear file, sets up the server, waits for db and
 ## mail to come up, then starts the wildfly server.  On subsequent
 ## runs, it should skip build and setup unless something changes.
-COPY bin/* /root/bin/
-RUN chmod a+x /root/bin/*
+COPY bin/* /usr/local/bin/
+RUN chmod a+x /usr/local/bin/*
 
-EXPOSE 8443 8080 9990
+EXPOSE 8443 80 9990
 
-CMD /root/bin/cmd.sh
+ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/wildfly/bin/entrypoint.sh
+++ b/docker/wildfly/bin/entrypoint.sh
@@ -24,10 +24,14 @@ function wait_for_db {
 }
 
 [ -z "$(ls -A /opt/jboss/wildfly)" ] && cp -r /opt/jboss/wildfly.static/* /opt/jboss/wildfly
-/root/bin/build.sh
-/root/bin/setup.sh
-wait_for_db
-wait_for_mail
+/usr/local/bin/build.sh
+/usr/local/bin/setup.sh
+
+# It is probably not useful to block on these.  Better for the app to
+# be able to handle missing services.  I leave the code here,
+# commented out, in case these are useful for debugging.
+#wait_for_db
+#wait_for_mail
 
 echo "Starting wildfly server!"
 ${JBOSS_HOME}/bin/standalone.sh -c standalone-full.xml -bmanagement 0.0.0.0 -b 0.0.0.0 -Djboss.http.port=80


### PR DESCRIPTION
I pushed some basic working docker stuff yesterday.  I'll be bumping it forward a little at a time and this PR is an example of that.  It tidies up how things are run, mostly by using Tini as init.

Please review.  If there are no objections (whether because you like the changes or you just don't care about the docker stuff), I'll merge it next week.

Oh, btw, here's a [useful thread](https://github.com/krallin/tini/issues/8) if you want to know about Tini.

Thanks!

The commit log message:

 * Use tini to launch our stuff

   Tini is a tiny init meant to be the PID 1 in our Wildfly container.
   The JVM doesn't do the things PID 1 is supposed to do.  It doesn't
   reap zombies and when acting as PID 1 doesn't handle signals
   appropriately.  Previsouly, `docker stop` didn't DTRT.  Docker
   would send graceful termination signals that Wildfly was ignoring.
   10 seconds later, the Docker daemon would kill -9 the process
   because Wildfly wasn't terminating on its own.  With Tini in place,
   those signals make it to Wildfly, which shuts down pretty fast.
   Then, the containers on which Wildfly depends also shutdown.

 * Rename cmd.sh to entrypoint.sh.  We're now running it as the
   entrypoint, so this makes sense.

 * Put scripts in /usr/local/bin

 * Documentation and expose tweak s/8080/80/