### PR TITLE
show nicely-formatted SQL in debug log

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -50,6 +50,7 @@
       <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
       <property name="hibernate.hbm2ddl.auto" value="none" />
       <property name="hibernate.show_sql" value="true" />
+      <property name="hibernate.format_sql" value="true" />
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
We are currently logging the SQL queries that Hibernate generates and runs. Hibernate also has the option to pretty-print those queries, which makes them much easier to read. Contrast:

```SQL
select authentica0_.username as username1_8_0_, authentica0_.password as password2_8_0_ from cms_authentication authentica0_ where authentica0_.username=?
```
with:
```SQL
select
    authentica0_.username as username1_8_0_,
    authentica0_.password as password2_8_0_
from
    cms_authentication authentica0_
where
    authentica0_.username=?
```

This is one of the simpler queries, of course, and mixed in with all the other lines in the server log, so the readability impact is even higher.