### PR TITLE
Hide useless alert about high-risk providers (#53)

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
@@ -5,11 +5,25 @@
   -
   - Description: it is used to render the high risk level.
 --%>
+<!-- Commenting this alert out for now, as per
+     github.com/OpenTechStrategies/psm/issues/53.
+     We can put it back when a) we know how to
+     conditionalize it on the presence of some
+     actual "high"-risk provider in the pagination
+     group currently being displayed, and b) we
+     know what our risk levels are and what we
+     want to say about one(s) considered "high".
+
+     TODO: Also, there's code duplication
+     between this snippet and a block in
+     ../../provider/dashboard/list.jsp (look
+     for a comment similar to this one).  
+
 <div class="row infoRow">
     <div class="row red">
         <b>* High risk level means:</b>
     </div>
-    <p>
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-    </p>
+    <p>TBD: Say something about what it means that some of the
+       providers shown are "high"-risk.</p>
 </div>
+-->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -71,14 +71,33 @@
                             <!-- /.tabFoot -->
                         </div>
                         <!-- /#tabApproved -->
+
+                        <!-- Commenting this alert out for now, as per
+                             github.com/OpenTechStrategies/psm/issues/53.
+                             We can put it back when a) we know how to
+                             conditionalize it on the presence of some
+                             actual "high"-risk provider in the pagination
+                             group currently being displayed, and b) we
+                             know what our risk levels are and what we
+                             want to say about one(s) considered "high".
+
+                             TODO: Also, there's a code duplication
+                             between this block and the snippet in
+                             ../../admin/includes/high_risk_level_means.jsp.
+                             And why isn't the code here doing
+                             <%@ include file="/WEB-INF/pages/admin/includes/high_risk_level_means.jsp" %>
+                             the way various other places in the
+                             PSM tree do?
+
                         <div class="row infoRow">
                             <div class="row red">
                                 <b>* High risk level means:</b>
                             </div>
-                            <p>
-                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-                            </p>
+                            <p>TBD: Say something about what it means
+                               that some of the providers shown on
+                               this page are "high"-risk.</p>
                         </div>
+                        -->
                 </div>
             </div>
             <!-- /#mainContent -->


### PR DESCRIPTION
Also note some code duplication, and the possibility that in one place
we should be using the same .jsp snippet that's used elsewhere.

This commit also removes a couple of "Lorem Ipsum" instances, which
contributes to the resolution of issue #51.