### PR TITLE
Hibernate-5-ify AgreementDocuments

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
@@ -83,7 +83,7 @@ public class HibernateAgreementDocumentBean extends BaseService implements Agree
                 throw new IllegalArgumentException("Argument 'agreementDocument' cannot be null.");
             }
 
-            agreementDocument.setId(getSequence().getNextValue(Sequences.AGREEMENT_DOC_SEQ));
+            agreementDocument.setId(0);
             agreementDocument.setCreatedOn(new Date());
             getEm().persist(agreementDocument);
 

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -694,23 +694,6 @@
 		<property column="CREATE_TS" generated="never" lazy="false"
 			name="createdOn" type="timestamp" />
 	</class>
-	<class name="gov.medicaid.entities.AgreementDocument" table="AGREEMENT_DOCUMENT">
-		<id column="AGREEMENT_DOCUMENT_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property column="DOC_TYPE" generated="never" lazy="false"
-			length="45" name="type" type="string" />
-		<property column="TITLE" generated="never" lazy="false"
-			length="100" name="title" type="string" />
-		<property column="VERSION" generated="never" lazy="false"
-			length="45" name="version" type="integer" />
-		<property column="DOC_TEXT" generated="never" lazy="false"
-			name="text" type="text" />
-		<property column="CREATED_BY" generated="never" lazy="false"
-			length="45" name="createdBy" type="string" />
-		<property column="CREATE_TS" generated="never" lazy="false"
-			name="createdOn" type="timestamp" />
-	</class>
 	<class name="gov.medicaid.entities.AcceptedAgreements" table="PROVIDER_AGREEMENT_XREF">
 		<id column="PROVIDER_AGREEMENT_XREF_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -41,6 +41,7 @@
     <class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
     <class>org.jbpm.task.User</class>
 
+    <class>gov.medicaid.entities.AgreementDocument</class>
     <class>gov.medicaid.entities.AuditDetail</class>
     <class>gov.medicaid.entities.AuditRecord</class>
     <class>gov.medicaid.entities.Authentication</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -2,6 +2,7 @@ DROP SEQUENCE IF EXISTS
   hibernate_sequence
 CASCADE;
 DROP TABLE IF EXISTS
+  agreement_documents,
   audit_details,
   audit_records,
   cms_authentication,
@@ -291,4 +292,14 @@ CREATE TABLE provider_profiles(
   created_at TIMESTAMP WITH TIME ZONE,
   last_modified_by TEXT,
   last_modified_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE agreement_documents(
+  agreement_document_id BIGINT PRIMARY KEY,
+  type TEXT,
+  title TEXT,
+  version INTEGER,
+  body TEXT,
+  created_by TEXT,
+  created_at TIMESTAMP WITH TIME ZONE
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -17,22 +17,9 @@ package gov.medicaid.entities;
 
 import java.util.Date;
 
-/**
- * Represents an agreement document.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 public class AgreementDocument extends IdentifiableEntity {
-
-    /**
-     * Document type.
-     */
     private String type;
 
-    /**
-     * Document title.
-     */
     private String title;
 
     /**
@@ -45,9 +32,6 @@ public class AgreementDocument extends IdentifiableEntity {
      */
     private String text;
 
-    /**
-     * Creator.
-     */
     private String createdBy;
 
     /**
@@ -66,130 +50,62 @@ public class AgreementDocument extends IdentifiableEntity {
     public AgreementDocument() {
     }
 
-    /**
-     * Gets the value of the field <code>title</code>.
-     *
-     * @return the title
-     */
     public String getTitle() {
         return title;
     }
 
-    /**
-     * Sets the value of the field <code>title</code>.
-     *
-     * @param title the title to set
-     */
     public void setTitle(String title) {
         this.title = title;
     }
 
-    /**
-     * Gets the value of the field <code>version</code>.
-     *
-     * @return the version
-     */
     public int getVersion() {
         return version;
     }
 
-    /**
-     * Sets the value of the field <code>version</code>.
-     *
-     * @param version the version to set
-     */
     public void setVersion(int version) {
         this.version = version;
     }
 
-    /**
-     * Gets the value of the field <code>text</code>.
-     *
-     * @return the text
-     */
     public String getText() {
         return text;
     }
 
-    /**
-     * Sets the value of the field <code>text</code>.
-     *
-     * @param text the text to set
-     */
     public void setText(String text) {
         this.text = text;
     }
 
-    /**
-     * Gets the value of the field <code>createdBy</code>.
-     *
-     * @return the createdBy
-     */
     public String getCreatedBy() {
         return createdBy;
     }
 
-    /**
-     * Sets the value of the field <code>createdBy</code>.
-     *
-     * @param createdBy the createdBy to set
-     */
     public void setCreatedBy(String createdBy) {
         this.createdBy = createdBy;
     }
 
-    /**
-     * Gets the value of the field <code>createdOn</code>.
-     *
-     * @return the createdOn
-     */
     public Date getCreatedOn() {
         return createdOn;
     }
 
-    /**
-     * Sets the value of the field <code>createdOn</code>.
-     *
-     * @param createdOn the createdOn to set
-     */
     public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
     }
 
-    /**
-     * Gets the value of the field <code>type</code>.
-     *
-     * @return the type
-     */
     public String getType() {
         return type;
     }
 
-    /**
-     * Sets the value of the field <code>type</code>.
-     *
-     * @param type the type to set
-     */
     public void setType(String type) {
         this.type = type;
     }
 
-    /**
-     * Gets the value of the field <code>canDelete</code>.
-     * @return the canDelete
-     */
     public boolean isCanDelete() {
         return canDelete;
     }
 
-    /**
-     * Sets the value of the field <code>canDelete</code>.
-     * @param canDelete the canDelete to set
-     */
     public void setCanDelete(boolean canDelete) {
         this.canDelete = canDelete;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
     	if (obj instanceof AgreementDocument) {
@@ -197,7 +113,7 @@ public class AgreementDocument extends IdentifiableEntity {
     	}
     	return false;
     }
-    
+
     @Override
     public int hashCode() {
     	return (int) this.getId();

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
@@ -44,12 +44,6 @@ public class AgreementDocument extends IdentifiableEntity {
      */
     private boolean canDelete;
 
-    /**
-     * Empty constructor.
-     */
-    public AgreementDocument() {
-    }
-
     public String getTitle() {
         return title;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
@@ -15,9 +15,23 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.io.Serializable;
 import java.util.Date;
 
-public class AgreementDocument extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "agreement_documents")
+public class AgreementDocument implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "agreement_document_id")
+    private long id;
+
     private String type;
 
     private String title;
@@ -30,19 +44,28 @@ public class AgreementDocument extends IdentifiableEntity {
     /**
      * Document data.
      */
+    @Column(name = "body")
     private String text;
 
+    @Column(name = "created_by")
     private String createdBy;
 
-    /**
-     * Timestamp.
-     */
+    @Column(name = "created_at")
     private Date createdOn;
 
     /**
      * If the agreement can be deleted.
      */
+    @Transient
     private boolean canDelete;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getTitle() {
         return title;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -113,11 +113,6 @@ public class Sequences {
     public static final String HELP_ITEM_SEQ = "HELP_ITEM_SEQ";
 
     /**
-     * For agreements and addendums.
-     */
-    public static final String AGREEMENT_DOC_SEQ = "AGREEMENT_DOC_SEQ";
-
-    /**
      * Event sequence.
      */
     public static final String EVENT_SEQ = "CMS_EVENT_SEQ";


### PR DESCRIPTION
Remove redundant comments, remove the empty constructor, pluralize the table name, use a more descriptive primary key column name, and generate primary key values using Hibernate natively.

I tested by creating an Agreement and creating an Agreement Addendum. Note that logging in as `admin` appears to fail because of a missing table (`ticket`), but it does give you a cookie, and you can enter the URL of the agreements page directly: https://localhost:8443/cms/admin/viewAgreementDocuments . Editing agreements is still blocked by provider settings. Deleting agreements appears not to have been fully implemented; the UI is present but disabled.

Issue #36 Use Hibernate 5, instead of 4