### PR TITLE
Hibernate-5-ify Enrollment

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -378,7 +378,6 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         }
 
         if (ticket.getTicketId() == 0) {
-            ticket.setTicketId(getSequence().getNextValue(Sequences.TICKET_SEQ));
             ticket.setCreatedBy(user.getUserId());
             ticket.setCreatedOn(Calendar.getInstance().getTime());
         } else {

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -2,62 +2,6 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                    "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-lazy="false">
-	<class name="gov.medicaid.entities.Enrollment" table="TICKET">
-		<id name="ticketId" type="long">
-			<column name="TICKET_ID" />
-			<generator class="assigned" />
-		</id>
-		<many-to-one class="gov.medicaid.entities.EnrollmentStatus"
-			fetch="join" name="status">
-			<column name="STATUS_CD" />
-		</many-to-one>
-		<many-to-one class="gov.medicaid.entities.RequestType"
-			fetch="join" name="requestType">
-			<column name="REQUEST_TYP_CD" />
-		</many-to-one>
-		<property generated="never" lazy="false" name="processInstanceId"
-			type="long">
-			<column default="0" name="PROCESS_INSTANCE_ID" not-null="true" />
-		</property>
-		<property generated="never" lazy="false" name="profileReferenceId"
-			type="long">
-			<column default="0" name="REF_PROFILE_ID" not-null="true" />
-		</property>
-		<property generated="never" lazy="false" name="submissionDate"
-			type="timestamp">
-			<column name="SUBMISSION_TS" />
-		</property>
-		<property generated="never" lazy="false" name="statusDate"
-			type="timestamp">
-			<column name="STATUS_TS" />
-		</property>
-		<property generated="never" lazy="false" name="statusNote"
-			type="string">
-			<column length="1000" name="STATUS_NOTE_TXT" />
-		</property>
-		<property generated="never" lazy="false" name="submittedBy"
-			type="string">
-			<column length="50" name="SUBMITTED_BY" />
-		</property>
-		<property generated="never" lazy="false" name="createdBy"
-			type="string">
-			<column length="50" name="CREATED_BY" />
-		</property>
-		<property column="CREATE_TS" generated="never" lazy="false"
-			name="createdOn" type="timestamp" />
-		<property generated="never" lazy="false" name="lastUpdatedBy"
-			type="string">
-			<column length="50" name="LAST_UPDATED_BY" />
-		</property>
-		<property generated="never" lazy="false" name="progressPage"
-			type="string">
-			<column length="100" name="PROGRESS_PAGE" />
-		</property>
-		<property generated="never" lazy="false" name="referenceTimestamp"
-			type="timestamp">
-			<column name="REF_PROFILE_TS" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.Address" table="ADDRESS">
 		<id name="id" type="long">
 			<column name="ADDRESS_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -46,6 +46,7 @@
     <class>gov.medicaid.entities.AuditRecord</class>
     <class>gov.medicaid.entities.Authentication</class>
     <class>gov.medicaid.entities.CMSUser</class>
+    <class>gov.medicaid.entities.Enrollment</class>
     <class>gov.medicaid.entities.EnrollmentStatus</class>
     <class>gov.medicaid.entities.HelpItem</class>
     <class>gov.medicaid.entities.ProfileStatus</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -8,6 +8,7 @@ DROP TABLE IF EXISTS
   cms_authentication,
   cms_user,
   enrollment_statuses,
+  enrollments,
   help_items,
   persistent_logins,
   profile_statuses,
@@ -325,4 +326,23 @@ CREATE TABLE agreement_documents(
   body TEXT,
   created_by TEXT,
   created_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE enrollments(
+  enrollment_id BIGINT PRIMARY KEY,
+  enrollment_status_code CHARACTER VARYING(2)
+    REFERENCES enrollment_statuses(code),
+  request_type_code CHARACTER VARYING(2)
+    REFERENCES request_types(code),
+  process_instance_id BIGINT NOT NULL DEFAULT 0,
+  profile_reference_id BIGINT NOT NULL DEFAULT 0,
+  reference_timestamp TIMESTAMP WITH TIME ZONE,
+  progress_page TEXT,
+  created_by TEXT,
+  created_at TIMESTAMP WITH TIME ZONE,
+  submitted_by TEXT,
+  submitted_at TIMESTAMP WITH TIME ZONE,
+  changed_by TEXT,
+  changed_at TIMESTAMP WITH TIME ZONE,
+  change_note TEXT
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -61,9 +61,6 @@ public class Enrollment implements Serializable {
      */
     private Date referenceTimestamp;
 
-    /**
-     * The submission date.
-     */
     private Date submissionDate;
 
     /**
@@ -86,9 +83,6 @@ public class Enrollment implements Serializable {
      */
     private String createdBy;
 
-    /**
-     * Username that created this request.
-     */
     private Date createdOn;
 
     /**
@@ -107,264 +101,122 @@ public class Enrollment implements Serializable {
     public Enrollment() {
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>status</code>.
-     *
-     * @return the status
-     */
     public EnrollmentStatus getStatus() {
         return status;
     }
 
-    /**
-     * Sets the value of the field <code>status</code>.
-     *
-     * @param status the status to set
-     */
     public void setStatus(EnrollmentStatus status) {
         this.status = status;
     }
 
-    /**
-     * Gets the value of the field <code>requestType</code>.
-     *
-     * @return the requestType
-     */
     public RequestType getRequestType() {
         return requestType;
     }
 
-    /**
-     * Sets the value of the field <code>requestType</code>.
-     *
-     * @param requestType the requestType to set
-     */
     public void setRequestType(RequestType requestType) {
         this.requestType = requestType;
     }
 
-    /**
-     * Gets the value of the field <code>statusDate</code>.
-     *
-     * @return the statusDate
-     */
     public Date getStatusDate() {
         return statusDate;
     }
 
-    /**
-     * Sets the value of the field <code>statusDate</code>.
-     *
-     * @param statusDate the statusDate to set
-     */
     public void setStatusDate(Date statusDate) {
         this.statusDate = statusDate;
     }
 
-    /**
-     * Gets the value of the field <code>statusNote</code>.
-     *
-     * @return the statusNote
-     */
     public String getStatusNote() {
         return statusNote;
     }
 
-    /**
-     * Sets the value of the field <code>statusNote</code>.
-     *
-     * @param statusNote the statusNote to set
-     */
     public void setStatusNote(String statusNote) {
         this.statusNote = statusNote;
     }
 
-    /**
-     * Gets the value of the field <code>submittedBy</code>.
-     *
-     * @return the submittedBy
-     */
     public String getSubmittedBy() {
         return submittedBy;
     }
 
-    /**
-     * Sets the value of the field <code>submittedBy</code>.
-     *
-     * @param submittedBy the submittedBy to set
-     */
     public void setSubmittedBy(String submittedBy) {
         this.submittedBy = submittedBy;
     }
 
-    /**
-     * Gets the value of the field <code>lastUpdatedBy</code>.
-     *
-     * @return the lastUpdatedBy
-     */
     public String getLastUpdatedBy() {
         return lastUpdatedBy;
     }
 
-    /**
-     * Sets the value of the field <code>lastUpdatedBy</code>.
-     *
-     * @param lastUpdatedBy the lastUpdatedBy to set
-     */
     public void setLastUpdatedBy(String lastUpdatedBy) {
         this.lastUpdatedBy = lastUpdatedBy;
     }
 
-    /**
-     * Gets the value of the field <code>details</code>.
-     *
-     * @return the details
-     */
     public ProviderProfile getDetails() {
         return details;
     }
 
-    /**
-     * Sets the value of the field <code>details</code>.
-     *
-     * @param details the details to set
-     */
     public void setDetails(ProviderProfile details) {
         this.details = details;
     }
 
-    /**
-     * Gets the value of the field <code>processInstanceId</code>.
-     *
-     * @return the processInstanceId
-     */
     public long getProcessInstanceId() {
         return processInstanceId;
     }
 
-    /**
-     * Sets the value of the field <code>processInstanceId</code>.
-     *
-     * @param processInstanceId the processInstanceId to set
-     */
     public void setProcessInstanceId(long processInstanceId) {
         this.processInstanceId = processInstanceId;
     }
 
-    /**
-     * Gets the value of the field <code>submissionDate</code>.
-     *
-     * @return the submissionDate
-     */
     public Date getSubmissionDate() {
         return submissionDate;
     }
 
-    /**
-     * Sets the value of the field <code>submissionDate</code>.
-     *
-     * @param submissionDate the submissionDate to set
-     */
     public void setSubmissionDate(Date submissionDate) {
         this.submissionDate = submissionDate;
     }
 
-    /**
-     * Gets the value of the field <code>createdBy</code>.
-     *
-     * @return the createdBy
-     */
     public String getCreatedBy() {
         return createdBy;
     }
 
-    /**
-     * Sets the value of the field <code>createdBy</code>.
-     *
-     * @param createdBy the createdBy to set
-     */
     public void setCreatedBy(String createdBy) {
         this.createdBy = createdBy;
     }
 
-    /**
-     * Gets the value of the field <code>profileReferenceId</code>.
-     * @return the profileReferenceId
-     */
     public long getProfileReferenceId() {
         return profileReferenceId;
     }
 
-    /**
-     * Sets the value of the field <code>profileReferenceId</code>.
-     * @param profileReferenceId the profileReferenceId to set
-     */
     public void setProfileReferenceId(long profileReferenceId) {
         this.profileReferenceId = profileReferenceId;
     }
 
-    /**
-     * Gets the value of the field <code>createdOn</code>.
-     * @return the createdOn
-     */
     public Date getCreatedOn() {
         return createdOn;
     }
 
-    /**
-     * Sets the value of the field <code>createdOn</code>.
-     * @param createdOn the createdOn to set
-     */
     public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
     }
 
-    /**
-     * Gets the value of the field <code>progressPage</code>.
-     * @return the progressPage
-     */
     public String getProgressPage() {
         return progressPage;
     }
 
-    /**
-     * Sets the value of the field <code>progressPage</code>.
-     * @param progressPage the progressPage to set
-     */
     public void setProgressPage(String progressPage) {
         this.progressPage = progressPage;
     }
 
-    /**
-     * Gets the value of the field <code>referenceTimestamp</code>.
-     * @return the referenceTimestamp
-     */
     public Date getReferenceTimestamp() {
         return referenceTimestamp;
     }
 
-    /**
-     * Sets the value of the field <code>referenceTimestamp</code>.
-     * @param referenceTimestamp the referenceTimestamp to set
-     */
     public void setReferenceTimestamp(Date referenceTimestamp) {
         this.referenceTimestamp = referenceTimestamp;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -15,6 +15,13 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -24,70 +31,96 @@ import java.util.Date;
  * @author TCSASSEMBLER
  * @version 1.0
  */
+@javax.persistence.Entity
+@Table(name = "enrollments")
 public class Enrollment implements Serializable {
 
     /**
      * Ticket identifier.
      */
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "enrollment_id")
     private long ticketId;
 
     /**
      * Ticket status.
      */
+    @ManyToOne
+    @JoinColumn(name = "enrollment_status_code")
     private EnrollmentStatus status;
 
     /**
      * Ticket request type.
      */
+    @ManyToOne
+    @JoinColumn(name = "request_type_code")
     private RequestType requestType;
 
     /**
      * Business process instance.
      */
-    private long processInstanceId;
+    @Column(
+            name = "process_instance_id",
+            nullable = false
+    )
+    private long processInstanceId = 0;
 
     /**
      * The profile id that was created by this ticket.
      */
-    private long profileReferenceId;
+    @Column(
+            name = "profile_reference_id",
+            nullable = false
+    )
+    private long profileReferenceId = 0;
 
     /**
      * The current page.
      */
+    @Column(name = "progress_page")
     private String progressPage;
 
     /**
      * The timestamp of the referenced profile.
      */
+    @Column(name = "reference_timestamp")
     private Date referenceTimestamp;
 
+    @Column(name = "submitted_at")
     private Date submissionDate;
 
     /**
      * The last status change date.
      */
+    @Column(name = "changed_at")
     private Date statusDate;
 
     /**
      * Note included in the last status change.
      */
+    @Column(name = "change_note")
     private String statusNote;
 
     /**
      * Username that submitted the request.
      */
+    @Column(name = "submitted_by")
     private String submittedBy;
 
     /**
      * Username that created this request.
      */
+    @Column(name = "created_by")
     private String createdBy;
 
+    @Column(name = "created_at")
     private Date createdOn;
 
     /**
      * Username that last made changes to the ticket.
      */
+    @Column(name = "changed_by")
     private String lastUpdatedBy;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -28,11 +28,6 @@ public class Sequences {
     public static final String ATTACHMENT_SEQ = "ATTACHMENT_SEQ";
 
     /**
-     * Used for tickets table.
-     */
-    public static final String TICKET_SEQ = "TICKET_SEQ";
-
-    /**
      * Used for provider group association table.
      */
     public static final String PROV_GRP_SEQ = "PROV_GRP_SEQ";


### PR DESCRIPTION
Remove redundant comments, pluralize the table name, use a more descriptive column names, and generate primary key values using Hibernate natively.

Note that the old table was named `TICKET`, and some of the fields (eg `ticketId`) and comments reflect that legacy name, as well. This is confusing and should be cleaned up later, but I argue it is out of scope at the moment and should be fixed as part of issue #57.

Issue #36 Use Hibernate 5, instead of 4