### PR TITLE
Hibernate-5-ify ContactInformation

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1287,7 +1287,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         }
         insertAddress(contactInformation.getAddress());
 
-        contactInformation.setId(getSequence().getNextValue(Sequences.CONTACT_INFO_SEQ));
+        contactInformation.setId(0);
         getEm().persist(contactInformation);
     }
 

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -295,27 +295,6 @@
 			<column name="STATUS" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.ContactInformation" table="CONTACT_INFO">
-		<id name="id" type="long">
-			<column name="CONTACT_INFO_ID" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="phoneNumber"
-			type="string">
-			<column length="30" name="PHONE_NUMBER" />
-		</property>
-		<property generated="never" lazy="false" name="faxNumber"
-			type="string">
-			<column length="30" name="FAX_NUMBER" />
-		</property>
-		<property generated="never" lazy="false" name="email" type="string">
-			<column length="50" name="EMAIL" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.Address" fetch="join"
-			name="address">
-			<column name="ADDRESS_ID" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.BeneficialOwnerType" table="LU_BEN_OWNER_TYP">
 		<id name="code" type="string">
 			<column length="2" name="CODE" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -47,6 +47,7 @@
     <class>gov.medicaid.entities.AuditRecord</class>
     <class>gov.medicaid.entities.Authentication</class>
     <class>gov.medicaid.entities.CMSUser</class>
+    <class>gov.medicaid.entities.ContactInformation</class>
     <class>gov.medicaid.entities.Enrollment</class>
     <class>gov.medicaid.entities.EnrollmentStatus</class>
     <class>gov.medicaid.entities.HelpItem</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -8,6 +8,7 @@ DROP TABLE IF EXISTS
   audit_records,
   cms_authentication,
   cms_user,
+  contacts,
   enrollment_statuses,
   enrollments,
   help_items,
@@ -416,6 +417,15 @@ CREATE TABLE agreement_documents(
   body TEXT,
   created_by TEXT,
   created_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE contacts(
+  contact_id BIGINT PRIMARY KEY,
+  phone_number TEXT,
+  fax_number TEXT,
+  email TEXT,
+  address_id BIGINT
+    REFERENCES addresses(address_id)
 );
 
 CREATE TABLE enrollments(

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
@@ -15,14 +15,42 @@
  */
 package gov.medicaid.entities;
 
-public class ContactInformation extends IdentifiableEntity {
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.io.Serializable;
+
+@javax.persistence.Entity
+@Table(name = "contacts")
+public class ContactInformation implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "contact_id")
+    private long id;
+
+    @Column(name = "phone_number")
     private String phoneNumber;
 
+    @Column(name = "fax_number")
     private String faxNumber;
 
     private String email;
 
+    @ManyToOne
+    @JoinColumn(name = "address_id")
     private Address address;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getPhoneNumber() {
         return phoneNumber;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
@@ -24,12 +24,6 @@ public class ContactInformation extends IdentifiableEntity {
 
     private Address address;
 
-    /**
-     * Empty constructor.
-     */
-    public ContactInformation() {
-    }
-
     public String getPhoneNumber() {
         return phoneNumber;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
@@ -15,32 +15,13 @@
  */
 package gov.medicaid.entities;
 
-/**
- * Represents the contact information.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 public class ContactInformation extends IdentifiableEntity {
-
-    /**
-     * The phone number.
-     */
     private String phoneNumber;
 
-    /**
-     * The fax number.
-     */
     private String faxNumber;
 
-    /**
-     * The email.
-     */
     private String email;
 
-    /**
-     * The address.
-     */
     private Address address;
 
     /**
@@ -49,74 +30,34 @@ public class ContactInformation extends IdentifiableEntity {
     public ContactInformation() {
     }
 
-    /**
-     * Gets the value of the field <code>phoneNumber</code>.
-     *
-     * @return the phoneNumber
-     */
     public String getPhoneNumber() {
         return phoneNumber;
     }
 
-    /**
-     * Sets the value of the field <code>phoneNumber</code>.
-     *
-     * @param phoneNumber the phoneNumber to set
-     */
     public void setPhoneNumber(String phoneNumber) {
         this.phoneNumber = phoneNumber;
     }
 
-    /**
-     * Gets the value of the field <code>faxNumber</code>.
-     *
-     * @return the faxNumber
-     */
     public String getFaxNumber() {
         return faxNumber;
     }
 
-    /**
-     * Sets the value of the field <code>faxNumber</code>.
-     *
-     * @param faxNumber the faxNumber to set
-     */
     public void setFaxNumber(String faxNumber) {
         this.faxNumber = faxNumber;
     }
 
-    /**
-     * Gets the value of the field <code>email</code>.
-     *
-     * @return the email
-     */
     public String getEmail() {
         return email;
     }
 
-    /**
-     * Sets the value of the field <code>email</code>.
-     *
-     * @param email the email to set
-     */
     public void setEmail(String email) {
         this.email = email;
     }
 
-    /**
-     * Gets the value of the field <code>address</code>.
-     *
-     * @return the address
-     */
     public Address getAddress() {
         return address;
     }
 
-    /**
-     * Sets the value of the field <code>address</code>.
-     *
-     * @param address the address to set
-     */
     public void setAddress(Address address) {
         this.address = address;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -48,11 +48,6 @@ public class Sequences {
     public static final String DESIGNATED_CONTACT_SEQ = "DESIGNATED_CONTACT_SEQ";
 
     /**
-     * Used for contact information table.
-     */
-    public static final String CONTACT_INFO_SEQ = "CONTACT_INFO_SEQ";
-
-    /**
      * Used for provider statement table.
      */
     public static final String STATEMENT_ID = "STATEMENT_ID";


### PR DESCRIPTION
Removing redundant comments, [trailing whitespace](https://github.com/OpenTechStrategies/psm/commit/67ff6d0e20244b3669ea4e3daaef6b1c90c97ba2?w=1), and an empty constructor. Pluralize the table name and generate primary key values using Hibernate natively.

Issue #36 Use Hibernate 5, instead of 4