### PR TITLE
Remove empty constructors

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -44,12 +44,6 @@ public class AcceptedAgreements extends IdentifiableEntity {
      * Related document.
      */
     private AgreementDocument agreementDocument;
-
-    /**
-     * Empty constructor.
-     */
-    public AcceptedAgreements() {
-    }
 
     /**
      * Gets the value of the field <code>profileId</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -60,27 +60,27 @@ public class Affiliation extends IdentifiableEntity {
      * Target entity.
      */
     private long targetEntityId;
-    
+
     /**
      * For qualified professionals.
      */
     private QPType qpType;
-    
+
     /**
      * Subtype for mental health professional.
      */
     private String mhpType;
-    
+
     /**
      * Acknowledgement attachment (QP).
      */
     private String acknowledgementAttachmentId;
-    
+
     /**
      * Ended flag.
      */
     private String terminatedInd;
-    
+
     /**
      * End date.
      */
@@ -90,7 +90,7 @@ public class Affiliation extends IdentifiableEntity {
      * Affiliates licenses.
      */
     private List<License> affiliateLicenses;
-    
+
     /**
      * The entity.
      */
@@ -100,17 +100,11 @@ public class Affiliation extends IdentifiableEntity {
      * The BGS Study ID for Personal Care Provider Org.
      */
     private String bgsStudyId;
-    
+
     /**
      * The BGS Clearance Date for Personal Care Provide Org.
      */
     private Date bgsClearanceDate;
-    
-    /**
-     * Empty constructor.
-     */
-    public Affiliation() {
-    }
 
     /**
      * Gets the value of the field <code>targetProfileId</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -28,12 +28,6 @@ public class AgreementDocumentSearchCriteria extends SearchCriteria {
 
     /** The type. */
     private AgreementDocumentType type;
-
-    /**
-     * Empty constructor.
-     */
-    public AgreementDocumentSearchCriteria() {
-    }
 
     /**
      * Getter of the title.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Asset.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Asset.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -42,12 +42,6 @@ public class Asset extends IdentifiableEntity {
      * Ownership type.
      */
     private OwnershipType ownershipType;
-
-    /**
-     * Empty constructor.
-     */
-    public Asset() {
-    }
 
     /**
      * Gets the value of the field <code>type</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AssuredService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AssuredService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 /**
  * Represents the Assured Statements from Chemical Dependency Program providers.
- * 
+ *
  * @author cyberjag
  * @version 1.0
  */
@@ -38,23 +38,17 @@ public class AssuredService extends IdentifiableEntity {
      * Represents the selected service assurance statements.
      */
     private List<ServiceAssuranceExtType> extendedTypes;
-    
+
     /**
      * Represents the status.
-     * 
+     *
      * 1 - Initiate New, 2 - Continue Current, 3 - Terminate
      */
     private int status;
 
     /**
-     * Empty constructor.
-     */
-    public AssuredService() {
-    }
-
-    /**
      * Gets the value of the field <code>profileId</code>.
-     * 
+     *
      * @return the profileId
      */
     public long getProfileId() {
@@ -63,7 +57,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Sets the value of the field <code>profileId</code>.
-     * 
+     *
      * @param profileId
      *            the profileId to set
      */
@@ -73,7 +67,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Gets the value of the field <code>ticketId</code>.
-     * 
+     *
      * @return the ticketId
      */
     public long getTicketId() {
@@ -82,7 +76,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Sets the value of the field <code>ticketId</code>.
-     * 
+     *
      * @param ticketId
      *            the ticketId to set
      */
@@ -92,7 +86,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Gets the value of the field <code>effectiveDate</code>.
-     * 
+     *
      * @return the effectiveDate
      */
     public Date getEffectiveDate() {
@@ -101,7 +95,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Sets the value of the field <code>effectiveDate</code>.
-     * 
+     *
      * @param effectiveDate
      *            the effectiveDate to set
      */
@@ -111,7 +105,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Gets the <code>type</code>.
-     * 
+     *
      * @return the type
      */
     public ServiceAssuranceType getType() {
@@ -120,7 +114,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Sets the <code>type</code>.
-     * 
+     *
      * @param type
      *            the type to set
      */
@@ -130,7 +124,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Gets the <code>extendedTypes</code>.
-     * 
+     *
      * @return the extendedTypes
      */
     public List<ServiceAssuranceExtType> getExtendedTypes() {
@@ -139,7 +133,7 @@ public class AssuredService extends IdentifiableEntity {
 
     /**
      * Sets the <code>extendedTypes</code>.
-     * 
+     *
      * @param extendedTypes
      *            the extendedTypes to set
      */

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -70,12 +70,6 @@ public class AuditDetail {
      */
     @Column(name = "new_value")
     private String newValue;
-
-    /**
-     * Empty constructor.
-     */
-    public AuditDetail() {
-    }
 
     public long getId() {
         return id;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -66,12 +66,6 @@ public class AuditRecord {
      */
     @OneToMany(mappedBy = "auditRecordId")
     private List<AuditDetail> details;
-
-    /**
-     * Default empty constructor.
-     */
-    public AuditRecord() {
-    }
 
     public long getId() {
         return id;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -69,12 +69,6 @@ public abstract class BeneficialOwner extends IdentifiableEntity {
      * Other provider address.
      */
     private Address otherProviderAddress;
-
-    /**
-     * Empty constructor.
-     */
-    protected BeneficialOwner() {
-    }
 
     /**
      * Gets the value of the field <code>type</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -27,12 +27,6 @@ public class BeneficialOwnerType extends LookupEntity {
      * Type of owner (P- person/O-org/A-any);
      */
     private String ownerType;
-    
-    /**
-     * Empty constructor.
-     */
-    public BeneficialOwnerType() {
-    }
 
     /**
      * Gets the value of the field <code>ownerType</code>.
@@ -49,6 +43,6 @@ public class BeneficialOwnerType extends LookupEntity {
     public void setOwnerType(String ownerType) {
         this.ownerType = ownerType;
     }
-    
-    
+
+
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -34,12 +34,6 @@ public class BinaryContent {
      * The content id.
      */
     private String contentId;
-
-    /**
-     * Empty constructor.
-     */
-    public BinaryContent() {
-    }
 
     /**
      * Gets the value of the field <code>content</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -97,12 +97,6 @@ public class CMSUser implements Serializable {
      */
     @Transient
     private ExternalAccountLink externalAccountLink;
-
-    /**
-     * Empty constructor.
-     */
-    public CMSUser() {
-    }
 
     /**
      * Gets the value of the field <code>username</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -17,15 +17,8 @@ package gov.medicaid.entities;
 
 /**
  * Represents possible relationship types.
- * 
+ *
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class CategoryOfService extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public CategoryOfService() {
-    }
-}
+public class CategoryOfService extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -42,12 +42,6 @@ public class ContactInformation extends IdentifiableEntity {
      * The address.
      */
     private Address address;
-
-    /**
-     * Empty constructor.
-     */
-    public ContactInformation() {
-    }
 
     /**
      * Gets the value of the field <code>phoneNumber</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class CountyType extends LookupEntity {
-
-    /**
-     * Default empty constructor.
-     */
-    public CountyType() {
-    }
-}
+public class CountyType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Degree.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Degree.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class Degree extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public Degree() {
-    }
-}
+public class Degree extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -54,12 +54,6 @@ public class DesignatedContact extends IdentifiableEntity {
      * The designated person.
      */
     private Person person;
-
-    /**
-     * Empty constructor.
-     */
-    public DesignatedContact() {
-    }
 
     /**
      * Gets the value of the field <code>profileId</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -70,12 +70,6 @@ public class Document extends IdentifiableEntity implements Cloneable {
      * Timestamp.
      */
     private Date createdOn;
-
-    /**
-     * Empty constructor.
-     */
-    public Document() {
-    }
 
     /**
      * Gets the value of the field <code>type</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -128,12 +128,6 @@ public class Enrollment implements Serializable {
      */
     private ProviderProfile details;
 
-    /**
-     * Empty constructor.
-     */
-    public Enrollment() {
-    }
-
     public long getTicketId() {
         return ticketId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public abstract class Entity extends IdentifiableEntity {
      * NPI - NPILookup.
      */
     private String npiLookupVerifiedInd;
-    
+
     /**
      * NPI.
      */
@@ -86,7 +86,7 @@ public abstract class Entity extends IdentifiableEntity {
      * The provider type (if enrolled).
      */
     private ProviderType providerType;
-    
+
     /**
      * Additional type information.
      */
@@ -106,12 +106,6 @@ public abstract class Entity extends IdentifiableEntity {
      * For agencies.
      */
     private Date backgroundClearanceDate;
-    
-    /**
-     * Empty constructor.
-     */
-    public Entity() {
-    }
 
     /**
      * Gets the value of the field <code>name</code>.
@@ -306,7 +300,7 @@ public abstract class Entity extends IdentifiableEntity {
     public void setNonExclusionVerifiedInd(String nonExclusionVerifiedInd) {
         this.nonExclusionVerifiedInd = nonExclusionVerifiedInd;
     }
-    
+
     /**
      * Gets the value of the field <code>backgroundStudyId</code>.
      *

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class EntityStructureType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public EntityStructureType() {
-    }
-}
+public class EntityStructureType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -45,12 +45,6 @@ public class Event extends IdentifiableEntity {
      * Timestamp.
      */
     private Date createdOn;
-
-    /**
-     * Default empty constructor.
-     */
-    public Event() {
-    }
 
     /**
      * Get the Npi.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -36,13 +36,6 @@ public class ExternalAccountLink extends IdentifiableEntity {
      * The external user id.
      */
     private String externalUserId;
-
-    /**
-     * Empty constructor.
-     */
-    public ExternalAccountLink() {
-
-    }
 
     /**
      * Gets the value of the field <code>userId</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalProfileLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalProfileLink.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -37,13 +37,6 @@ public class ExternalProfileLink extends IdentifiableEntity {
      * The external user id.
      */
     private String externalProfileId;
-
-    /**
-     * Empty constructor.
-     */
-    public ExternalProfileLink() {
-
-    }
 
     /**
      * Gets the value of the field <code>profileId</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/HelpItem.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/HelpItem.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -49,12 +49,6 @@ public class HelpItem {
      */
     private String description;
 
-    /**
-     * Default empty constructor.
-     */
-    public HelpItem() {
-    }
-
     public long getId() {
         return id;
     }
@@ -62,7 +56,7 @@ public class HelpItem {
     public void setId(long id) {
         this.id = id;
     }
-    
+
     /**
      * Gets the value of the field <code>title</code>.
      * @return the title
@@ -95,5 +89,5 @@ public class HelpItem {
         this.description = description;
     }
 
-    
+
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/HelpSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/HelpSearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -28,12 +28,6 @@ public class HelpSearchCriteria extends SearchCriteria {
      * Term.
      */
     private String term;
-
-    /**
-     * Default empty constructor.
-     */
-    public HelpSearchCriteria() {
-    }
 
     /**
      * Gets the value of the field <code>term</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -29,12 +29,6 @@ public abstract class IdentifiableEntity implements Serializable {
      * The entity identifier.
      */
     private long id;
-
-    /**
-     * Default empty constructor.
-     */
-    protected IdentifiableEntity() {
-    }
 
     /**
      * Gets the value of the field <code>id</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class IssuingBoard extends LookupEntity {
-
-    /**
-     * Default empty constructor.
-     */
-    public IssuingBoard() {
-    }
-}
+public class IssuingBoard extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LegacySystemMapping.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LegacySystemMapping.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -29,27 +29,21 @@ public class LegacySystemMapping extends IdentifiableEntity implements Serializa
      * The external system name.
      */
     private String systemName;
-    
+
     /**
      * The code type.
      */
     private String codeType;
-    
+
     /**
      * The external code.
      */
     private String externalCode;
-    
+
     /**
      * The internal code.
      */
     private String internalCode;
-    
-    /**
-     * Empty constructor.
-     */
-    public LegacySystemMapping() {
-    }
 
     /**
      * Gets the value of the field <code>systemName</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class License extends IdentifiableEntity {
      * The owner ticket.
      */
     private long ticketId;
-    
+
     /**
      * The affiliate id if it belongs to a QP.
      */
@@ -95,12 +95,6 @@ public class License extends IdentifiableEntity {
      * Attachment id.
      */
     private long attachmentId;
-
-    /**
-     * Default empty constructor.
-     */
-    public License() {
-    }
 
     /**
      * Gets the value of the field <code>licenseNumber</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -29,12 +29,6 @@ public class LicenseStatus extends LookupEntity {
      * License status date.
      */
     private Date date;
-
-    /**
-     * Default empty constructor.
-     */
-    public LicenseStatus() {
-    }
 
     /**
      * Gets the value of the field <code>date</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -42,12 +42,6 @@ public class LookupEntity implements Serializable {
      */
     @Column(unique = true)
     private String description;
-
-    /**
-     * Empty constructor.
-     */
-    public LookupEntity() {
-    }
 
     /**
      * Gets the value of the field <code>code</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -27,12 +27,6 @@ public class MemberSearchCriteria extends SearchCriteria {
      * Practice NPI.
      */
     private String npi;
-
-    /**
-     * Empty constructor.
-     */
-    public MemberSearchCriteria() {
-    }
 
     /**
      * Gets the value of the field <code>npi</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -49,12 +49,6 @@ public class Note extends IdentifiableEntity {
      * Timestamp.
      */
     private Date createdOn;
-
-    /**
-     * Empty constructor.
-     */
-    public Note() {
-    }
 
     /**
      * Gets the value of the field <code>profileId</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -84,12 +84,6 @@ public class Organization extends Entity {
      * EFT Vendor number.
      */
     private String eftVendorNumber;
-
-    /**
-     * Empty constructor.
-     */
-    public Organization() {
-    }
 
     /**
      * Gets the value of the field <code>fein</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -32,12 +32,6 @@ public class OrganizationBeneficialOwner extends BeneficialOwner {
      * Entity employer number.
      */
     private String fein;
-
-    /**
-     * Empty constructor.
-     */
-    public OrganizationBeneficialOwner() {
-    }
 
     /**
      * Gets the value of the field <code>legalName</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class OwnershipType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public OwnershipType() {
-    }
-}
+public class OwnershipType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -49,20 +49,14 @@ public class PayToProvider extends IdentifiableEntity {
      * The target profile id.
      */
     private long targetProfileId;
-    
-    private String contactName;
-    
-    private String name;
-    
-    private String phone;
-    
-    private String npi;
 
-    /**
-     * Empty constructor.
-     */
-    public PayToProvider() {
-    }
+    private String contactName;
+
+    private String name;
+
+    private String phone;
+
+    private String npi;
 
     /**
      * Gets the value of the field <code>profileId</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class PayToProviderType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public PayToProviderType() {
-    }
-}
+public class PayToProviderType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Person.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Person.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -74,12 +74,6 @@ public class Person extends Entity {
      * The middle name.
      */
     private String middleName;
-
-    /**
-     * Empty constructor.
-     */
-    public Person() {
-    }
 
     /**
      * Gets the value of the field <code>ssn</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -59,12 +59,6 @@ public class PersonBeneficialOwner extends BeneficialOwner {
      * Relationship type.
      */
     private RelationshipType relationship;
-
-    /**
-     * Empty constructor.
-     */
-    public PersonBeneficialOwner() {
-    }
 
     /**
      * Gets the value of the field <code>firstName</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -57,12 +57,6 @@ public class PracticeSearchCriteria extends SearchCriteria {
      * Flag indicating this is a search for agencies.
      */
     private boolean agency;
-
-    /**
-     * Empty constructor.
-     */
-    public PracticeSearchCriteria() {
-    }
 
     /**
      * Gets the value of the field <code>name</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -101,12 +101,6 @@ public class ProviderSearchCriteria extends SearchCriteria {
      * Provider name filter.
      */
     private String providerName;
-
-    /**
-     * Default empty constructor.
-     */
-    public ProviderSearchCriteria() {
-    }
 
     /**
      * Gets the value of the field <code>enrollmentNumber</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -54,12 +54,6 @@ public class ProviderStatement extends IdentifiableEntity {
      * Statement date.
      */
     private Date date;
-
-    /**
-     * Default empty constructor.
-     */
-    public ProviderStatement() {
-    }
 
     /**
      * Gets the value of the field <code>name</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -28,12 +28,6 @@ public class ProviderTypeSearchCriteria extends SearchCriteria {
      * Type name.
      */
     private String typeName;
-
-    /**
-     * Default empty constructor.
-     */
-    public ProviderTypeSearchCriteria() {
-    }
 
     /**
      * Gets the value of the field <code>typeName</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSetting.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSetting.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -42,13 +42,6 @@ public class ProviderTypeSetting extends IdentifiableEntity {
      * The related entity code.
      */
     private String relatedEntityCode;
-
-    /**
-     * Empty constructor.
-     */
-    public ProviderTypeSetting() {
-
-    }
 
     /**
      * Gets the value of the field <code>providerTypeCode</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class QPType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public QPType() {
-    }
-}
+public class QPType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class RelationshipType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public RelationshipType() {
-    }
-}
+public class RelationshipType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RequiredField.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RequiredField.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -27,12 +27,6 @@ public class RequiredField extends LookupEntity {
      * The required field type.
      */
     private RequiredFieldType type;
-
-    /**
-     * Default empty constructor.
-     */
-    public RequiredField() {
-    }
 
     /**
      * Gets the value of the field <code>type</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RequiredFieldType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RequiredFieldType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author argolite, TCSASSEMBLER
  * @version 1.0
  */
-public class RequiredFieldType extends LookupEntity {
-
-    /**
-     * Default empty constructor.
-     */
-    public RequiredFieldType() {
-    }
-}
+public class RequiredFieldType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -39,12 +39,6 @@ public class ScreeningSchedule extends IdentifiableEntity {
      * Interval type.
      */
     private ScreeningIntervalType intervalType;
-
-    /**
-     * Default empty constructor.
-     */
-    public ScreeningSchedule() {
-    }
 
     /**
      * Gets the value of the field <code>upcomingScreeningDate</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -47,12 +47,6 @@ public abstract class SearchCriteria {
      * Show filter panel flag.
      */
     private boolean showFilterPanel;
-
-    /**
-     * Default empty constructor.
-     */
-    public SearchCriteria() {
-    }
 
     /**
      * Gets the value of the field <code>pageSize</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -45,12 +45,6 @@ public class SearchResult<T> {
      * Total results.
      */
     private int total;
-
-    /**
-     * Default empty constructor.
-     */
-    public SearchResult() {
-    }
 
     /**
      * Gets the value of the field <code>items</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceExtType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceExtType.java
@@ -5,7 +5,7 @@ package gov.medicaid.entities;
 
 /**
  * Represents the Assurance Statements lookup for Chemical Dependency Program.
- * 
+ *
  * @author cyberjag
  * @version 1.0
  */
@@ -17,14 +17,8 @@ public class ServiceAssuranceExtType extends LookupEntity {
     private String serviceAssuranceCode;
 
     /**
-     * Empty constructor.
-     */
-    public ServiceAssuranceExtType() {
-    }
-
-    /**
      * Gets the service assurance code.
-     * 
+     *
      * @return serviceAssuranceCode
      */
     public String getServiceAssuranceCode() {
@@ -33,7 +27,7 @@ public class ServiceAssuranceExtType extends LookupEntity {
 
     /**
      * Sets the service assurance code.
-     * 
+     *
      * @param serviceAssuranceCode
      *            serviceAssuranceCode
      */

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceAssuranceType.java
@@ -19,14 +19,8 @@ public class ServiceAssuranceType extends LookupEntity {
     private String patientInd;
 
     /**
-     * Empty constructor.
-     */
-    public ServiceAssuranceType() {
-    }
-
-    /**
      * Gets the patient indicator.
-     * 
+     *
      * @return the patientInd
      */
     public String getPatientInd() {
@@ -35,7 +29,7 @@ public class ServiceAssuranceType extends LookupEntity {
 
     /**
      * Sets the patient indicator.
-     * 
+     *
      * @param patientInd
      */
     public void setPatientInd(String patientInd) {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -21,11 +21,4 @@ package gov.medicaid.entities;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class ServiceCategory extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public ServiceCategory() {
-    }
-}
+public class ServiceCategory extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SpecialtyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SpecialtyType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -27,12 +27,6 @@ public class SpecialtyType extends LookupEntity {
      * Specialty subcategory.
      */
     private String subCategory;
-
-    /**
-     * Default empty constructor.
-     */
-    public SpecialtyType() {
-    }
 
     /**
      * Gets the value of the field <code>subCategory</code>.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -73,12 +73,6 @@ public class UserSearchCriteria extends SearchCriteria {
      * @since v1.2 - Medicaid Provider Screening Portal - System Admin Front End Assembly
      */
     private boolean searchBox;
-
-    /**
-     * Default empty constructor.
-     */
-    public UserSearchCriteria() {
-    }
 
     /**
      * Gets the value of the field <code>username</code>.


### PR DESCRIPTION
This patch just removes all the empty constructors from the java files in the /psm-app/services/src/main/java/gov/medicaid/entities directory.