### PR TITLE
Convert Remaining subclasses of LookupEntity to H5

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -132,80 +132,6 @@
 			<column name="STATUS" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.BeneficialOwnerType" table="LU_BEN_OWNER_TYP">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="ownerType"
-			type="string">
-			<column length="1" name="OWNER_TYPE" />
-		</property>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.EntityStructureType" table="LU_CORP_STRUCTURE_TYP">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.RelationshipType" table="LU_RELATIONSHIP_TYP">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.QPType" table="LU_QP_TYP">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.ServiceCategory" table="LU_SVC_CAT">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.CategoryOfService" table="LU_COS">
-		<id name="code" type="string">
-			<column length="3" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.OwnershipType" table="LU_OWNERSHIP_TYP">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.SpecialtyType" table="LU_SPECIALTY_TYPE">
 		<id name="code" type="string">
 			<column length="2" name="CODE" />
@@ -218,46 +144,6 @@
 		<property generated="never" lazy="false" length="2" name="subCategory"
 			type="string">
 			<column name="SUB_CAT_CD" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.CountyType" table="LU_COUNTY">
-		<id name="code" type="string">
-			<column length="3" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.LicenseStatus" table="LU_LICENSE_STATUS">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.IssuingBoard" table="LU_ISSUING_BOARD">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-	</class>
-	<class name="gov.medicaid.entities.PayToProviderType" table="LU_PAYTO_TYPE">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
 		</property>
 	</class>
 	<class name="gov.medicaid.entities.DesignatedContact" table="DESIGNATED_CONTACT">
@@ -696,20 +582,6 @@
 			length="50" name="createdBy" type="string" />
 		<property column="CREATE_TS" generated="never" lazy="false"
 			name="createdOn" type="timestamp" />
-	</class>
-	<class name="gov.medicaid.entities.RequiredField" table="REQUIRED_FLD">
-		<id name="code" type="string">
-			<column length="2" name="CODE" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" length="200" name="description"
-			type="string">
-			<column name="DESCRIPTION" />
-		</property>
-		<many-to-one cascade="all" class="gov.medicaid.entities.RequiredField"
-			name="type">
-			<column name="REQUIRED_FLD_TYPE_ID" />
-		</many-to-one>
 	</class>
 	<class name="gov.medicaid.entities.ScreeningSchedule" table="SCREENING_SCHEDULE">
 		<id column="SCREENING_SCHEDULE_ID" name="id" type="long">

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -47,25 +47,42 @@
     <class>gov.medicaid.entities.AuditRecord</class>
     <class>gov.medicaid.entities.Authentication</class>
     <class>gov.medicaid.entities.BinaryContent</class>
+    <class>gov.medicaid.entities.BeneficialOwnerType</class>
+    <class>gov.medicaid.entities.CategoryOfService</class>
+    <class>gov.medicaid.entities.BeneficialOwnerType</class>
+    <class>gov.medicaid.entities.CategoryOfService</class>
     <class>gov.medicaid.entities.CMSUser</class>
     <class>gov.medicaid.entities.ContactInformation</class>
     <class>gov.medicaid.entities.Degree</class>
+    <class>gov.medicaid.entities.CountyType</class>
     <class>gov.medicaid.entities.Enrollment</class>
     <class>gov.medicaid.entities.EnrollmentStatus</class>
     <class>gov.medicaid.entities.Entity</class>
+    <class>gov.medicaid.entities.EntityStructureType</class>
     <class>gov.medicaid.entities.HelpItem</class>
+    <class>gov.medicaid.entities.IssuingBoard</class>
     <class>gov.medicaid.entities.LicenseType</class>
     <class>gov.medicaid.entities.Organization</class>
     <class>gov.medicaid.entities.Person</class>
+    <class>gov.medicaid.entities.LicenseStatus</class>
+    <class>gov.medicaid.entities.OwnershipType</class>
+    <class>gov.medicaid.entities.PayToProviderType</class>
+    <class>gov.medicaid.entities.LicenseStatus</class>
+    <class>gov.medicaid.entities.OwnershipType</class>
+    <class>gov.medicaid.entities.PayToProviderType</class>
     <class>gov.medicaid.entities.ProfileStatus</class>
     <class>gov.medicaid.entities.ProviderProfile</class>
     <class>gov.medicaid.entities.ProviderType</class>
+    <class>gov.medicaid.entities.QPType</class>
+    <class>gov.medicaid.entities.RelationshipType</class>
     <class>gov.medicaid.entities.RequestType</class>
+    <class>gov.medicaid.entities.RequiredField</class>
     <class>gov.medicaid.entities.RequiredFieldType</class>
     <class>gov.medicaid.entities.RiskLevel</class>
     <class>gov.medicaid.entities.Role</class>
     <class>gov.medicaid.entities.ServiceAssuranceExtType</class>
     <class>gov.medicaid.entities.ServiceAssuranceType</class>
+    <class>gov.medicaid.entities.ServiceCategory</class>
     <class>gov.medicaid.entities.StateType</class>
 
     <properties>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -2,29 +2,41 @@ DROP SEQUENCE IF EXISTS
   hibernate_sequence
 CASCADE;
 DROP TABLE IF EXISTS
+  beneficial_owner_types,
   addresses,
   agreement_documents,
   audit_details,
   audit_records,
   binary_contents,
+  categories_of_service,
   cms_authentication,
   cms_user,
   contacts,
   degrees,
+  counties,
   enrollment_statuses,
   enrollments,
   entities,
+  entity_structure_types,
   help_items,
+  issuing_boards,
   license_types,
   organizations,
   people,
+  license_statuses,
+  ownership_types,
+  payto_types,
+  ownership_types,
   persistent_logins,
   profile_statuses,
   provider_profiles,
   provider_type_agreement_documents,
   provider_type_license_types,
   provider_types,
+  qp_types,
+  relationship_types,
   request_types,
+  required_fields,
   required_field_types,
   risk_levels,
   roles,
@@ -115,6 +127,17 @@ CREATE TABLE help_items(
   title TEXT,
   description TEXT
 );
+
+CREATE TABLE qp_types(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO qp_types(code, description) VALUES
+('01', 'Registered Nurse'),
+('02', 'Licensed Social Worker'),
+('03', 'Mental Health Professional'),
+('04', 'Qualified Developmental Disability Specialist');
+
 
 CREATE TABLE provider_types(
   code CHARACTER VARYING(2) PRIMARY KEY,
@@ -210,6 +233,7 @@ INSERT INTO profile_statuses (code, description) VALUES
   ('02', 'Suspended'),
   ('03', 'Expired');
 
+
 CREATE TABLE required_field_types(
   code CHARACTER VARYING(2) PRIMARY KEY,
   description TEXT UNIQUE
@@ -217,6 +241,239 @@ CREATE TABLE required_field_types(
 INSERT INTO required_field_types (code, description) VALUES
   ('01', 'Required'),
   ('02', 'Optional');
+
+CREATE TABLE required_fields(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE,
+  required_field_type_code CHARACTER VARYING(2) REFERENCES  required_field_types(code)
+);
+
+CREATE TABLE entity_structure_types(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO entity_structure_types (code, description) VALUES
+ ('01', 'Sole Proprietorship'),
+ ('02', 'Partnership'),
+ ('03', 'Corporation'),
+ ('04', 'Non-Profit'),
+ ('05', 'Hospital Based'),
+ ('06', 'State'),
+ ('07', 'Public'),
+ ('08', 'Professional Association'),
+ ('99', 'Other');
+
+CREATE TABLE issuing_boards(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO issuing_boards (code, description) VALUES
+ ('B1', 'AANA'),
+ ('B2', 'NARM'),
+ ('B3', 'ANCC'),
+ ('B4', 'AOTA'),
+ ('B5', 'ADA'),
+ ('B6', 'ABMS'),
+ ('B7', 'ABPS');
+  
+CREATE TABLE license_statuses(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE,
+  date DATE NULL
+);
+INSERT INTO license_statuses (code, description) VALUES
+ ('01', 'Active'),
+ ('02', 'Suspended'),
+ ('03', 'Expired');
+
+
+-- This entity may be obsolete BenGalewsky 6-8-17
+CREATE TABLE ownership_types(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE);
+
+CREATE TABLE payto_types(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE);
+
+INSERT INTO payto_types(code, description) VALUES
+('01', 'Claim'),
+('02', 'ERA'),
+('03', 'Both');
+
+CREATE TABLE categories_of_service (
+  code        CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO categories_of_service (code, description) VALUES
+  ('01', 'AC Transportation'),
+  ('02', 'Home Delivered Meals'),
+  ('03', 'Adult Day Services'),
+  ('04', 'Homemaker Services'),
+  ('05', 'Behavioral Program Services'),
+  ('06', 'In-home Family Support'),
+  ('07', 'Caregiver Training'),
+  ('08', 'Independent Living Skills'),
+  ('09', 'Case Management Waiver/Alternative Care'),
+  ('10', 'Modification and Adaptations'),
+  ('11', 'Chore'),
+  ('12', 'Nutritional Services'),
+  ('13', 'Cognitive Therapy'),
+  ('14', 'PERS and AC Supplies'),
+  ('15', 'Companion Services'),
+  ('16', 'Respite Care'),
+  ('17', 'Consumer Directed Community Support (CDCS)'),
+  ('18', 'Specialized Supplies &' || ' Equipment (Waiver)'),
+  ('19', 'Spenddown Collection'),
+  ('20', 'Customized Living, 24 CL, Residential Care Services, Assisted Living Services'),
+  ('21', 'Structured Day Program Services'),
+  ('22', 'Supported Employment Services'),
+  ('23', 'Family Counseling and Training'),
+  ('24', 'Supported Living Services'),
+  ('25', 'Foster Care Services'),
+  ('26', 'Waiver Transportation');
+
+
+CREATE TABLE service_categories (
+  code        CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO service_categories (code, description) VALUES
+ ('01', 'AC Transportation'),
+ ('02', 'Home Delivered Meals'),
+ ('03', 'Adult Day Services'),
+ ('04', 'Homemaker Services'),
+ ('05', 'Behavioral Program Services'),
+ ('06', 'In-home Family Support'),
+ ('07', 'Caregiver Training'),
+ ('08', 'Independent Living Skills'),
+ ('09', 'Case Management Waiver/Alternative Care'),
+ ('10', 'Modification and Adaptations'),
+ ('11', 'Chore'),
+ ('12', 'Nutritional Services'),
+ ('13', 'Cognitive Therapy'),
+ ('14', 'PERS and AC Supplies'),
+ ('15', 'Companion Services'),
+ ('16', 'Respite Care'),
+ ('17', 'Consumer Directed Community Support (CDCS)'),
+ ('18', 'Specialized Supplies &'|| ' Equipment (Waiver)'),
+ ('19', 'Spenddown Collection'),
+ ('20', 'Customized Living, 24 CL, Residential Care Services, Assisted Living Services'),
+ ('21', 'Structured Day Program Services'),
+ ('22', 'Supported Employment Services'),
+ ('23', 'Family Counseling and Training'),
+ ('24', 'Supported Living Services'),
+ ('25', 'Foster Care Services'),
+ ('26', 'Waiver Transportation');
+
+
+CREATE TABLE counties (
+  code        CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO counties (code, description) VALUES
+   ('01', 'Aitkin'),
+ ('02', 'Anoka'),
+ ('03', 'Becker'),
+ ('04', 'Beltrami'),
+ ('05', 'Benton'),
+ ('06', 'Big Stone'),
+ ('07', 'Blue Earth'),
+ ('08', 'Brown'),
+ ('09', 'Carlton'),
+ ('10', 'Carver'),
+ ('11', 'Cass'),
+ ('12', 'Chippewa'),
+ ('13', 'Chisago'),
+ ('14', 'Clay'),
+ ('15', 'Clearwater'),
+ ('16', 'Cook'),
+ ('17', 'Cottonwood'),
+ ('18', 'Crow Wing'),
+ ('19', 'Dakota'),
+ ('20', 'Dodge'),
+ ('21', 'Douglas'),
+ ('22', 'Faribault'),
+ ('23', 'Fillmore'),
+ ('24', 'Freeborn'),
+ ('25', 'Goodhue'),
+ ('26', 'Grant'),
+ ('27', 'Hennepin'),
+ ('28', 'Houston'),
+ ('29', 'Hubbard'),
+ ('30', 'Isanti'),
+ ('31', 'Itasca'),
+ ('32', 'Jackson'),
+ ('33', 'Kanabec'),
+ ('34', 'Kandiyohi'),
+ ('35', 'Kittson'),
+ ('36', 'Koochiching'),
+ ('37', 'Lac qui Parle'),
+ ('38', 'Lake'),
+ ('39', 'Lake of the Woods'),
+ ('40', 'Le Sueur'),
+ ('41', 'Lincoln'),
+ ('42', 'Lyon'),
+ ('43', 'Mahnomen'),
+ ('44', 'Marshall'),
+ ('45', 'Martin'),
+ ('46', 'McLeod'),
+ ('47', 'Meeker'),
+ ('48', 'Mille Lacs'),
+ ('49', 'Morrison'),
+ ('50', 'Mower'),
+ ('51', 'Murray'),
+ ('52', 'Nicollet'),
+ ('53', 'Nobles'),
+ ('54', 'Norman'),
+ ('55', 'Olmsted'),
+ ('56', 'Otter Tail'),
+ ('57', 'Pennington'),
+ ('58', 'Pine'),
+ ('59', 'Pipestone'),
+ ('60', 'Polk'),
+ ('61', 'Pope'),
+ ('62', 'Ramsey'),
+ ('63', 'Red Lake'),
+ ('64', 'Redwood'),
+ ('65', 'Renville'),
+ ('66', 'Rice'),
+ ('67', 'Rock'),
+ ('68', 'Roseau'),
+ ('69', 'Scott'),
+ ('70', 'Sherburne'),
+ ('71', 'Sibley'),
+ ('72', 'St. Louis'),
+ ('73', 'Stearns'),
+ ('74', 'Steele'),
+ ('75', 'Stevens'),
+ ('76', 'Swift'),
+ ('77', 'Todd'),
+ ('78', 'Traverse'),
+ ('79', 'Wabasha'),
+ ('80', 'Wadena'),
+ ('81', 'Waseca'),
+ ('82', 'Washington'),
+ ('83', 'Watonwan'),
+ ('84', 'Wilkin'),
+ ('85', 'Winona'),
+ ('86', 'Wright'),
+ ('87', 'Yellow');
+
+CREATE TABLE beneficial_owner_types(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE,
+  owner_type CHARACTER VARYING(2)
+);
+INSERT INTO beneficial_owner_types (code, description, owner_type) VALUES
+  ('01', 'Non Profit', 'O'),
+  ('02', 'Sole Proprietership', 'O'),
+  ('03', 'Hospital', 'O'),
+  ('04', 'Corporation', 'O'),
+  ('05', 'Partnership', 'O'),
+  ('06', 'State', 'A'),
+  ('07', 'Public', 'P');
+
 
 CREATE TABLE risk_levels(
   code CHARACTER VARYING(2) PRIMARY KEY,
@@ -235,6 +492,16 @@ CREATE TABLE degrees(
 INSERT INTO degrees(CODE, DESCRIPTION) VALUES
   ('D1', 'MASTERS'),
   ('D2', 'DOCTORATE');
+
+CREATE TABLE relationship_types(
+  code CHARACTER VARYING(2) PRIMARY KEY,
+  description TEXT UNIQUE
+);
+INSERT INTO relationship_types(CODE, DESCRIPTION) VALUES
+('01', 'Spouse'),
+('02', 'Child'),
+('03', 'Parent'),
+('04', 'Sibling');
 
 CREATE TABLE enrollment_statuses(
   code CHARACTER VARYING(2) PRIMARY KEY,

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
+import javax.persistence.Column;
 
-/**
- * Represents possible beneficial owner types.
- *
- * @author TCSASSEMBLER
- * @version 1.0
+/*
+ * Represents the Assurance Statements lookup for Chemical Dependency Program.
  */
+@javax.persistence.Entity
+@Table(name = "beneficial_owner_types")
 public class BeneficialOwnerType extends LookupEntity {
-
     /**
      * Type of owner (P- person/O-org/A-any);
      */
+    @Column(name = "owner_type")
     private String ownerType;
-    
+
     /**
      * Empty constructor.
      */
@@ -49,6 +50,5 @@ public class BeneficialOwnerType extends LookupEntity {
     public void setOwnerType(String ownerType) {
         this.ownerType = ownerType;
     }
-    
-    
+
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Represents possible relationship types.
- * 
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class CategoryOfService extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public CategoryOfService() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "categories_of_service")
+public class CategoryOfService extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Represents a state type.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class CountyType extends LookupEntity {
-
-    /**
-     * Default empty constructor.
-     */
-    public CountyType() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "counties")
+public class CountyType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Represents possible entity structures.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class EntityStructureType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public EntityStructureType() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "entity_structure_types")
+public class EntityStructureType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Represents an issuing board.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class IssuingBoard extends LookupEntity {
-
-    /**
-     * Default empty constructor.
-     */
-    public IssuingBoard() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "issuing_boards")
+public class IssuingBoard extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -15,19 +15,21 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Table;
+import javax.persistence.Column;
 import java.util.Date;
 
-/**
- * Represents a license status.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
+/*
+ * Represents the Assurance Statements lookup for Chemical Dependency Program.
  */
+@javax.persistence.Entity
+@Table(name = "license_statuses")
 public class LicenseStatus extends LookupEntity {
 
     /**
      * License status date.
      */
+    @Column(name = "date")
     private Date date;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Lookup entity for ownership types.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class OwnershipType extends LookupEntity {
+@javax.persistence.Entity
+@Table(name = "ownership_types")
+public class OwnershipType extends LookupEntity {}
 
-    /**
-     * Empty constructor.
-     */
-    public OwnershipType() {
-    }
-}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Lookup entity for pay to provider type.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class PayToProviderType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public PayToProviderType() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "payto_types")
+public class PayToProviderType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Represents possible relationship types.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class QPType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public QPType() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "qp_types")
+public class QPType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Represents possible relationship types.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class RelationshipType extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public RelationshipType() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "relationship_types")
+public class RelationshipType extends LookupEntity {}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RequiredField.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RequiredField.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -15,17 +15,19 @@
  */
 package gov.medicaid.entities;
 
-/**
- * This represents a required field.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
- */
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@javax.persistence.Entity
+@Table(name = "required_fields")
 public class RequiredField extends LookupEntity {
 
     /**
      * The required field type.
      */
+    @ManyToOne
+    @JoinColumn(name = "required_field_type_code")
     private RequiredFieldType type;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+import javax.persistence.Table;
 
-/**
- * Represents possible relationship types.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class ServiceCategory extends LookupEntity {
-
-    /**
-     * Empty constructor.
-     */
-    public ServiceCategory() {
-    }
-}
+@javax.persistence.Entity
+@Table(name = "service_categories")
+public class ServiceCategory extends LookupEntity {}


### PR DESCRIPTION
There are several subclasses of LookupEntity. Their conversion to H5 involved 

- looking up the old table name in medicade.hbm.xml
- finding the table in mpse-clean.sql to extract test data
- Creating the new table along with test data in seed.sql 
- Updating the class to use the new annotations
- Deleting the reference to the class from Medicade.hbn.xml
- Adding a reference to the class in persistence.xml

Progress on #36 