### PR TITLE
Add commit message guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,31 @@ you might also want to look at [DESIGN.md](DESIGN.md).
 
 This repository has a home on
 [GitHub](https://github.com/OpenTechStrategies/psm).  Please submit
-pull requests there.
+[pull requests](https://help.github.com/articles/about-pull-requests/) there.
 
+### Commit Messages
+Please adhere
+to [these guidelines](https://chris.beams.io/posts/git-commit/) for
+each commit message.  The "Seven Rules" described in that post are:
+
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain _what_ and _why_ vs. _how_
+
+Think of the commit message as an introduction to the change.  A
+reviewer will read the commit message right before reading the diff
+itself, so the commit message's purpose is to put the reader in the
+right frame of mind to understand the code change.
+
+The reason for the short initial summary line is to support commands,
+such as `git show-branch`, that list changes by showing just the first
+line of each one's commit message.
+
+### Licensing Your Contribution
 The PSM is published under the terms of version 2 of the
 [Apache Software License](http://www.apache.org/licenses/).  It is
 important that the codebase continue to be publishable under that


### PR DESCRIPTION
Also, link to GitHub's documentation about pull requests, and add a
section header "Licensing Your Contribution" to separate that topic
from the newly-added section on commit messages.