### PR TITLE
Convert ServiceAssuranceType to annotation

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -602,20 +602,6 @@
 			<column name="DESCRIPTION" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.ServiceAssuranceType" table="LU_SVC_ASSURANCE_TYP">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-		<property generated="never" lazy="false" length="3" name="patientInd"
-			type="string">
-			<column name="PATIENT_IND" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.ServiceAssuranceExtType" table="LU_SVC_ASSURANCE_EXT_TYP">
 		<id name="code" type="string">
 			<column length="2" name="CODE" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -47,7 +47,8 @@
     <class>gov.medicaid.entities.CMSUser</class>
     <class>gov.medicaid.entities.ProviderType</class>
     <class>gov.medicaid.entities.Role</class>
-
+    <class>gov.medicaid.entities.ServiceAssuranceType</class>
+    
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
       <property name="hibernate.hbm2ddl.auto" value="none" />

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -10,10 +10,9 @@ DROP TABLE IF EXISTS
   persistent_logins,
   profile_statuses,
   provider_types,
-  roles,
-  service_assurance_types,
   risk_levels,
   roles,
+  service_assurance_types,
   states
 CASCADE;
 
@@ -39,7 +38,7 @@ INSERT INTO roles (code, description) VALUES
 CREATE TABLE service_assurance_types (
   code CHARACTER VARYING(2) PRIMARY KEY,
   description TEXT UNIQUE,
-  patient_ind TEXT
+  patient_indicator TEXT
 );
 
 CREATE TABLE cms_user (

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -8,7 +8,8 @@ DROP TABLE IF EXISTS
   cms_user,
   persistent_logins,
   provider_types,
-  roles
+  roles,
+  service_assurance_types
 CASCADE;
 
 CREATE SEQUENCE hibernate_sequence;
@@ -29,6 +30,12 @@ INSERT INTO roles (code, description) VALUES
   ('R2', 'Service Agent'),
   ('R3', 'Service Administrator'),
   ('R4', 'System Administrator');
+
+CREATE TABLE service_assurance_types (
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE,
+  patient_ind TEXT
+);
 
 CREATE TABLE cms_user (
   user_id TEXT PRIMARY KEY,

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceType.java
@@ -3,16 +3,19 @@
  */
 package gov.medicaid.entities;
 
-/**
+import javax.persistence.Table;
+import javax.persistence.Column;
+
+/*
  * Represents the Assurance Statements lookup for Chemical Dependency Program.
- * 
- * @author cyberjag
- * @version 1.0
  */
+@javax.persistence.Entity
+@Table(name = "service_assurance_types")
 public class ServiceAssuranceType extends LookupEntity {
     /**
-     * Represents the IN/OUT Patient indicator.
+     * Represents the IN/OUT patient indicator.
      */
+    @Column(name = "patient_ind")
     private String patientInd;
 
     /**
@@ -22,7 +25,7 @@ public class ServiceAssuranceType extends LookupEntity {
     }
 
     /**
-     * Gets the patientInd.
+     * Gets the patient indicator.
      * 
      * @return the patientInd
      */
@@ -31,10 +34,9 @@ public class ServiceAssuranceType extends LookupEntity {
     }
 
     /**
-     * Sets the patiend indicator.
+     * Sets the patient indicator.
      * 
      * @param patientInd
-     *            the patientInd
      */
     public void setPatientInd(String patientInd) {
         this.patientInd = patientInd;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceType.java
@@ -15,7 +15,7 @@ public class ServiceAssuranceType extends LookupEntity {
     /**
      * Represents the IN/OUT patient indicator.
      */
-    @Column(name = "patient_ind")
+    @Column(name = "patient_indicator")
     private String patientInd;
 
     /**


### PR DESCRIPTION
Followed the Role conversion (see commit 1163124) as an example of turning a LookupEntity class into an annotation.  Add table creation to seed.sql, but don't include any sample data.  Neither CMS.sql nor
psm-app/db/mpse-clean-setup.sql seem to include seed data for this table.

Part of #36: Use Hibernate 5

@jasonaowen, will you check over `ServiceAssuranceType.java` in particular?  I think I marked the only column that needed it, but would like another pair of eyes.