### PR TITLE
Hibernate-5-ify BinaryContent

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -73,7 +73,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import javax.annotation.Resource;
 import javax.ejb.Local;
@@ -1760,12 +1759,10 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @throws SerialException if content cannot be transformed to a blob
      */
     private String saveAttachmentContent(InputStream content) throws IOException, SerialException, SQLException {
-        String contentId = UUID.randomUUID().toString();
         BinaryContent binaryContent = new BinaryContent();
-        binaryContent.setContentId(contentId);
         binaryContent.setContent(new SerialBlob(IOUtils.toByteArray(content)));
         getEm().persist(binaryContent);
-        return contentId;
+        return binaryContent.getContentId();
     }
 
     /**

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -340,14 +340,6 @@
 			<column name="ISSUING_BOARD_CD" />
 		</many-to-one>
 	</class>
-	<class name="gov.medicaid.entities.BinaryContent" table="DOCUMENT_CONTENT">
-		<id column="CONTENT_ID" name="contentId" type="string">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="content" type="blob">
-			<column name="RAW_CONTENT" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.Document" table="CMS_ATTACHMENT">
 		<id column="ATTACHMENT_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -46,6 +46,7 @@
     <class>gov.medicaid.entities.AuditDetail</class>
     <class>gov.medicaid.entities.AuditRecord</class>
     <class>gov.medicaid.entities.Authentication</class>
+    <class>gov.medicaid.entities.BinaryContent</class>
     <class>gov.medicaid.entities.CMSUser</class>
     <class>gov.medicaid.entities.ContactInformation</class>
     <class>gov.medicaid.entities.Degree</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS
   agreement_documents,
   audit_details,
   audit_records,
+  binary_contents,
   cms_authentication,
   cms_user,
   contacts,
@@ -661,4 +662,9 @@ CREATE TABLE people(
   degree_code CHARACTER VARYING(2)
     REFERENCES degrees(code),
   degree_award_date DATE
+);
+
+CREATE TABLE binary_contents(
+  binary_content_id TEXT PRIMARY KEY,
+  content OID
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
@@ -22,12 +22,6 @@ public class BinaryContent {
 
     private String contentId;
 
-    /**
-     * Empty constructor.
-     */
-    public BinaryContent() {
-    }
-
     public Blob getContent() {
         return content;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
@@ -17,22 +17,9 @@ package gov.medicaid.entities;
 
 import java.sql.Blob;
 
-/**
- * Stores BLOB contents.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 public class BinaryContent {
-
-    /**
-     * The binary content.
-     */
     private Blob content;
 
-    /**
-     * The content id.
-     */
     private String contentId;
 
     /**
@@ -41,38 +28,18 @@ public class BinaryContent {
     public BinaryContent() {
     }
 
-    /**
-     * Gets the value of the field <code>content</code>.
-     *
-     * @return the content
-     */
     public Blob getContent() {
         return content;
     }
 
-    /**
-     * Sets the value of the field <code>content</code>.
-     *
-     * @param content the content to set
-     */
     public void setContent(Blob content) {
         this.content = content;
     }
 
-    /**
-     * Gets the value of the field <code>contentId</code>.
-     *
-     * @return the contentId
-     */
     public String getContentId() {
         return contentId;
     }
 
-    /**
-     * Sets the value of the field <code>contentId</code>.
-     *
-     * @param contentId the contentId to set
-     */
     public void setContentId(String contentId) {
         this.contentId = contentId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
@@ -15,12 +15,26 @@
  */
 package gov.medicaid.entities;
 
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 import java.sql.Blob;
 
+@javax.persistence.Entity
+@Table(name = "binary_contents")
 public class BinaryContent {
-    private Blob content;
-
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @Column(name = "binary_content_id")
     private String contentId;
+
+    @Lob
+    private Blob content;
 
     public Blob getContent() {
         return content;


### PR DESCRIPTION
Remove redundant comments, empty constructor, and trailing whitespace; rename the table to reflect the class name, pluralize it, rename the columns, and tell Hibernate to generate UUIDs instead of doing it ourselves.

This class stores files, and Hibernate with PostgreSQL handles that with OIDs: https://www.postgresql.org/docs/current/static/largeobjects.html .

I was able to verify an uploaded file in a psql session by

```sql
SELECT binary_content_id, lo_get(content, 0, 3) FROM binary_contents
```

to select the first three bytes as hex, and compare with

```ShellSession
xxd uploaded_file | head
```

from the command line.

Issue #36 Use Hibernate 5, instead of 4