### PR TITLE
Switch enrollment status over to annotations

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -494,16 +494,6 @@
 			<column name="DESCRIPTION" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.EnrollmentStatus" table="LU_TICKET_STATUS">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.SpecialtyType" table="LU_SPECIALTY_TYPE">
 		<id name="code" type="string">
 			<column length="2" name="CODE" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -45,6 +45,7 @@
     <class>gov.medicaid.entities.AuditRecord</class>
     <class>gov.medicaid.entities.Authentication</class>
     <class>gov.medicaid.entities.CMSUser</class>
+    <class>gov.medicaid.entities.EnrollmentStatus</class>
     <class>gov.medicaid.entities.HelpItem</class>
     <class>gov.medicaid.entities.ProfileStatus</class>
     <class>gov.medicaid.entities.ProviderProfile</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS
   audit_records,
   cms_authentication,
   cms_user,
+  enrollment_statuses,
   help_items,
   persistent_logins,
   profile_statuses,
@@ -197,6 +198,16 @@ INSERT INTO risk_levels (code, sort_index, description) VALUES
   ('01', 1, 'Limited'),
   ('02', 2, 'Moderate'),
   ('03', 3, 'High');
+
+CREATE TABLE enrollment_statuses(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO enrollment_statuses (code, description) VALUES
+  ('01', 'Draft'),
+  ('02', 'Pending'),
+  ('03', 'Rejected'),
+  ('04', 'Approved');
 
 CREATE TABLE states (
    code CHARACTER VARYING(2) PRIMARY KEY,

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
@@ -15,17 +15,14 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Table;
+
 /**
  * Lookup entity for enrollment status (Draft/Pending/Approved/Rejected).
  *
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class EnrollmentStatus extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public EnrollmentStatus() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "enrollment_statuses")
+public class EnrollmentStatus extends LookupEntity {}


### PR DESCRIPTION
Pluralize the table name, remove the `lu_` prefix, and add seed data.

Issue #36 Use Hibernate 5, instead of 4