### PR TITLE
Hibernate-5-ify DesignatedContact

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1235,7 +1235,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             Person person = designatedContact.getPerson();
             insertNonProviderEntity(person);
 
-            designatedContact.setId(getSequence().getNextValue(Sequences.DESIGNATED_CONTACT_SEQ));
+            designatedContact.setId(0);
             getEm().persist(designatedContact);
         }
     }

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -146,39 +146,6 @@
 			<column name="SUB_CAT_CD" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.DesignatedContact" table="DESIGNATED_CONTACT">
-		<id name="id" type="long">
-			<column name="CONTROL_NO" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKET_ID" />
-		</property>
-		<property generated="never" lazy="false" name="sameAsProvider"
-			type="string">
-			<column length="1" name="SAME_AS_PROVIDER_IND" />
-		</property>
-		<property generated="never" lazy="false" name="hireDate"
-			type="date">
-			<column name="HIRE_DT" />
-		</property>
-		<property generated="never" lazy="false" name="type">
-			<column name="TYPE" />
-			<type name="org.hibernate.type.EnumType">
-				<param name="type">12</param>
-				<param name="enumClass">gov.medicaid.entities.DesignatedContactType</param>
-			</type>
-		</property>
-		<many-to-one class="gov.medicaid.entities.Person" fetch="join"
-			name="person">
-			<column name="PERSON_ID" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.License" table="LICENSE">
 		<id column="LICENSE_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -53,6 +53,7 @@
     <class>gov.medicaid.entities.ContactInformation</class>
     <class>gov.medicaid.entities.CountyType</class>
     <class>gov.medicaid.entities.Degree</class>
+    <class>gov.medicaid.entities.DesignatedContact</class>
     <class>gov.medicaid.entities.Document</class>
     <class>gov.medicaid.entities.Enrollment</class>
     <class>gov.medicaid.entities.EnrollmentStatus</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -14,6 +14,7 @@ DROP TABLE IF EXISTS
   contacts,
   counties,
   degrees,
+  designated_contacts,
   documents,
   enrollment_statuses,
   enrollments,
@@ -933,4 +934,15 @@ CREATE TABLE documents(
   binary_content_id TEXT,
   created_by TEXT,
   created_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE designated_contacts(
+  designated_contact_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  designated_contact_type TEXT,
+  same_as_provider CHARACTER VARYING(1),
+  hired_at DATE,
+  person_id BIGINT
+    REFERENCES people(entity_id)
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
@@ -46,12 +46,6 @@ public class DesignatedContact extends IdentifiableEntity {
      */
     private Person person;
 
-    /**
-     * Empty constructor.
-     */
-    public DesignatedContact() {
-    }
-
     public long getProfileId() {
         return profileId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
@@ -17,12 +17,6 @@ package gov.medicaid.entities;
 
 import java.util.Date;
 
-/**
- * Represents a designated contact.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 public class DesignatedContact extends IdentifiableEntity {
 
     /**
@@ -35,9 +29,6 @@ public class DesignatedContact extends IdentifiableEntity {
      */
     private long ticketId;
 
-    /**
-     * The contact type.
-     */
     private DesignatedContactType type;
 
     /**
@@ -61,108 +52,50 @@ public class DesignatedContact extends IdentifiableEntity {
     public DesignatedContact() {
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>type</code>.
-     *
-     * @return the type
-     */
     public DesignatedContactType getType() {
         return type;
     }
 
-    /**
-     * Sets the value of the field <code>type</code>.
-     *
-     * @param type the type to set
-     */
     public void setType(DesignatedContactType type) {
         this.type = type;
     }
 
-    /**
-     * Gets the value of the field <code>person</code>.
-     *
-     * @return the person
-     */
     public Person getPerson() {
         return person;
     }
 
-    /**
-     * Sets the value of the field <code>person</code>.
-     *
-     * @param person the person to set
-     */
     public void setPerson(Person person) {
         this.person = person;
     }
 
-    /**
-     * Gets the value of the field <code>sameAsProvider</code>.
-     *
-     * @return the sameAsProvider
-     */
     public String getSameAsProvider() {
         return sameAsProvider;
     }
 
-    /**
-     * Sets the value of the field <code>sameAsProvider</code>.
-     *
-     * @param sameAsProvider the sameAsProvider to set
-     */
     public void setSameAsProvider(String sameAsProvider) {
         this.sameAsProvider = sameAsProvider;
     }
 
-    /**
-     * Gets the value of the field <code>hireDate</code>.
-     * @return the hireDate
-     */
     public Date getHireDate() {
         return hireDate;
     }
 
-    /**
-     * Sets the value of the field <code>hireDate</code>.
-     * @param hireDate the hireDate to set
-     */
     public void setHireDate(Date hireDate) {
         this.hireDate = hireDate;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
@@ -15,36 +15,68 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.Date;
 
-public class DesignatedContact extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "designated_contacts")
+public class DesignatedContact implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "designated_contact_id")
+    private long id;
 
     /**
      * The owner profile.
      */
+    @Column(name = "profile_id")
     private long profileId;
 
     /**
      * The owner ticket.
      */
+    @Column(name = "ticket_id")
     private long ticketId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "designated_contact_type")
     private DesignatedContactType type;
 
     /**
      * Use the same contact details as the provider profile.
      */
+    @Column(name = "same_as_provider")
     private String sameAsProvider;
 
     /**
      * Designee hire date.
      */
+    @Column(name = "hired_at")
     private Date hireDate;
 
     /**
      * The designated person.
      */
+    @ManyToOne
+    @JoinColumn(name = "person_id")
     private Person person;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public long getProfileId() {
         return profileId;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -33,11 +33,6 @@ public class Sequences {
     public static final String LICENSE_SEQ = "LICENSE_SEQ";
 
     /**
-     * Used for designated contacts table.
-     */
-    public static final String DESIGNATED_CONTACT_SEQ = "DESIGNATED_CONTACT_SEQ";
-
-    /**
      * Used for provider statement table.
      */
     public static final String STATEMENT_ID = "STATEMENT_ID";


### PR DESCRIPTION
Remove redundant comments, empty constructor, and trailing whitespace; pluralize table name, rename columns, and use Hibernate to generate IDs.

Issue #36 Use Hibernate 5, instead of 4