### PR TITLE
Allow null enrollment status on Entity

### DIFF
--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -610,7 +610,7 @@ INSERT INTO provider_type_license_types(
 
 CREATE TABLE entities(
   entity_id BIGINT PRIMARY KEY,
-  enrolled CHARACTER VARYING(1) NOT NULL,
+  enrolled CHARACTER VARYING(1),
   profile_id BIGINT NOT NULL,
   ticket_id BIGINT,
   name TEXT,

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
@@ -46,7 +46,6 @@ public abstract class Entity implements Serializable {
     /**
      * Enrolled flag.
      */
-    @Column(nullable = false)
     private String enrolled;
 
     /**


### PR DESCRIPTION
The Hibernate XML mapping file said the `enrolled` field must be backed by a non-nullable column, but looking at the source, there is no default and it is only ever written to with the string 'Y'. Looking at the Oracle database instance, it appears that the table was created with a nullable column. Do the same.

We should fix this, long-term; this appears to be another artifact of Oracle not having a boolean data type. See issue #57.

Bug introduced in 322664d4192e238d6960a62ab7022126a350086f.

Issue #36 Use Hibernate 5, instead of 4