### PR TITLE
Hibernate-5-ify Address

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1301,7 +1301,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             return;
         }
 
-        address.setId(getSequence().getNextValue(Sequences.ADDRESS_SEQ));
+        address.setId(0);
         getEm().persist(address);
     }
 

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -2,34 +2,6 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                    "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-lazy="false">
-	<class name="gov.medicaid.entities.Address" table="ADDRESS">
-		<id name="id" type="long">
-			<column name="ADDRESS_ID" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="attentionTo"
-			type="string">
-			<column length="30" name="ATTN_TO" />
-		</property>
-		<property generated="never" lazy="false" name="line1" type="string">
-			<column length="30" name="LINE1" />
-		</property>
-		<property generated="never" lazy="false" name="line2" type="string">
-			<column length="30" name="LINE2" />
-		</property>
-		<property generated="never" lazy="false" name="city" type="string">
-			<column length="20" name="CITY" />
-		</property>
-		<property generated="never" lazy="false" name="state" type="string">
-			<column length="2" name="STATE" />
-		</property>
-		<property generated="never" lazy="false" name="zipcode" type="string">
-			<column length="10" name="ZIPCODE" />
-		</property>
-		<property generated="never" lazy="false" name="county" type="string">
-			<column length="20" name="COUNTY" />
-		</property>
-	</class>
 	<class abstract="true" name="gov.medicaid.entities.Entity" table="ENTITY">
 		<id name="id" type="long">
 			<column name="ENTITY_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -41,6 +41,7 @@
     <class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
     <class>org.jbpm.task.User</class>
 
+    <class>gov.medicaid.entities.Address</class>
     <class>gov.medicaid.entities.AgreementDocument</class>
     <class>gov.medicaid.entities.AuditDetail</class>
     <class>gov.medicaid.entities.AuditRecord</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -2,6 +2,7 @@ DROP SEQUENCE IF EXISTS
   hibernate_sequence
 CASCADE;
 DROP TABLE IF EXISTS
+  addresses,
   agreement_documents,
   audit_details,
   audit_records,
@@ -394,6 +395,17 @@ CREATE TABLE provider_profiles(
   created_at TIMESTAMP WITH TIME ZONE,
   last_modified_by TEXT,
   last_modified_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE addresses(
+  address_id BIGINT PRIMARY KEY,
+  attention_line TEXT,
+  address_line_1 TEXT,
+  address_line_2 TEXT,
+  city TEXT,
+  state TEXT,
+  zip_code TEXT,
+  county TEXT
 );
 
 CREATE TABLE agreement_documents(

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
@@ -15,21 +15,24 @@
  */
 package gov.medicaid.entities;
 
-public class Address extends IdentifiableEntity {
+import javax.persistence.*;
+import java.io.Serializable;
 
-    /**
-     * Attention line.
-     */
+@javax.persistence.Entity
+@Table(name = "addresses")
+public class Address implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "address_id")
+    private long id;
+
+    @Column(name = "attention_line")
     private String attentionTo;
 
-    /**
-     * Address line 1.
-     */
+    @Column(name = "address_line_1")
     private String line1;
 
-    /**
-     * Address line 2.
-     */
+    @Column(name = "address_line_2")
     private String line2;
 
     private String city;
@@ -39,9 +42,18 @@ public class Address extends IdentifiableEntity {
      */
     private String state;
 
+    @Column(name = "zip_code")
     private String zipcode;
 
     private String county;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getCity() {
         return city;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
@@ -15,12 +15,6 @@
  */
 package gov.medicaid.entities;
 
-/**
- * Represents an address.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 public class Address extends IdentifiableEntity {
 
     /**
@@ -38,9 +32,6 @@ public class Address extends IdentifiableEntity {
      */
     private String line2;
 
-    /**
-     * City.
-     */
     private String city;
 
     /**
@@ -48,14 +39,8 @@ public class Address extends IdentifiableEntity {
      */
     private String state;
 
-    /**
-     * Zip code.
-     */
     private String zipcode;
 
-    /**
-     * County.
-     */
     private String county;
 
     /**
@@ -64,128 +49,58 @@ public class Address extends IdentifiableEntity {
     public Address() {
     }
 
-    /**
-     * Gets the value of the field <code>city</code>.
-     *
-     * @return the city
-     */
     public String getCity() {
         return city;
     }
 
-    /**
-     * Sets the value of the field <code>city</code>.
-     *
-     * @param city the city to set
-     */
     public void setCity(String city) {
         this.city = city;
     }
 
-    /**
-     * Gets the value of the field <code>state</code>.
-     *
-     * @return the state
-     */
     public String getState() {
         return state;
     }
 
-    /**
-     * Sets the value of the field <code>state</code>.
-     *
-     * @param state the state to set
-     */
     public void setState(String state) {
         this.state = state;
     }
 
-    /**
-     * Gets the value of the field <code>zipcode</code>.
-     *
-     * @return the zipcode
-     */
     public String getZipcode() {
         return zipcode;
     }
 
-    /**
-     * Sets the value of the field <code>zipcode</code>.
-     *
-     * @param zipcode the zipcode to set
-     */
     public void setZipcode(String zipcode) {
         this.zipcode = zipcode;
     }
 
-    /**
-     * Gets the value of the field <code>county</code>.
-     *
-     * @return the county
-     */
     public String getCounty() {
         return county;
     }
 
-    /**
-     * Sets the value of the field <code>county</code>.
-     *
-     * @param county the county to set
-     */
     public void setCounty(String county) {
         this.county = county;
     }
 
-    /**
-     * Gets the value of the field <code>line1</code>.
-     *
-     * @return the line1
-     */
     public String getLine1() {
         return line1;
     }
 
-    /**
-     * Sets the value of the field <code>line1</code>.
-     *
-     * @param line1 the line1 to set
-     */
     public void setLine1(String line1) {
         this.line1 = line1;
     }
 
-    /**
-     * Gets the value of the field <code>line2</code>.
-     *
-     * @return the line2
-     */
     public String getLine2() {
         return line2;
     }
 
-    /**
-     * Sets the value of the field <code>line2</code>.
-     *
-     * @param line2 the line2 to set
-     */
     public void setLine2(String line2) {
         this.line2 = line2;
     }
 
-    /**
-     * Gets the value of the field <code>attentionTo</code>.
-     *
-     * @return the attentionTo
-     */
     public String getAttentionTo() {
         return attentionTo;
     }
 
-    /**
-     * Sets the value of the field <code>attentionTo</code>.
-     *
-     * @param attentionTo the attentionTo to set
-     */
     public void setAttentionTo(String attentionTo) {
         this.attentionTo = attentionTo;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
@@ -43,12 +43,6 @@ public class Address extends IdentifiableEntity {
 
     private String county;
 
-    /**
-     * Default empty constructor.
-     */
-    public Address() {
-    }
-
     public String getCity() {
         return city;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -53,11 +53,6 @@ public class Sequences {
     public static final String CONTACT_INFO_SEQ = "CONTACT_INFO_SEQ";
 
     /**
-     * Used for address table.
-     */
-    public static final String ADDRESS_SEQ = "ADDRESS_SEQ";
-
-    /**
      * Used for provider statement table.
      */
     public static final String STATEMENT_ID = "STATEMENT_ID";


### PR DESCRIPTION
Remove redundant comments, remove default constructor, pluralize the table name, expand the column abbreviations, and generate primary key values using Hibernate natively.

Issue #36 Use Hibernate 5, instead of 4