### PR TITLE
Do not persist transient data in Enrollment

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2036,10 +2036,11 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      */
     private long saveTicket(CMSUser user, Enrollment ticket, boolean insertDetails) throws PortalServiceException {
         ticket.setLastUpdatedBy(user.getUserId());
-        getEm().merge(ticket);
+        ProviderProfile details = ticket.getDetails();
+        ticket = getEm().merge(ticket);
 
         if (insertDetails) {
-            insertProfile(ticket.getTicketId(), ticket.getDetails());
+            insertProfile(ticket.getTicketId(), details);
         }
 
         return ticket.getTicketId();

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -22,6 +22,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -126,6 +127,7 @@ public class Enrollment implements Serializable {
     /**
      * Ticket details.
      */
+    @Transient
     private ProviderProfile details;
 
     /**


### PR DESCRIPTION
When migrating the Enrollment class to JPA annotations in b2ed85991988adab9f0858cd390cb7be4b9ade85, I missed that the `details` field did not have a corresponding entry in the legacy Hibernate mapping XML file. Mark it as `@Transient` so Hibernate does not complain about a missing column.

Issue #36 Use Hibernate 5, instead of 4
Pull request #83 Hibernate-5-ify Enrollment