### PR TITLE
Extract ProviderType-AgreementDocument link

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
@@ -132,8 +132,7 @@ public class GlobalLookups {
             .findAllLookups(gov.medicaid.entities.ProviderType.class);
 
         for (gov.medicaid.entities.ProviderType providerType : all) {
-            List<AgreementDocument> agreement = lookupService.findRequiredDocuments(providerType.getCode());
-            for (AgreementDocument document : agreement) {
+            for (AgreementDocument document : providerType.getAgreementDocuments()) {
                 entries.add(new LookupEntry("RequiredAgreement", providerType.getDescription(), document.getTitle()));
             }
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import javax.persistence.Query;
 
 /**
  * Defines the UI related services.
- * 
+ *
  * @author TCSASSEMBLER
  * @version 1.0
  */
@@ -79,7 +79,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Retrieves the provider types filtered by applicant type.
-     * 
+     *
      * @param applicantType
      *            individual or organizations
      * @return the filtered provider types
@@ -96,7 +96,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Retrieves the lookup with the given description.
-     * 
+     *
      * @param cls
      *            the class to lookup
      * @param description
@@ -124,7 +124,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Retrieves the lookup with the given code.
-     * 
+     *
      * @param cls
      *            the class to lookup
      * @param description
@@ -152,7 +152,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Sets the value of the field <code>em</code>.
-     * 
+     *
      * @param em
      *            the em to set
      */
@@ -162,7 +162,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Find the related lookups to the given provider.
-     * 
+     *
      * @param cls
      *            the class to search for
      * @param providerType
@@ -203,11 +203,11 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Finds the provider type setting based on the given parameters.
-     * 
+     *
      * @param providerTypeCode provider type code
      * @param relatedEntityType related entity type
      * @param relatedEntityCode related entity code
-     * 
+     *
      * @return the list of settings
      */
     @SuppressWarnings("unchecked")
@@ -218,10 +218,10 @@ public class LookupServiceBean implements LookupService {
     			.setParameter("relatedEntityType", relatedEntityType)
     			.getResultList();
     }
-    
+
     /**
      * Retrieves all the lookups of the given class.
-     * 
+     *
      * @param cls
      *            the class to search for
      * @param <T>
@@ -235,7 +235,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Retrieves all the owner types allowed for the given structure.
-     * 
+     *
      * @param entityType
      *            the corporate structure type
      * @return the matched lookups
@@ -257,7 +257,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Retrieves all the service types based on indicator.
-     * 
+     *
      * @param indicator
      *            in/out patient indicator
      * @return the matched lookups
@@ -271,7 +271,7 @@ public class LookupServiceBean implements LookupService {
 
     /**
      * Retrieves all the service types based on code.
-     * 
+     *
      * @param code
      *            the parent service code
      * @return the matched lookups
@@ -295,7 +295,7 @@ public class LookupServiceBean implements LookupService {
     public String findLegacyMapping(String name, String codeType, String internalCodeValue) {
         String query = "from LegacySystemMapping l where l.systemName = :systemName "
             + "AND l.codeType = :codeType AND l.internalCode = :internalCode";
-        
+
         List<LegacySystemMapping> resultList = em.createQuery(query).setParameter("systemName", name)
             .setParameter("codeType", codeType).setParameter("internalCode", internalCodeValue).getResultList();
         if (resultList.isEmpty()) {
@@ -303,7 +303,7 @@ public class LookupServiceBean implements LookupService {
         }
         return resultList.get(0).getExternalCode();
     }
-    
+
     /**
      * Retrieves the mapped code for the given external lookup.
      * @param name the system name
@@ -322,7 +322,7 @@ public class LookupServiceBean implements LookupService {
         }
         return resultList.get(0).getInternalCode();
     }
-    
+
     @Override
     public void updateProviderTypeAgreementSettings(String providerTypeCode,
     		long[] agreementIds) {
@@ -343,7 +343,7 @@ public class LookupServiceBean implements LookupService {
         		em.remove(setting);
         	}
         }
-        
+
         for (long id: agreementIds) {
         	if (!persistedIds.contains(id)) {
         		// new addition
@@ -354,11 +354,11 @@ public class LookupServiceBean implements LookupService {
         		setting.setRelatedEntityCode(format.format(id));
         		setting.setRelatedEntityType("AgreementDocument");
         		setting.setRelationshipType("RA");
-        		
+
         		em.persist(setting);
         	}
         }
-        
+
         GlobalLookups.refresh();
     }
 }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -16,25 +16,17 @@
 package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.model.ApplicantType;
-import gov.medicaid.domain.rules.GlobalLookups;
 import gov.medicaid.entities.AgreementDocument;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.EntityStructureType;
 import gov.medicaid.entities.LegacySystemMapping;
 import gov.medicaid.entities.LookupEntity;
 import gov.medicaid.entities.ProviderType;
-import gov.medicaid.entities.ProviderTypeSetting;
 import gov.medicaid.entities.ServiceAssuranceExtType;
 import gov.medicaid.entities.ServiceAssuranceType;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.util.Util;
-
-import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import javax.ejb.Local;
 import javax.ejb.Stateless;
@@ -45,6 +37,11 @@ import javax.ejb.TransactionManagementType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Defines the UI related services.
@@ -181,42 +178,8 @@ public class LookupServiceBean implements LookupService {
         query.setParameter("providerType", providerType);
         query.setParameter("relationshipType", relType);
         query.setParameter("entityType", cls.getSimpleName());
-        
-        return query.getResultList();
-    }
 
-    /**
-     * Finds all the required agreements for the given provider type.
-     * 
-     * @param providerType
-     *            the provider type
-     * @return the required documents
-     */
-    @SuppressWarnings("unchecked")
-    public List<AgreementDocument> findRequiredDocuments(String providerType) {
-        Query query = em.createQuery("Select d FROM AgreementDocument d, ProviderTypeSetting s WHERE "
-                + "s.providerTypeCode = :providerType AND d.id = s.relatedEntityCode "
-                + "AND s.relatedEntityType = 'AgreementDocument'");
-        query.setParameter("providerType", providerType);
         return query.getResultList();
-    }
-
-    /**
-     * Finds the provider type setting based on the given parameters.
-     *
-     * @param providerTypeCode provider type code
-     * @param relatedEntityType related entity type
-     * @param relatedEntityCode related entity code
-     *
-     * @return the list of settings
-     */
-    @SuppressWarnings("unchecked")
-	public List<ProviderTypeSetting> findProviderTypeSetting(String providerTypeCode, String relatedEntityType) {
-    	return em.createQuery("SELECT s from ProviderTypeSetting s WHERE s.providerTypeCode = :providerTypeCode " +
-    			"AND s.relatedEntityType = :relatedEntityType")
-    			.setParameter("providerTypeCode", providerTypeCode)
-    			.setParameter("relatedEntityType", relatedEntityType)
-    			.getResultList();
     }
 
     /**
@@ -324,41 +287,29 @@ public class LookupServiceBean implements LookupService {
     }
 
     @Override
-    public void updateProviderTypeAgreementSettings(String providerTypeCode,
-    		long[] agreementIds) {
-    	List<ProviderTypeSetting> selectedSettings = findProviderTypeSetting(providerTypeCode, "AgreementDocument");
-        DecimalFormat format = new DecimalFormat("00");
-        List<Long> persistedIds = new ArrayList<Long>();
-        for (ProviderTypeSetting setting: selectedSettings) {
-        	boolean keep = false;
-        	for (long id: agreementIds) {
-        		if (setting.getRelatedEntityCode().equals(format.format(id))) {
-        			keep = true;
-        			persistedIds.add(id);
-        			break;
-        		}
-        	}
-        	if (!keep) {
-        		// delete the setting from DB
-        		em.remove(setting);
-        	}
+    public void updateProviderTypeAgreementSettings(
+            ProviderType providerType,
+            long[] agreementIds
+    ) {
+        providerType.setAgreementDocuments(
+                getAgreementDocuments(agreementIds)
+        );
+        em.merge(providerType);
+    }
+
+    private List<AgreementDocument> getAgreementDocuments(long[] agreementIds) {
+        if (agreementIds.length == 0) {
+            return new ArrayList<>();
+        } else {
+            return em.createQuery(
+                    "FROM AgreementDocument WHERE id IN :ids",
+                    AgreementDocument.class
+            ).setParameter(
+                    "ids",
+                    Arrays.stream(agreementIds)
+                            .boxed()
+                            .collect(Collectors.toList())
+            ).getResultList();
         }
-
-        for (long id: agreementIds) {
-        	if (!persistedIds.contains(id)) {
-        		// new addition
-        		ProviderTypeSetting setting = new ProviderTypeSetting();
-        		BigDecimal maxId = (BigDecimal) em.createNativeQuery("select max(provider_setting_id) from PROVIDER_SETTING").getSingleResult();
-        		setting.setId(maxId.longValue() + 1);
-        		setting.setProviderTypeCode(providerTypeCode);
-        		setting.setRelatedEntityCode(format.format(id));
-        		setting.setRelatedEntityType("AgreementDocument");
-        		setting.setRelationshipType("RA");
-
-        		em.persist(setting);
-        	}
-        }
-
-        GlobalLookups.refresh();
     }
 }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
@@ -24,17 +24,19 @@ import gov.medicaid.services.ProviderTypeService;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.services.util.Util;
 
-import java.util.HashSet;
-import java.util.List;
-
 import javax.ejb.Local;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
+import javax.persistence.EntityGraph;
 import javax.persistence.PersistenceException;
 import javax.persistence.Query;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class provides an implementation of the <code>ProviderTypeDAO</code> as a local EJB.
@@ -162,7 +164,12 @@ public class ProviderTypeServiceBean extends BaseService implements ProviderType
         LogUtil.traceEntry(getLog(), signature, new String[] {"id"}, new Object[] {id});
 
         try {
-            return LogUtil.traceExit(getLog(), signature, getEm().find(ProviderType.class, id));
+            EntityGraph graph = getEm().getEntityGraph(
+                    "ProviderType with AgreementDocuments"
+            );
+            Map<String, Object> hints = new HashMap<>();
+            hints.put("javax.persistence.loadgraph", graph);
+            return LogUtil.traceExit(getLog(), signature, getEm().find(ProviderType.class, id, hints));
         } catch (PersistenceException e) {
             LogUtil.traceError(getLog(), signature, e);
             throw new PortalServiceException("Could not database complete operation.", e);

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -175,10 +175,9 @@ public class ProviderTypeController extends BaseServiceAdminController {
 
         try {
             ProviderType providerType = providerTypeService.get(providerTypeId);
-            List<AgreementDocument> agreements = lookupService.findRequiredDocuments(providerType.getCode());
             ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
             model.addObject("providerType", providerType);
-            model.addObject("agreements", agreements);
+            model.addObject("agreements", providerType.getAgreementDocuments());
             return LogUtil.traceExit(getLog(), signature, model);
         } catch (PortalServiceException e) {
             LogUtil.traceError(getLog(), signature, e);
@@ -246,8 +245,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
             criteria.setPageSize(-1);
             List<AgreementDocument> agreements = agreementDocumentService.search(criteria).getItems();
             List<AgreementDocument> remainingAgreements = new ArrayList<AgreementDocument>(agreements);
-            List<AgreementDocument> selectedAgreements = lookupService.findRequiredDocuments(providerType.getCode());
-            
+            List<AgreementDocument> selectedAgreements = providerType.getAgreementDocuments();
+
             for (AgreementDocument agreement: agreements) {
             	for (AgreementDocument selectedAgreement: selectedAgreements) {
             		if (selectedAgreement.getId() == agreement.getId()) {
@@ -331,12 +330,12 @@ public class ProviderTypeController extends BaseServiceAdminController {
             // Retrieve
             providerType = providerTypeService.get(providerType.getCode());
             long[] agreementIds = ServletRequestUtils.getLongParameters(request, "providerAgreements");
-            
-            lookupService.updateProviderTypeAgreementSettings(providerType.getCode(), agreementIds);
-            
+
+            lookupService.updateProviderTypeAgreementSettings(providerType, agreementIds);
+
             ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
             model.addObject("providerType", providerType);
-            model.addObject("agreements", lookupService.findRequiredDocuments(providerType.getCode()));
+            model.addObject("agreements", providerType.getAgreementDocuments());
             return LogUtil.traceExit(getLog(), signature, model);
         } catch (PortalServiceException e) {
             LogUtil.traceError(getLog(), signature, e);

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -14,6 +14,7 @@ DROP TABLE IF EXISTS
   persistent_logins,
   profile_statuses,
   provider_profiles,
+  provider_type_agreement_documents,
   provider_types,
   request_types,
   risk_levels,
@@ -405,6 +406,17 @@ CREATE TABLE agreement_documents(
   created_by TEXT,
   created_at TIMESTAMP WITH TIME ZONE
 );
+INSERT INTO agreement_documents (
+  agreement_document_id,
+  type,
+  title,
+  version,
+  body,
+  created_by,
+  created_at
+) VALUES
+  (1, '01', 'Agreement (1)', 0, 'This is the content of the agreement.', 'system', NOW()),
+  (2, '02', 'Addendum (2)', 0, 'This is the content of the addendum.', 'system', NOW());
 
 CREATE TABLE enrollments(
   enrollment_id BIGINT PRIMARY KEY,
@@ -424,3 +436,16 @@ CREATE TABLE enrollments(
   changed_at TIMESTAMP WITH TIME ZONE,
   change_note TEXT
 );
+
+CREATE TABLE provider_type_agreement_documents(
+  provider_type_code CHARACTER VARYING(2)
+    REFERENCES provider_types(code),
+  agreement_document_id BIGINT
+    REFERENCES agreement_documents(agreement_document_id),
+  PRIMARY KEY (provider_type_code, agreement_document_id)
+);
+INSERT INTO provider_type_agreement_documents (
+  provider_type_code,
+  agreement_document_id
+) VALUES
+  ('18', 1);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -117,7 +117,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         }
 
         ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+        List<AgreementDocument> docs = pt.getAgreementDocuments();
 
         List<ProviderAgreementType> xList = new ArrayList<ProviderAgreementType>();
         HashSet<String> agreed = new HashSet<String>();
@@ -165,7 +165,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         if (enrollment.getRequestType() == RequestType.RENEWAL && provider.getRenewalShowBlankStatement() == null) {
         	attr(mv, "renewalBlankInit", "Y");
         	ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-            List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+            List<AgreementDocument> docs = pt.getAgreementDocuments();
             int i = 0;
             for (AgreementDocument doc : docs) {
                 attr(mv, "documentId", i, "" + doc.getId());
@@ -189,7 +189,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 	        AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
 	
 	        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-	        List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+	        List<AgreementDocument> docs = pt.getAgreementDocuments();
 	        int i = 0;
 	        for (AgreementDocument doc : docs) {
 	            attr(mv, "documentId", i, "" + doc.getId());
@@ -288,7 +288,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         List<AcceptedAgreements> hList = profile.getAgreements();
 
         ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> activeList = getLookupService().findRequiredDocuments(pt.getCode());
+        List<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         // Retain any previously accepted agreements that is no longer shown in the page
@@ -391,7 +391,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         provider.setHasPreviousExclusion(profile.getPreviousExclusionInd());
 
         ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> activeList = getLookupService().findRequiredDocuments(pt.getCode());
+        List<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         AcceptedAgreementsType acceptedAgreements = XMLUtility.nsGetAcceptedAgreements(enrollment);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -98,7 +98,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         }
 
         ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+        List<AgreementDocument> docs = pt.getAgreementDocuments();
 
         List<ProviderAgreementType> xList = new ArrayList<ProviderAgreementType>();
         HashSet<String> agreed = new HashSet<String>();
@@ -152,7 +152,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         if (enrollment.getRequestType() == RequestType.RENEWAL && "Y".equals(provider.getRenewalShowBlankStatement())) {
             attr(mv, "renewalBlankInit", "YY");
             ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-            List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+            List<AgreementDocument> docs = pt.getAgreementDocuments();
             int i = 0;
             for (AgreementDocument doc : docs) {
                 attr(mv, "documentId", i, "" + doc.getId());
@@ -171,7 +171,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
             AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
 
             ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-            List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+            List<AgreementDocument> docs = pt.getAgreementDocuments();
             int i = 0;
             for (AgreementDocument doc : docs) {
                 attr(mv, "documentId", i, "" + doc.getId());
@@ -260,7 +260,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         List<AcceptedAgreements> hList = profile.getAgreements();
 
         ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> activeList = getLookupService().findRequiredDocuments(pt.getCode());
+        List<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         // Retain any previously accepted agreements that is no longer shown in the page
@@ -364,7 +364,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         ProviderProfile profile = ticket.getDetails();
 
         ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> activeList = getLookupService().findRequiredDocuments(pt.getCode());
+        List<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         AcceptedAgreementsType acceptedAgreements = XMLUtility.nsGetAcceptedAgreements(enrollment);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -74,12 +74,16 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
     /**
      * Binds the request to the model.
-     * @param enrollment the model to bind to
-     * @param request the request containing the form fields
      *
+     * @param enrollment the model to bind to
+     * @param request    the request containing the form fields
      * @throws BinderException if the format of the fields could not be bound properly
      */
-    public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
+    public List<BinderException> bindFromPage(
+            CMSUser user,
+            EnrollmentType enrollment,
+            HttpServletRequest request
+    ) {
         List<BinderException> exceptions = new ArrayList<BinderException>();
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         provider.setRenewalShowBlankStatement(param(request, "renewalBlankInit"));
@@ -125,79 +129,85 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
             providerAgreement.clear();
             providerAgreement.addAll(xList);
         }
-        
+
         return exceptions;
     }
 
     /**
      * Binds the model to the request attributes.
+     *
      * @param enrollment the model to bind from
-     * @param mv the model and view to bind to
-     * @param readOnly true if the view is read only
+     * @param mv         the model and view to bind to
+     * @param readOnly   true if the view is read only
      */
-    public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
+    public void bindToPage(
+            CMSUser user,
+            EnrollmentType enrollment,
+            Map<String, Object> mv,
+            boolean readOnly
+    ) {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
 
         if (enrollment.getRequestType() == RequestType.RENEWAL && "Y".equals(provider.getRenewalShowBlankStatement())) {
-        	attr(mv, "renewalBlankInit", "YY");
-        	ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-	        List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
-	        int i = 0;
-	        for (AgreementDocument doc : docs) {
-	            attr(mv, "documentId", i, "" + doc.getId());
-	            attr(mv, "documentName", i, doc.getTitle());
-	
-	            attr(mv, "accepted", i, "N");
-	            attr(mv, "updatedVersion", i, "N");
-	            i++;
-	        }
+            attr(mv, "renewalBlankInit", "YY");
+            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+            List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+            int i = 0;
+            for (AgreementDocument doc : docs) {
+                attr(mv, "documentId", i, "" + doc.getId());
+                attr(mv, "documentName", i, doc.getTitle());
+
+                attr(mv, "accepted", i, "N");
+                attr(mv, "updatedVersion", i, "N");
+                i++;
+            }
         } else {
-        	ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
-	        attr(mv, "name", statement.getName());
-	        attr(mv, "title", statement.getTitle());
-	        attr(mv, "date", statement.getSignDate());
-	
-	        AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
-	
-	        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-	        List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
-	        int i = 0;
-	        for (AgreementDocument doc : docs) {
-	            attr(mv, "documentId", i, "" + doc.getId());
-	            attr(mv, "documentName", i, doc.getTitle());
-	
-	            boolean agreed = false;
-	            boolean updatedVersion = false;
-	
-	            if (acceptedAgreements != null) {
-	                List<ProviderAgreementType> agreements = acceptedAgreements.getProviderAgreement();
-	                for (ProviderAgreementType agreement : agreements) {
-	                    if (doc.getType().equals(agreement.getAgreementDocumentType())) {
-	                        if (String.valueOf(doc.getVersion()).equals(agreement.getAgreementDocumentVersion())) {
-	                            agreed = true;
-	                        } else {
-	                            updatedVersion = true;
-	                        }
-	                        break;
-	                    }
-	                }
-	            }
-	
-	            attr(mv, "accepted", i, agreed ? "Y" : "N");
-	            attr(mv, "updatedVersion", i, updatedVersion ? "Y" : "N");
-	            i++;
-	        }
-	
-	        attr(mv, "requiredAgreementsSize", docs.size());
+            ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
+            attr(mv, "name", statement.getName());
+            attr(mv, "title", statement.getTitle());
+            attr(mv, "date", statement.getSignDate());
+
+            AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
+
+            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+            List<AgreementDocument> docs = getLookupService().findRequiredDocuments(pt.getCode());
+            int i = 0;
+            for (AgreementDocument doc : docs) {
+                attr(mv, "documentId", i, "" + doc.getId());
+                attr(mv, "documentName", i, doc.getTitle());
+
+                boolean agreed = false;
+                boolean updatedVersion = false;
+
+                if (acceptedAgreements != null) {
+                    List<ProviderAgreementType> agreements = acceptedAgreements.getProviderAgreement();
+                    for (ProviderAgreementType agreement : agreements) {
+                        if (doc.getType().equals(agreement.getAgreementDocumentType())) {
+                            if (String.valueOf(doc.getVersion()).equals(agreement.getAgreementDocumentVersion())) {
+                                agreed = true;
+                            } else {
+                                updatedVersion = true;
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                attr(mv, "accepted", i, agreed ? "Y" : "N");
+                attr(mv, "updatedVersion", i, updatedVersion ? "Y" : "N");
+                i++;
+            }
+
+            attr(mv, "requiredAgreementsSize", docs.size());
         }
     }
 
     /**
      * Captures the error messages related to the form.
-     * @param enrollment the enrollment that was validated
-     * @param messages the messages to select from
      *
+     * @param enrollment the enrollment that was validated
+     * @param messages   the messages to select from
      * @return the list of errors related to the form
      */
     protected List<FormError> selectErrors(EnrollmentType enrollment, StatusMessagesType messages) {
@@ -241,7 +251,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
      * Binds the fields of the form to the persistence model.
      *
      * @param enrollment the front end model
-     * @param ticket the persistent model
+     * @param ticket     the persistent model
      */
     public void bindToHibernate(EnrollmentType enrollment, Enrollment ticket) {
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
@@ -291,6 +301,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
     /**
      * Maps the given list by id.
+     *
      * @param list the list to be mapped
      * @return the lookup map
      */
@@ -304,6 +315,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
     /**
      * Maps the given list by id.
+     *
      * @param list the list to be mapped
      * @return the lookup map
      */
@@ -319,12 +331,15 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
     /**
      * Filters the inactive agreements from the given list.
-     * @param accepted the current agreements
+     *
+     * @param accepted    the current agreements
      * @param documentMap the active agreements
      * @return the inactive agreements
      */
-    private List<AcceptedAgreements> filterOnlyInactive(List<AcceptedAgreements> accepted,
-        Map<String, AgreementDocument> documentMap) {
+    private List<AcceptedAgreements> filterOnlyInactive(
+            List<AcceptedAgreements> accepted,
+            Map<String, AgreementDocument> documentMap
+    ) {
         List<AcceptedAgreements> inactiveList = new ArrayList<AcceptedAgreements>();
         if (accepted != null) {
             for (AcceptedAgreements agreement : accepted) {
@@ -341,7 +356,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
     /**
      * Binds the fields of the persistence model to the front end xml.
      *
-     * @param ticket the persistent model
+     * @param ticket     the persistent model
      * @param enrollment the front end model
      */
     public void bindFromHibernate(Enrollment ticket, EnrollmentType enrollment) {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
@@ -20,8 +20,14 @@ import gov.medicaid.domain.model.ApplicantType;
 import javax.persistence.Column;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import java.util.List;
 
 /**
  * Represents a provider type.
@@ -31,6 +37,10 @@ import javax.persistence.Transient;
  */
 @javax.persistence.Entity
 @Table(name = "provider_types")
+@NamedEntityGraph(
+        name = "ProviderType with AgreementDocuments",
+        attributeNodes = {@NamedAttributeNode("agreementDocuments")}
+)
 public class ProviderType extends LookupEntity {
 
     /**
@@ -48,6 +58,20 @@ public class ProviderType extends LookupEntity {
      */
     @Transient
     private boolean canDelete;
+
+    @ManyToMany
+    @JoinTable(
+            name = "provider_type_agreement_documents",
+            joinColumns = @JoinColumn(
+                    name = "provider_type_code",
+                    referencedColumnName = "code"
+            ),
+            inverseJoinColumns = @JoinColumn(
+                    name = "agreement_document_id",
+                    referencedColumnName = "agreement_document_id"
+            )
+    )
+    private List<AgreementDocument> agreementDocuments;
 
    /**
      * Gets the value of the field <code>applicantType</code>.
@@ -72,4 +96,12 @@ public class ProviderType extends LookupEntity {
 	public void setCanDelete(boolean canDelete) {
 		this.canDelete = canDelete;
 	}
+
+    public List<AgreementDocument> getAgreementDocuments() {
+        return agreementDocuments;
+    }
+
+    public void setAgreementDocuments(List<AgreementDocument> agreementDocuments) {
+        this.agreementDocuments = agreementDocuments;
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -16,11 +16,9 @@
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.ApplicantType;
-import gov.medicaid.entities.AgreementDocument;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.LookupEntity;
 import gov.medicaid.entities.ProviderType;
-import gov.medicaid.entities.ProviderTypeSetting;
 import gov.medicaid.entities.ServiceAssuranceExtType;
 import gov.medicaid.entities.ServiceAssuranceType;
 
@@ -89,15 +87,6 @@ public interface LookupService {
     <T extends LookupEntity> List<T> findRelatedLookup(Class<T> cls, String providerType, String relType);
 
     /**
-     * Finds all the required agreements for the given provider type.
-     * 
-     * @param providerType
-     *            the provider type
-     * @return the required documents
-     */
-    List<AgreementDocument> findRequiredDocuments(String providerType);
-
-    /**
      * Retrieves all the lookups of the given class.
      * 
      * @param cls
@@ -152,23 +141,12 @@ public interface LookupService {
      * @return the mapped value, or the external code if not found
      */
     public String findInternalMapping(String name, String codeType, String externalCodeValue);
-    
-    /**
-     * Finds the provider type setting based on the given parameters.
-     * 
-     * @param providerTypeCode provider type code
-     * @param relatedEntityType related entity type
-     * @param relatedEntityCode related entity code
-     * 
-     * @return the list of settings
-     */
-	public List<ProviderTypeSetting> findProviderTypeSetting(String providerTypeCode, String relatedEntityType);
 
 	/**
 	 * Updates the ProviderTypeSettings for agreements.
-	 * 
-	 * @param providerTypeCode providerTypeCode
+	 *
+	 * @param providerType providerType
 	 * @param agreementIds agreement ids
 	 */
-	public void updateProviderTypeAgreementSettings(String providerTypeCode, long[] agreementIds);
+	public void updateProviderTypeAgreementSettings(ProviderType providerType, long[] agreementIds);
 }


### PR DESCRIPTION
One of the more challenging design decisions in converting from Hibernate 4 to Hibernate 5 is the implementation of `ProviderTypeSetting`. It is a polymorphic link table, meaning it relates `ProviderType` to a number of other classes, including `AgreementDocument`. It was created without the help of Hibernate 4, and it does some things that Hibernate 5 and/or PostgreSQL doesn't like. This is the first step in pulling functionality out of `ProviderTypeSetting`, with the eventual goal of deleting the class entirely.

I've split this into three commits:

- The first is a [whitespace-only commit](https://github.com/OpenTechStrategies/psm/commit/10fd8a8d6fcd518b528bfd203ab576620c62c323?w=1).
- The second is a [whitespace-mostly commit](https://github.com/OpenTechStrategies/psm/commit/40eefb8ec0d6eb140b49d57320a039db3f8627a8?w=1).
- The third is a doozy, and I wrote a bit of an essay in the commit message. This is an atomic set of changes, and I'm afraid I couldn't figure out a way to split it up any more than this - sorry for the large commit/review.

You can test the functionality of this by logging in as `admin`/`admin`, ignoring the error, and going to https://localhost:8443/cms/admin/viewProviderTypes . Once there, you should be able to view a provider type, edit a provider type to link and unlink agreements, and see the changes show up in the UI, in the server log (by way of Hibernate queries), and in the database (`SELECT * FROM provider_type_agreement_documents` in a `psql(1)` session).

You can also go to the "Agreements & Addendums" tab to create a new agreement and link it to provider types, but you may encounter a duplicate primary key exception - there are a few pre-seeded agreements already. You can work around this by creating a new user (which uses up a few numbers in the sequence) or by running `SELECT setval('hibernate_sequence', 10);` in `psql(1)`.

Related reading:
- [Java Persistence - ManyToMany](https://en.wikibooks.org/wiki/Java_Persistence/ManyToMany)
- [Named Entity Graphs](https://www.thoughts-on-java.org/jpa-21-entity-graph-part-1-named-entity/).