### PR TITLE
Fix lazy initialization bug with agreement docs

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -16,6 +16,7 @@
 package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.model.ApplicantType;
+import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.entities.AgreementDocument;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.EntityStructureType;
@@ -93,7 +94,9 @@ public class LookupServiceBean implements LookupService {
     }
 
     @Override
-    public ProviderType getProviderTypeWithLicenseTypesByDescription(String providerTypeDescription) {
+    public ProviderType getProviderTypeWithLicenseTypes(
+            ProviderInformationType providerInformationType
+    ) {
         EntityGraph graph = em.getEntityGraph(
                 "ProviderType with LicenseTypes"
         );
@@ -101,7 +104,7 @@ public class LookupServiceBean implements LookupService {
                 "FROM ProviderType WHERE description = :description",
                 ProviderType.class
         ).setParameter(
-                "description", providerTypeDescription
+                "description", providerInformationType.getProviderType()
         ).setHint(
                 "javax.persistence.loadgraph", graph
         ).getSingleResult();

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -94,12 +94,30 @@ public class LookupServiceBean implements LookupService {
     }
 
     @Override
+    public ProviderType getProviderTypeWithAgreementDocuments(
+            ProviderInformationType providerInformationType
+    ) {
+        return getProviderTypeWithNamedEntityGraph(
+                providerInformationType,
+                "ProviderType with AgreementDocuments"
+        );
+    }
+
+    @Override
     public ProviderType getProviderTypeWithLicenseTypes(
             ProviderInformationType providerInformationType
     ) {
-        EntityGraph graph = em.getEntityGraph(
+        return getProviderTypeWithNamedEntityGraph(
+                providerInformationType,
                 "ProviderType with LicenseTypes"
         );
+    }
+
+    private ProviderType getProviderTypeWithNamedEntityGraph(
+            ProviderInformationType providerInformationType,
+            String entityGraphName
+    ) {
+        EntityGraph graph = em.getEntityGraph(entityGraphName);
         return em.createQuery(
                 "FROM ProviderType WHERE description = :description",
                 ProviderType.class

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
@@ -202,7 +202,7 @@ public class FacilityLicenseFormBinder extends BaseFormBinder {
 
         attr(mv, "categorySize", services.size());
 
-        ProviderType pt = getLookupService().getProviderTypeWithLicenseTypesByDescription(provider.getProviderType());
+        ProviderType pt = getLookupService().getProviderTypeWithLicenseTypes(provider);
 
         if (!readOnly) {
             attr(mv, "licenseTypes", pt.getLicenseTypes());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -162,11 +162,13 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
     public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
+        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+        List<AgreementDocument> docs = pt.getAgreementDocuments();
+
         // for renewal the form should be blank
         if (enrollment.getRequestType() == RequestType.RENEWAL && provider.getRenewalShowBlankStatement() == null) {
             attr(mv, "renewalBlankInit", "Y");
-            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-            List<AgreementDocument> docs = pt.getAgreementDocuments();
+
             int i = 0;
             for (AgreementDocument doc : docs) {
                 attr(mv, "documentId", i, "" + doc.getId());
@@ -189,8 +191,6 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
             AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
 
-            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-            List<AgreementDocument> docs = pt.getAgreementDocuments();
             int i = 0;
             for (AgreementDocument doc : docs) {
                 attr(mv, "documentId", i, "" + doc.getId());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -116,7 +116,9 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
             exceptions.add(e);
         }
 
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        );
         List<AgreementDocument> docs = pt.getAgreementDocuments();
 
         List<ProviderAgreementType> xList = new ArrayList<ProviderAgreementType>();
@@ -162,7 +164,9 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
     public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        );
         List<AgreementDocument> docs = pt.getAgreementDocuments();
 
         // for renewal the form should be blank
@@ -288,7 +292,9 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
         List<AcceptedAgreements> hList = profile.getAgreements();
 
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        );
         List<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
@@ -394,7 +400,9 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         provider.setHasCivilPenalty(profile.getCivilPenaltyInd());
         provider.setHasPreviousExclusion(profile.getPreviousExclusionInd());
 
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        );
         List<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -94,9 +94,9 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
     /**
      * Binds the request to the model.
-     * @param enrollment the model to bind to
-     * @param request the request containing the form fields
      *
+     * @param enrollment the model to bind to
+     * @param request    the request containing the form fields
      * @throws BinderException if the format of the fields could not be bound properly
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
@@ -148,23 +148,24 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
             providerAgreement.clear();
             providerAgreement.addAll(xList);
         }
-        
+
         return exceptions;
     }
 
     /**
      * Binds the model to the request attributes.
+     *
      * @param enrollment the model to bind from
-     * @param mv the model and view to bind to
-     * @param readOnly true if the view is read only
+     * @param mv         the model and view to bind to
+     * @param readOnly   true if the view is read only
      */
     public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         // for renewal the form should be blank
         if (enrollment.getRequestType() == RequestType.RENEWAL && provider.getRenewalShowBlankStatement() == null) {
-        	attr(mv, "renewalBlankInit", "Y");
-        	ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+            attr(mv, "renewalBlankInit", "Y");
+            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
             List<AgreementDocument> docs = pt.getAgreementDocuments();
             int i = 0;
             for (AgreementDocument doc : docs) {
@@ -177,55 +178,55 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
             attr(mv, "requiredAgreementsSize", docs.size());
         } else {
-	        attr(mv, "criminalConvictionInd", provider.getHasCriminalConviction());
-	        attr(mv, "civilPenaltyInd", provider.getHasCivilPenalty());
-	        attr(mv, "previousExclusionInd", provider.getHasPreviousExclusion());
-	
-	        ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
-	        attr(mv, "name", statement.getName());
-	        attr(mv, "title", statement.getTitle());
-	        attr(mv, "date", statement.getSignDate());
-	
-	        AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
-	
-	        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-	        List<AgreementDocument> docs = pt.getAgreementDocuments();
-	        int i = 0;
-	        for (AgreementDocument doc : docs) {
-	            attr(mv, "documentId", i, "" + doc.getId());
-	            attr(mv, "documentName", i, doc.getTitle());
-	
-	            boolean agreed = false;
-	            boolean updatedVersion = false;
-	
-	            if (acceptedAgreements != null) {
-	                List<ProviderAgreementType> agreements = acceptedAgreements.getProviderAgreement();
-	                for (ProviderAgreementType agreement : agreements) {
-	                    if (doc.getType().equals(agreement.getAgreementDocumentType())) {
-	                        if (String.valueOf(doc.getVersion()).equals(agreement.getAgreementDocumentVersion())) {
-	                            agreed = true;
-	                        } else {
-	                            updatedVersion = true;
-	                        }
-	                        break;
-	                    }
-	                }
-	            }
-	
-	            attr(mv, "accepted", i, agreed ? "Y" : "N");
-	            attr(mv, "updatedVersion", i, updatedVersion ? "Y" : "N");
-	            i++;
-	        }
-	
-	        attr(mv, "requiredAgreementsSize", docs.size());
+            attr(mv, "criminalConvictionInd", provider.getHasCriminalConviction());
+            attr(mv, "civilPenaltyInd", provider.getHasCivilPenalty());
+            attr(mv, "previousExclusionInd", provider.getHasPreviousExclusion());
+
+            ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
+            attr(mv, "name", statement.getName());
+            attr(mv, "title", statement.getTitle());
+            attr(mv, "date", statement.getSignDate());
+
+            AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
+
+            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+            List<AgreementDocument> docs = pt.getAgreementDocuments();
+            int i = 0;
+            for (AgreementDocument doc : docs) {
+                attr(mv, "documentId", i, "" + doc.getId());
+                attr(mv, "documentName", i, doc.getTitle());
+
+                boolean agreed = false;
+                boolean updatedVersion = false;
+
+                if (acceptedAgreements != null) {
+                    List<ProviderAgreementType> agreements = acceptedAgreements.getProviderAgreement();
+                    for (ProviderAgreementType agreement : agreements) {
+                        if (doc.getType().equals(agreement.getAgreementDocumentType())) {
+                            if (String.valueOf(doc.getVersion()).equals(agreement.getAgreementDocumentVersion())) {
+                                agreed = true;
+                            } else {
+                                updatedVersion = true;
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                attr(mv, "accepted", i, agreed ? "Y" : "N");
+                attr(mv, "updatedVersion", i, updatedVersion ? "Y" : "N");
+                i++;
+            }
+
+            attr(mv, "requiredAgreementsSize", docs.size());
         }
     }
 
     /**
      * Captures the error messages related to the form.
-     * @param enrollment the enrollment that was validated
-     * @param messages the messages to select from
      *
+     * @param enrollment the enrollment that was validated
+     * @param messages   the messages to select from
      * @return the list of errors related to the form
      */
     protected List<FormError> selectErrors(EnrollmentType enrollment, StatusMessagesType messages) {
@@ -275,7 +276,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
      * Binds the fields of the form to the persistence model.
      *
      * @param enrollment the front end model
-     * @param ticket the persistent model
+     * @param ticket     the persistent model
      */
     public void bindToHibernate(EnrollmentType enrollment, Enrollment ticket) {
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
@@ -329,6 +330,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
     /**
      * Maps the given list by id.
+     *
      * @param list the list to be mapped
      * @return the lookup map
      */
@@ -342,6 +344,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
     /**
      * Maps the given list by id.
+     *
      * @param list the list to be mapped
      * @return the lookup map
      */
@@ -357,12 +360,13 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
     /**
      * Filters the inactive agreements from the given list.
-     * @param accepted the current agreements
+     *
+     * @param accepted    the current agreements
      * @param documentMap the active agreements
      * @return the inactive agreements
      */
     private List<AcceptedAgreements> filterOnlyInactive(List<AcceptedAgreements> accepted,
-        Map<String, AgreementDocument> documentMap) {
+                                                        Map<String, AgreementDocument> documentMap) {
         List<AcceptedAgreements> inactiveList = new ArrayList<AcceptedAgreements>();
         if (accepted != null) {
             for (AcceptedAgreements agreement : accepted) {
@@ -379,7 +383,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
     /**
      * Binds the fields of the persistence model to the front end xml.
      *
-     * @param ticket the persistent model
+     * @param ticket     the persistent model
      * @param enrollment the front end model
      */
     public void bindFromHibernate(Enrollment ticket, EnrollmentType enrollment) {
@@ -424,31 +428,31 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
             xStatement.setSignDate(BinderUtils.toCalendar(hStatement.getDate()));
         }
     }
-    
+
     @Override
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model)
-        throws DocumentException {
-        
+            throws DocumentException {
+
         // Provider Statement Section
-        PdfPTable disclosureInfo = new PdfPTable(new float[] {7, 1});
+        PdfPTable disclosureInfo = new PdfPTable(new float[]{7, 1});
         PDFHelper.setTableAsFullPage(disclosureInfo);
 
         String ns = NAMESPACE;
 
         if ("Y".equals(PDFHelper.value(model, ns, "bound"))) {
             PDFHelper.addLabelValueCell(disclosureInfo, "Have you ever been convicted of a criminal offense related to "
-                + "involvement in any program underMedicare, Medicaid, Title XX, or Title XXI in "
-                + "Minnesota or any other state or jurisdiction since the inception of these programs?",
-                PDFHelper.formatBoolean(PDFHelper.value(model, ns, "criminalConvictionInd")));
+                            + "involvement in any program underMedicare, Medicaid, Title XX, or Title XXI in "
+                            + "Minnesota or any other state or jurisdiction since the inception of these programs?",
+                    PDFHelper.formatBoolean(PDFHelper.value(model, ns, "criminalConvictionInd")));
 
             PDFHelper.addLabelValueCell(disclosureInfo, "Have you had civil money penalties or assessments "
-                + "imposed under section 1128A of the Social Security Act?",
-                PDFHelper.formatBoolean(PDFHelper.value(model, ns, "civilPenaltyInd")));
+                            + "imposed under section 1128A of the Social Security Act?",
+                    PDFHelper.formatBoolean(PDFHelper.value(model, ns, "civilPenaltyInd")));
 
             PDFHelper.addLabelValueCell(disclosureInfo,
-                "Have you ever been excluded or terminated from participation in Medicare,  Medicaid, "
-                    + "Children's Health Insurance Program (CHIP), or the Title XXI services program in Minnesota "
-                    + "or any other state since the inception of these programs?",
+                    "Have you ever been excluded or terminated from participation in Medicare,  Medicaid, "
+                            + "Children's Health Insurance Program (CHIP), or the Title XXI services program in Minnesota "
+                            + "or any other state since the inception of these programs?",
                     PDFHelper.formatBoolean(PDFHelper.value(model, ns, "previousExclusionInd")));
 
             disclosureInfo.setSpacingAfter(20);
@@ -458,13 +462,13 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
             PDFHelper.setTableAsFullPage(statementInfo);
 
             PDFHelper.addCell(statementInfo,
-                "I certify that the information provided on this form is accurate, complete and truthful. I will "
-                    + "notify MHCP Provider Enrollment of any changes to this information. I acknowledge that any "
-                    + "misrepresentations in the information submitted to MHCP, including false claims,  statements, "
-                    + "documents, or concealment of a material fact, may be cause for denial or termination "
-                    + "of participation as a Medicaid provider.");
+                    "I certify that the information provided on this form is accurate, complete and truthful. I will "
+                            + "notify MHCP Provider Enrollment of any changes to this information. I acknowledge that any "
+                            + "misrepresentations in the information submitted to MHCP, including false claims,  statements, "
+                            + "documents, or concealment of a material fact, may be cause for denial or termination "
+                            + "of participation as a Medicaid provider.");
 
-            PdfPTable nameTable = new PdfPTable(new float[] {1, 1, 4});
+            PdfPTable nameTable = new PdfPTable(new float[]{1, 1, 4});
             PDFHelper.setTableAsFullPage(nameTable);
             PDFHelper.addLabelValueCell(nameTable, "Provider Name", PDFHelper.value(model, ns, "name"));
             PDFHelper.addLabelValueCell(nameTable, "Provider Title", PDFHelper.value(model, ns, "title"));

--- a/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
@@ -171,7 +171,7 @@ public class LicenseInformationFormBinder extends BaseFormBinder {
             attr(mv, "attachmentSize", i);
         }
 
-        ProviderType pt = getLookupService().getProviderTypeWithLicenseTypesByDescription(provider.getProviderType());
+        ProviderType pt = getLookupService().getProviderTypeWithLicenseTypes(provider);
 
         if (!readOnly) {
             attr(mv, "licenseTypes", pt.getLicenseTypes());

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -16,6 +16,7 @@
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.ApplicantType;
+import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.LookupEntity;
 import gov.medicaid.entities.ProviderType;
@@ -50,10 +51,11 @@ public interface LookupService {
      * Finds a ProviderType by its description, and eager-load
      * its related LicenseTypes.
      *
-     * @param providerTypeDescription The name of the provider type.
+     * @param providerInformationType The XML-backed provider type to look up in
+     *                                the database.
      * @return The ProviderType, with its licenseTypes field fully initialized.
      */
-    ProviderType getProviderTypeWithLicenseTypesByDescription(String providerTypeDescription);
+    ProviderType getProviderTypeWithLicenseTypes(ProviderInformationType providerInformationType);
 
     /**
      * Retrieves the lookup with the given description.

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -46,6 +46,16 @@ public interface LookupService {
      */
     public List<ProviderType> getProviderTypes(ApplicantType applicantType);
 
+    /**
+     * Finds a ProviderType by its description, and eager-load
+     * its related AgreementDocuments.
+     *
+     * @param providerInformationType The XML-backed provider type to look up in
+     *                                the database.
+     * @return The ProviderType, with its agreementDocuments field fully
+     * initialized.
+     */
+    ProviderType getProviderTypeWithAgreementDocuments(ProviderInformationType providerInformationType);
 
     /**
      * Finds a ProviderType by its description, and eager-load


### PR DESCRIPTION
When I extracted the ProviderType-AgreementDocument link in #86, there were sections of code that I could not execute because they were blocked by the incomplete Hibernate migration. Now that more functionality is working, some of those problems can start to be fixed.

In this case, we need to look up a ProviderType from a ProviderInformationType, and we need the AgreementDocuments to be loaded. Clean up ([whitespace-mostly change](https://github.com/OpenTechStrategies/psm/commit/50e4391dbb666ca546438348d62161aa0c5f4f3b?w=1)) and refactor, then introduce a new method to look up a ProviderType by its description and prefetch the associated AgreementDocuments.

Issue #36 Use Hibernate 5, instead of 4