### PR TITLE
Fix syntax error in seed.sql

### DIFF
--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -211,7 +211,7 @@ CREATE TABLE required_field_types(
 );
 INSERT INTO required_field_types (code, description) VALUES
   ('01', 'Required'),
-  ('02', 'Optional'),
+  ('02', 'Optional');
 
 CREATE TABLE risk_levels(
   code CHARACTER VARYING(2) PRIMARY KEY,


### PR DESCRIPTION
Convert a trailing comma to a terminating semicolon. Typo introduced in
0fd71089ac8e2195e77471d31f2d138e8b2e337b.