### PR TITLE
Hibernate-5-ify Document (formerly cms_attachment)

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -675,7 +675,6 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      */
     public long uploadAttachment(CMSUser user, Document attachment) throws PortalServiceException {
         if (attachment.getId() <= 0) {
-            attachment.setId(getSequence().getNextValue(Sequences.ATTACHMENT_SEQ));
             attachment.setCreatedOn(Calendar.getInstance().getTime());
             attachment.setCreatedBy(user.getUserId());
         }
@@ -1160,11 +1159,14 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             if (attachment.getId() > 0) {
                 // regenerate attachment id when cloning, but keep reference so we can
                 // fix non-mapped references
-                long generated = getSequence().getNextValue(Sequences.ATTACHMENT_SEQ);
-                mapping.put(attachment.getId(), generated);
-                attachment.setId(generated);
+                long oldAttachmentId = attachment.getId();
+                getEm().detach(attachment);
+                attachment.setId(0);
+                long newAttachmentId = uploadAttachment(attachment);
+                mapping.put(oldAttachmentId, newAttachmentId);
+            } else {
+                uploadAttachment(attachment);
             }
-            uploadAttachment(attachment);
         }
 
         return mapping;

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -340,31 +340,6 @@
 			<column name="ISSUING_BOARD_CD" />
 		</many-to-one>
 	</class>
-	<class name="gov.medicaid.entities.Document" table="CMS_ATTACHMENT">
-		<id column="ATTACHMENT_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKET_ID" />
-		</property>
-		<property column="TYPE" generated="never" lazy="false"
-			length="45" name="type" type="string" />
-		<property column="FILE_NAME" generated="never" lazy="false"
-			length="45" name="filename" type="string" />
-		<property column="DESCRIPTION" generated="never" lazy="false"
-			length="45" name="description" type="string" />
-		<property column="CONTENT_ID" generated="never" lazy="false"
-			name="contentId" type="string" />
-		<property column="CREATED_BY" generated="never" lazy="false"
-			length="45" name="createdBy" type="string" />
-		<property column="CREATE_TS" generated="never" lazy="false"
-			name="createdOn" type="timestamp" />
-	</class>
 	<class name="gov.medicaid.entities.AcceptedAgreements" table="PROVIDER_AGREEMENT_XREF">
 		<id column="PROVIDER_AGREEMENT_XREF_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -50,6 +50,7 @@
     <class>gov.medicaid.entities.CMSUser</class>
     <class>gov.medicaid.entities.ContactInformation</class>
     <class>gov.medicaid.entities.Degree</class>
+    <class>gov.medicaid.entities.Document</class>
     <class>gov.medicaid.entities.Enrollment</class>
     <class>gov.medicaid.entities.EnrollmentStatus</class>
     <class>gov.medicaid.entities.Entity</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -11,6 +11,7 @@ DROP TABLE IF EXISTS
   cms_user,
   contacts,
   degrees,
+  documents,
   enrollment_statuses,
   enrollments,
   entities,
@@ -667,4 +668,15 @@ CREATE TABLE people(
 CREATE TABLE binary_contents(
   binary_content_id TEXT PRIMARY KEY,
   content OID
+);
+CREATE TABLE documents(
+  document_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  "type" TEXT,
+  filename TEXT,
+  description TEXT,
+  binary_content_id TEXT,
+  created_by TEXT,
+  created_at TIMESTAMP WITH TIME ZONE
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
@@ -20,55 +20,24 @@ import java.util.Date;
 
 /**
  * Represents an attachment.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class Document extends IdentifiableEntity implements Cloneable {
-
-    /**
-     * The profile id.
-     */
     private long profileId;
 
-    /**
-     * The ticket id.
-     */
     private long ticketId;
 
-    /**
-     * The document type.
-     */
     private String type;
 
-    /**
-     * The document name.
-     */
     private String filename;
 
-    /**
-     * The document description.
-     */
     private String description;
 
-    /**
-     * The document content id.
-     */
     private String contentId;
 
-    /**
-     * The document stream.
-     */
     private InputStream stream;
 
-    /**
-     * Creator.
-     */
     private String createdBy;
 
-    /**
-     * Timestamp.
-     */
     private Date createdOn;
 
     /**
@@ -77,164 +46,74 @@ public class Document extends IdentifiableEntity implements Cloneable {
     public Document() {
     }
 
-    /**
-     * Gets the value of the field <code>type</code>.
-     *
-     * @return the type
-     */
     public String getType() {
         return type;
     }
 
-    /**
-     * Sets the value of the field <code>type</code>.
-     *
-     * @param type the type to set
-     */
     public void setType(String type) {
         this.type = type;
     }
 
-    /**
-     * Gets the value of the field <code>filename</code>.
-     *
-     * @return the filename
-     */
     public String getFilename() {
         return filename;
     }
 
-    /**
-     * Sets the value of the field <code>filename</code>.
-     *
-     * @param filename the filename to set
-     */
     public void setFilename(String filename) {
         this.filename = filename;
     }
 
-    /**
-     * Gets the value of the field <code>description</code>.
-     *
-     * @return the description
-     */
     public String getDescription() {
         return description;
     }
 
-    /**
-     * Sets the value of the field <code>description</code>.
-     *
-     * @param description the description to set
-     */
     public void setDescription(String description) {
         this.description = description;
     }
 
-    /**
-     * Gets the value of the field <code>createdBy</code>.
-     *
-     * @return the createdBy
-     */
     public String getCreatedBy() {
         return createdBy;
     }
 
-    /**
-     * Sets the value of the field <code>createdBy</code>.
-     *
-     * @param createdBy the createdBy to set
-     */
     public void setCreatedBy(String createdBy) {
         this.createdBy = createdBy;
     }
 
-    /**
-     * Gets the value of the field <code>createdOn</code>.
-     *
-     * @return the createdOn
-     */
     public Date getCreatedOn() {
         return createdOn;
     }
 
-    /**
-     * Sets the value of the field <code>createdOn</code>.
-     *
-     * @param createdOn the createdOn to set
-     */
     public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>contentId</code>.
-     *
-     * @return the contentId
-     */
     public String getContentId() {
         return contentId;
     }
 
-    /**
-     * Sets the value of the field <code>contentId</code>.
-     *
-     * @param contentId the contentId to set
-     */
     public void setContentId(String contentId) {
         this.contentId = contentId;
     }
 
-    /**
-     * Gets the value of the field <code>stream</code>.
-     *
-     * @return the stream
-     */
     public InputStream getStream() {
         return stream;
     }
 
-    /**
-     * Sets the value of the field <code>stream</code>.
-     *
-     * @param stream the stream to set
-     */
     public void setStream(InputStream stream) {
         this.stream = stream;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
@@ -15,15 +15,31 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.Date;
 
 /**
  * Represents an attachment.
  */
-public class Document extends IdentifiableEntity implements Cloneable {
+@javax.persistence.Entity
+@Table(name = "documents")
+public class Document implements Cloneable, Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "document_id")
+    private long id;
+
+    @Column(name = "profile_id")
     private long profileId;
 
+    @Column(name = "ticket_id")
     private long ticketId;
 
     private String type;
@@ -32,13 +48,25 @@ public class Document extends IdentifiableEntity implements Cloneable {
 
     private String description;
 
+    @Column(name = "binary_content_id")
     private String contentId;
 
+    @Transient
     private InputStream stream;
 
+    @Column(name = "created_by")
     private String createdBy;
 
+    @Column(name = "created_at")
     private Date createdOn;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getType() {
         return type;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
@@ -40,12 +40,6 @@ public class Document extends IdentifiableEntity implements Cloneable {
 
     private Date createdOn;
 
-    /**
-     * Empty constructor.
-     */
-    public Document() {
-    }
-
     public String getType() {
         return type;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -23,11 +23,6 @@ package gov.medicaid.services.util;
  */
 public class Sequences {
     /**
-     * Used for attachments table.
-     */
-    public static final String ATTACHMENT_SEQ = "ATTACHMENT_SEQ";
-
-    /**
      * Used for provider group association table.
      */
     public static final String PROV_GRP_SEQ = "PROV_GRP_SEQ";


### PR DESCRIPTION
Remove redundant comments, empty constructor, and trailing whitespace (I should just make a text snippet for this...); rename the table to reflect the name of the class, pluralize the table name, and use Hibernate to generate IDs.

Issue #36 Use Hibernate 5, instead of 4