### PR TITLE
Switch Role over to annotations

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -484,16 +484,6 @@
 			<column name="DESCRIPTION" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.Role" table="LU_ROLE">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.Degree" table="LU_DEGREE">
 		<id name="code" type="string">
 			<column length="2" name="CODE" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -46,6 +46,7 @@
     <class>gov.medicaid.entities.Authentication</class>
     <class>gov.medicaid.entities.CMSUser</class>
     <class>gov.medicaid.entities.ProviderType</class>
+    <class>gov.medicaid.entities.Role</class>
 
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -6,9 +6,9 @@ DROP TABLE IF EXISTS
   audit_records,
   cms_authentication,
   cms_user,
-  lu_role,
   persistent_logins,
-  provider_types
+  provider_types,
+  roles
 CASCADE;
 
 CREATE SEQUENCE hibernate_sequence;
@@ -20,14 +20,15 @@ CREATE TABLE persistent_logins (
   last_used TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
-CREATE TABLE lu_role (
+CREATE TABLE roles (
   code CHARACTER VARYING(2) PRIMARY KEY,
-  description TEXT
+  description TEXT UNIQUE
 );
-INSERT INTO lu_role VALUES ('R1', 'Provider');
-INSERT INTO lu_role VALUES ('R2', 'Service Agent');
-INSERT INTO lu_role VALUES ('R3', 'Service Administrator');
-INSERT INTO lu_role VALUES ('R4', 'System Administrator');
+INSERT INTO roles (code, description) VALUES
+  ('R1', 'Provider'),
+  ('R2', 'Service Agent'),
+  ('R3', 'Service Administrator'),
+  ('R4', 'System Administrator');
 
 CREATE TABLE cms_user (
   user_id TEXT PRIMARY KEY,
@@ -38,7 +39,7 @@ CREATE TABLE cms_user (
   phone_number TEXT,
   email TEXT,
   status TEXT,
-  role_code CHARACTER VARYING(2) REFERENCES lu_role(code)
+  role_code CHARACTER VARYING(2) REFERENCES roles(code)
 );
 INSERT INTO cms_user (
   user_id,

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Role.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Role.java
@@ -15,17 +15,8 @@
  */
 package gov.medicaid.entities;
 
-/**
- * Represents a role.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class Role extends LookupEntity {
+import javax.persistence.Table;
 
-    /**
-     * Empty constructor.
-     */
-    public Role() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "roles")
+public class Role extends LookupEntity {}


### PR DESCRIPTION
And, in so doing, remove redundant comments and empty constructor, since it is the same as the default constructor.

Tested by deploying, logging in as `system`, and verifying that all four role options are available on the create new user page.

Issue #36 Use Hibernate 5, instead of 4