### PR TITLE
Fix enumeration & null queries

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -152,7 +152,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
             providerTypes = sortCollection(getLookupService().getProviderTypes(ApplicantType.ORGANIZATION));
             break;
         default:
-            providerTypes = getLookupService().getProviderTypes(null);
+            providerTypes = getLookupService().getAllProviderTypes();
             break;
         }
         group.getLookupTableEntry().addAll(mapLookupEntity(providerTypes));

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -70,6 +70,13 @@ public class LookupServiceBean implements LookupService {
     public LookupServiceBean() {
     }
 
+    public List<ProviderType> getAllProviderTypes() {
+        return em.createQuery(
+                "FROM ProviderType",
+                ProviderType.class
+        ).getResultList();
+    }
+
     /**
      * Retrieves the provider types filtered by applicant type.
      * 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -84,21 +84,14 @@ public class LookupServiceBean implements LookupService {
      *            individual or organizations
      * @return the filtered provider types
      */
-    @SuppressWarnings("unchecked")
     public List<ProviderType> getProviderTypes(ApplicantType applicantType) {
-        Query q = null;
-        switch (applicantType) {
-        case INDIVIDUAL:
-            q = em.createQuery("FROM ProviderType p WHERE applicantType = 0");
-            break;
-        case ORGANIZATION:
-            q = em.createQuery("FROM ProviderType p WHERE applicantType = 1");
-            break;
-        default:
-            q = em.createQuery("FROM ProviderType p");
-            break;
-        }
-        return q.getResultList();
+        return em.createQuery(
+                "FROM ProviderType WHERE applicantType = :type",
+                ProviderType.class
+        ).setParameter(
+                "type",
+                applicantType
+        ).getResultList();
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -33,6 +33,10 @@ import java.util.List;
  * @version 1.0
  */
 public interface LookupService {
+    /**
+     * @return all provider types
+     */
+    List<ProviderType> getAllProviderTypes();
 
     /**
      * Retrieves the provider types filtered by applicant type.


### PR DESCRIPTION
I introduced a bug in 2c050e253528bea510035933348855dc48764991, but it was hidden behind other Hibernate 5 migration problems. When I examined the broken code more closely, I found a second bug.

The first is a piece I missed from converting the `applicantType` field from an `int` to the `enum` we had, and allowing Hibernate to serialize that as a string. The fix is to use a dynamic query with a bound parameter instead of hardcoded queries. Also fix a suppressed warning by using [a newer query API](https://docs.oracle.com/javaee/7/api/javax/persistence/EntityManager.html#createQuery-javax.persistence.criteria.CriteriaQuery-) that returns a typed result instead of the older, untyped result.

The second bug is related to `null` parameters, which was explicitly passed in somewhere. In Java, `switch`ing on an `enum` instance that is `null` causes a `NullPointerException`. Split the intended purpose of the (incorrectly unreachable) code into a new method and call that, instead.

Tested by creating a new provider user and starting the enrollment process. I'm not sure how to reach the code that was invoking the second bug; it might be hidden behind another page broken by the Hibernate migration.