### PR TITLE
#36 Converted AcceptedAgreements to H5

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1054,7 +1054,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             acceptedAgreements.setProfileId(details.getProfileId());
             acceptedAgreements.setTicketId(details.getTicketId());
 
-            acceptedAgreements.setId(getSequence().getNextValue(Sequences.AGREEMENT_SEQ));
+            acceptedAgreements.setId(0);
             getEm().persist(acceptedAgreements);
         }
     }

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -179,27 +179,6 @@
 			<column name="ISSUING_BOARD_CD" />
 		</many-to-one>
 	</class>
-	<class name="gov.medicaid.entities.AcceptedAgreements" table="PROVIDER_AGREEMENT_XREF">
-		<id column="PROVIDER_AGREEMENT_XREF_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILEID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKETID" />
-		</property>
-		<property generated="never" lazy="false" name="acceptedDate"
-			type="date">
-			<column name="ACCEPTED_DATE" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.AgreementDocument"
-			fetch="join" name="agreementDocument">
-			<column name="AGREEMENT_DOCUMENT_ID" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.ProviderStatement" table="PROVIDER_STATEMENT">
 		<id column="PROVIDER_STATEMENT_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -41,6 +41,7 @@
     <class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
     <class>org.jbpm.task.User</class>
 
+    <class>gov.medicaid.entities.AcceptedAgreements</class>
     <class>gov.medicaid.entities.Address</class>
     <class>gov.medicaid.entities.AgreementDocument</class>
     <class>gov.medicaid.entities.AuditDetail</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -2,6 +2,7 @@ DROP SEQUENCE IF EXISTS
   hibernate_sequence
 CASCADE;
 DROP TABLE IF EXISTS
+  accepted_agreements,
   addresses,
   agreement_documents,
   audit_details,
@@ -1009,6 +1010,7 @@ CREATE TABLE binary_contents(
   binary_content_id TEXT PRIMARY KEY,
   content OID
 );
+
 CREATE TABLE documents(
   document_id BIGINT PRIMARY KEY,
   profile_id BIGINT,
@@ -1031,3 +1033,13 @@ CREATE TABLE designated_contacts(
   person_id BIGINT
     REFERENCES people(entity_id)
 );
+
+CREATE TABLE accepted_agreements(
+  accepted_agreement_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  accepted_date DATE,
+  agreement_document_id BIGINT
+    REFERENCES  agreement_documents(agreement_document_id)
+ ) ;
+

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -15,110 +15,73 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.Date;
 
-/**
- * Represents user accepted agreements.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class AcceptedAgreements extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "accepted_agreements")
+public class AcceptedAgreements implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "accepted_agreement_id")
+    private long id;
 
-    /**
-     * Owning profile id.
-     */
+    @Column(name = "profile_id")
     private long profileId;
 
-    /**
-     * Owning ticket id.
-     */
+    @Column(name = "ticket_id")
     private long ticketId;
 
-    /**
-     * Date accepted.
-     */
+    @Column(name = "accepted_date")
     private Date acceptedDate;
 
-    /**
-     * Related document.
-     */
+    @ManyToOne
+    @JoinColumn(name = "agreement_document_id")
     private AgreementDocument agreementDocument;
 
-    /**
-     * Empty constructor.
-     */
-    public AcceptedAgreements() {
+    public long getId() {
+        return id;
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
+    public void setId(long id) {
+        this.id = id;
+    }
+
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>acceptedDate</code>.
-     *
-     * @return the acceptedDate
-     */
     public Date getAcceptedDate() {
         return acceptedDate;
     }
 
-    /**
-     * Sets the value of the field <code>acceptedDate</code>.
-     *
-     * @param acceptedDate the acceptedDate to set
-     */
     public void setAcceptedDate(Date acceptedDate) {
         this.acceptedDate = acceptedDate;
     }
 
-    /**
-     * Gets the value of the field <code>agreementDocument</code>.
-     *
-     * @return the agreementDocument
-     */
     public AgreementDocument getAgreementDocument() {
         return agreementDocument;
     }
 
-    /**
-     * Sets the value of the field <code>agreementDocument</code>.
-     *
-     * @param agreementDocument the agreementDocument to set
-     */
     public void setAgreementDocument(AgreementDocument agreementDocument) {
         this.agreementDocument = agreementDocument;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -53,11 +53,6 @@ public class Sequences {
     public static final String ACOUNT_LINK_SEQ = "ACOUNT_LINK_SEQ";
 
     /**
-     * The agreements accepted.
-     */
-    public static final String AGREEMENT_SEQ = "AGREEMENT_SEQ";
-
-    /**
      * Ownership information.
      */
     public static final String OWNERSHIP_SEQ = "OWNERSHIP_SEQ";
@@ -90,14 +85,14 @@ public class Sequences {
     public static final String PAY_TO_SEQ = "PAY_TO_SEQ";
 
     public static final String SERVICE_SEQ = "SERVICE_SEQ";
-    
+
     /**
      * For Assured Services.
      */
     public static final String ASSURED_SERVICE_SEQ = "ASSURED_SERVICE_SEQ";
 
     public static final String PROVIDER_COS_SEQ = "PROVIDER_COS_SEQ";
-    
+
     /**
      * Private constructor.
      */


### PR DESCRIPTION
Converted AcceptedAgreements to Hibernate 5
- Created table name in seed.sql
- Added annotations
- Removed explicit sequence generation
- Moved out from IdentifiableEntity so ID column in DB has clearer name

Progress on #36 