### PR TITLE
Allow LookupEntity subclasses to reuse ids

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
@@ -17,8 +17,7 @@ package gov.medicaid.entities;
 
 import javax.persistence.Column;
 import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
+import javax.persistence.MappedSuperclass;
 import java.io.Serializable;
 
 /**
@@ -27,8 +26,7 @@ import java.io.Serializable;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-@javax.persistence.Entity
-@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@MappedSuperclass
 public class LookupEntity implements Serializable {
 
     /**


### PR DESCRIPTION
When I marked `LookupEntity` as an `@Entity` (with the table-per-class inheritance strategy), I told Hibernate that all of its subclasses would have distinct IDs (in this case, the `code` field/column). Hibernate used that information to cache instances it's seen. Unfortunately, that's not how the data is set up, and it's not how the model is set up!

As we (and in particular, @BenGalewsky) converted more of the LookupEntity derivatives over and included more of the seed data, we eventually triggered this problem, which shows up as a stack trace in the server log like:

> Caused by: javax.ejb.EJBTransactionRolledbackException: org.hibernate.WrongClassException: Object [id=01] was not of the specified subclass [gov.medicaid.entities.ProviderType] : loaded object was of wrong class class gov.medicaid.entities.EntityStructureType

In this case, one of the `ProviderType`s shared code '01' with one of the `EntityStructureType`s. Hibernate said "oh, I know what a LookupEntity with code='01' is, here you go" and then got confused because it was a different subclass.

The fix is to not mark `LookupEntity` as an `@Entity`, but instead to mark it as a `@MappedSuperclass`.

For more information, see: https://en.wikibooks.org/wiki/Java_Persistence/Inheritance#Mapped_Superclasses

Issue #36 Use Hibernate 5, instead of 4