### PR TITLE
Auto-generate Entity ID

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1271,7 +1271,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             insertAddress(org.getTen99Address());
         }
 
-        entity.setId(getSequence().getNextValue(Sequences.ENTITY_SEQ));
+        entity.setId(0);
         getEm().persist(entity);
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -38,11 +38,6 @@ public class Sequences {
     public static final String LICENSE_SEQ = "LICENSE_SEQ";
 
     /**
-     * Used for entities table.
-     */
-    public static final String ENTITY_SEQ = "ENTITY_SEQ";
-
-    /**
      * Used for designated contacts table.
      */
     public static final String DESIGNATED_CONTACT_SEQ = "DESIGNATED_CONTACT_SEQ";


### PR DESCRIPTION
Use Hibernate to automatically generate Entity/Person/Organization IDs, and remove the Sequences enum value.

Follow-up to 322664d4192e238d6960a62ab7022126a350086f.

Issue #36 Use Hibernate 5, instead of 4