### PR TITLE
Switch risk level over to annotation

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -504,20 +504,6 @@
 			<column name="DESCRIPTION" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.RiskLevel" table="LU_RISK_LEVEL">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="sortIndex"
-			type="int">
-			<column name="SORT_IDX" />
-		</property>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.SpecialtyType" table="LU_SPECIALTY_TYPE">
 		<id name="code" type="string">
 			<column length="2" name="CODE" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -47,6 +47,7 @@
     <class>gov.medicaid.entities.CMSUser</class>
     <class>gov.medicaid.entities.ProfileStatus</class>
     <class>gov.medicaid.entities.ProviderType</class>
+    <class>gov.medicaid.entities.RiskLevel</class>
     <class>gov.medicaid.entities.Role</class>
     <class>gov.medicaid.entities.StateType</class>
 

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -9,6 +9,7 @@ DROP TABLE IF EXISTS
   persistent_logins,
   profile_statuses,
   provider_types,
+  risk_levels,
   roles,
   states
 CASCADE;
@@ -172,6 +173,16 @@ INSERT INTO profile_statuses (code, description) VALUES
   ('01', 'Active'),
   ('02', 'Suspended'),
   ('03', 'Expired');
+
+CREATE TABLE risk_levels(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  sort_index INTEGER UNIQUE NOT NULL,
+  description TEXT UNIQUE
+);
+INSERT INTO risk_levels (code, sort_index, description) VALUES
+  ('01', 1, 'Limited'),
+  ('02', 2, 'Moderate'),
+  ('03', 3, 'High');
 
 CREATE TABLE states (
    code CHARACTER VARYING(2) PRIMARY KEY,

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RiskLevel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RiskLevel.java
@@ -15,24 +15,18 @@
  */
 package gov.medicaid.entities;
 
-/**
- * Represents a risk level.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
+import javax.persistence.Column;
+import javax.persistence.Table;
+
+@javax.persistence.Entity
+@Table(name = "risk_levels")
 public class RiskLevel extends LookupEntity {
-
-    /**
-     * Sorting index.
-     */
+    @Column(
+            name = "sort_index",
+            nullable = false,
+            unique = true
+    )
     private int sortIndex;
-
-    /**
-     * Empty constructor.
-     */
-    public RiskLevel() {
-    }
 
     /**
      * Gets the value of the field <code>sortIndex</code>.


### PR DESCRIPTION
Pluralize the table name, remove the `lu_` prefix, and add seed data.

Issue #36 Use Hibernate 5, instead of 4