### PR TITLE
Switch states over to annotations

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -552,16 +552,6 @@
 			<column name="DESCRIPTION" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.StateType" table="LU_STATE">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.CountyType" table="LU_COUNTY">
 		<id name="code" type="string">
 			<column length="3" name="CODE" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -47,6 +47,7 @@
     <class>gov.medicaid.entities.CMSUser</class>
     <class>gov.medicaid.entities.ProviderType</class>
     <class>gov.medicaid.entities.Role</class>
+    <class>gov.medicaid.entities.StateType</class>
 
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -8,7 +8,8 @@ DROP TABLE IF EXISTS
   cms_user,
   persistent_logins,
   provider_types,
-  roles
+  roles,
+  states
 CASCADE;
 
 CREATE SEQUENCE hibernate_sequence;
@@ -161,3 +162,60 @@ INSERT INTO provider_types(code, description, applicant_type) VALUES
   ('76', 'Birthing Center', 'ORGANIZATION'),
   ('77', 'Medical Transportation', 'ORGANIZATION'),
   ('78', 'Billing Entity for Physician Services', 'ORGANIZATION');
+
+CREATE TABLE states (
+   code CHARACTER VARYING(2) PRIMARY KEY,
+   description TEXT UNIQUE
+);
+INSERT INTO states (code, description) VALUES
+  ('AK', 'Alaska'),
+  ('AL', 'Alabama'),
+  ('AR', 'Arkansas'),
+  ('AZ', 'Arizona'),
+  ('CA', 'California'),
+  ('CO', 'Colorado'),
+  ('CT', 'Connecticut'),
+  ('DC', 'District of Columbia'),
+  ('DE', 'Delaware'),
+  ('FL', 'Florida'),
+  ('GA', 'Georgia'),
+  ('HI', 'Hawaii'),
+  ('IA', 'Iowa'),
+  ('ID', 'Idaho'),
+  ('IL', 'Illinois'),
+  ('IN', 'Indiana'),
+  ('KS', 'Kansas'),
+  ('KY', 'Kentucky'),
+  ('LA', 'Louisiana'),
+  ('MA', 'Massachusetts'),
+  ('MD', 'Maryland'),
+  ('ME', 'Maine'),
+  ('MI', 'Michigan'),
+  ('MN', 'Minnesota'),
+  ('MO', 'Missouri'),
+  ('MS', 'Mississippi'),
+  ('MT', 'Montana'),
+  ('NC', 'North Carolina'),
+  ('ND', 'North Dakota'),
+  ('NE', 'Nebraska'),
+  ('NH', 'New Hampshire'),
+  ('NJ', 'New Jersey'),
+  ('NM', 'New Mexico'),
+  ('NV', 'Nevada'),
+  ('NY', 'New York'),
+  ('OH', 'Ohio'),
+  ('OK', 'Oklahoma'),
+  ('OR', 'Oregon'),
+  ('PA', 'Pennsylvania'),
+  ('RI', 'Rhode Island'),
+  ('SC', 'South Carolina'),
+  ('SD', 'South Dakota'),
+  ('TN', 'Tennessee'),
+  ('TX', 'Texas'),
+  ('UT', 'Utah'),
+  ('VA', 'Virginia'),
+  ('VT', 'Vermont'),
+  ('WA', 'Washington'),
+  ('WI', 'Wisconsin'),
+  ('WV', 'West Virginia'),
+  ('WY', 'Wyoming');

--- a/psm-app/services/src/main/java/gov/medicaid/entities/StateType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/StateType.java
@@ -15,17 +15,8 @@
  */
 package gov.medicaid.entities;
 
-/**
- * Represents a state type.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class StateType extends LookupEntity {
+import javax.persistence.Table;
 
-    /**
-     * Default empty constructor.
-     */
-    public StateType() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "states")
+public class StateType extends LookupEntity {}


### PR DESCRIPTION
Pluralize the table name, remove the `lu_` prefix, remove the empty constructor, remove the redundant comment, and add seed data.

The seed data contains the 50 states and the District of Columbia. Do we also need to include US territories, associated states, and other similar? See issue #62.

https://en.wikipedia.org/wiki/List_of_U.S._state_abbreviations

Issue #36 Use Hibernate 5, instead of 4