### PR TITLE
Convert ScreeningSchedule to Hibernate 5

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -504,24 +504,6 @@
 			<column name="REQUIRED_FLD_TYPE_ID" />
 		</many-to-one>
 	</class>
-	<class name="gov.medicaid.entities.ScreeningSchedule" table="SCREENING_SCHEDULE">
-		<id column="SCREENING_SCHEDULE_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property column="UPCOMING_SCREENING_DT" generated="never"
-			lazy="false" name="upcomingScreeningDate" type="timestamp" />
-		<property column="INTERVAL_TYPE" generated="never" lazy="false"
-			name="intervalType">
-			<type name="org.hibernate.type.EnumType">
-				<param name="type">12</param>
-				<param name="enumClass">gov.medicaid.entities.ScreeningIntervalType</param>
-			</type>
-		</property>
-		<property generated="never" lazy="false" name="interval"
-			type="int">
-			<column default="0" name="INTERVAL_VALUE" not-null="true" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.LegacySystemMapping" table="LEGACY_MAPPING">
 		<id column="LEGACY_MAPPING_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -77,6 +77,7 @@
     <class>gov.medicaid.entities.RequiredFieldType</class>
     <class>gov.medicaid.entities.RiskLevel</class>
     <class>gov.medicaid.entities.Role</class>
+    <class>gov.medicaid.entities.ScreeningSchedule</class>
     <class>gov.medicaid.entities.ServiceAssuranceExtType</class>
     <class>gov.medicaid.entities.ServiceAssuranceType</class>
     <class>gov.medicaid.entities.ServiceCategory</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -41,6 +41,7 @@ DROP TABLE IF EXISTS
   required_field_types,
   risk_levels,
   roles,
+  screening_schedules,
   service_assurance_ext_types,
   service_assurance_types,
   service_categories,
@@ -1043,3 +1044,17 @@ CREATE TABLE accepted_agreements(
     REFERENCES  agreement_documents(agreement_document_id)
  ) ;
 
+CREATE TABLE screening_schedules(
+  screening_schedule_id BIGINT PRIMARY KEY,
+  upcoming_screening_date DATE,
+  interval_type TEXT,
+  interval_value BIGINT NOT NULL
+);
+
+INSERT INTO screening_schedules(
+  screening_schedule_id,
+  upcoming_screening_date,
+  interval_type,
+  interval_value
+) VALUES
+  (1, null, null, 0);

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -17,27 +17,12 @@ package gov.medicaid.entities;
 
 import java.util.Date;
 
-/**
- * Represents a screening schedule.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
- */
 public class ScreeningSchedule extends IdentifiableEntity {
 
-    /**
-     * Upcoming screening date.
-     */
     private Date upcomingScreeningDate;
 
-    /**
-     * Interval.
-     */
     private int interval;
 
-    /**
-     * Interval type.
-     */
     private ScreeningIntervalType intervalType;
 
     /**
@@ -46,56 +31,26 @@ public class ScreeningSchedule extends IdentifiableEntity {
     public ScreeningSchedule() {
     }
 
-    /**
-     * Gets the value of the field <code>upcomingScreeningDate</code>.
-     *
-     * @return the upcomingScreeningDate
-     */
     public Date getUpcomingScreeningDate() {
         return upcomingScreeningDate;
     }
 
-    /**
-     * Sets the value of the field <code>upcomingScreeningDate</code>.
-     *
-     * @param upcomingScreeningDate the upcomingScreeningDate to set
-     */
     public void setUpcomingScreeningDate(Date upcomingScreeningDate) {
         this.upcomingScreeningDate = upcomingScreeningDate;
     }
 
-    /**
-     * Gets the value of the field <code>interval</code>.
-     *
-     * @return the interval
-     */
     public int getInterval() {
         return interval;
     }
 
-    /**
-     * Sets the value of the field <code>interval</code>.
-     *
-     * @param interval the interval to set
-     */
     public void setInterval(int interval) {
         this.interval = interval;
     }
 
-    /**
-     * Gets the value of the field <code>intervalType</code>.
-     *
-     * @return the intervalType
-     */
     public ScreeningIntervalType getIntervalType() {
         return intervalType;
     }
 
-    /**
-     * Sets the value of the field <code>intervalType</code>.
-     *
-     * @param intervalType the intervalType to set
-     */
     public void setIntervalType(ScreeningIntervalType intervalType) {
         this.intervalType = intervalType;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -28,7 +28,7 @@ import java.util.Date;
 @javax.persistence.Entity 
 @Table(name = "screening_schedules")
 public class ScreeningSchedule implements Serializable {
- @Id
+    @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "screening_schedule_id")
     private long id;
@@ -45,10 +45,6 @@ public class ScreeningSchedule implements Serializable {
     @Column(name = "interval_value")
     private int interval;
 
-    /*
-     * The `interval` is expressed in days, weeks, or months.  See
-     * ScreeningIntervalType.java.
-     */
     @Enumerated(EnumType.STRING)
     @Column(name = "interval_type")
     private ScreeningIntervalType intervalType;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -15,15 +15,44 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.Date;
 
-public class ScreeningSchedule extends IdentifiableEntity {
-
+@javax.persistence.Entity 
+@Table(name = "screening_schedules")
+public class ScreeningSchedule implements Serializable {
+ @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "screening_schedule_id")
+    private long id;
+    
+    /* 
+     * Next screening date.
+     */
+    @Column(name = "upcoming_screening_date")
     private Date upcomingScreeningDate;
 
+    /*
+     * Interval between screenings.
+     */
+    @Column(name = "interval_value")
     private int interval;
 
+    /*
+     * The `interval` is expressed in days, weeks, or months.  See
+     * ScreeningIntervalType.java.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interval_type")
     private ScreeningIntervalType intervalType;
+
 
     public Date getUpcomingScreeningDate() {
         return upcomingScreeningDate;
@@ -48,4 +77,13 @@ public class ScreeningSchedule extends IdentifiableEntity {
     public void setIntervalType(ScreeningIntervalType intervalType) {
         this.intervalType = intervalType;
     }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -25,12 +25,6 @@ public class ScreeningSchedule extends IdentifiableEntity {
 
     private ScreeningIntervalType intervalType;
 
-    /**
-     * Default empty constructor.
-     */
-    public ScreeningSchedule() {
-    }
-
     public Date getUpcomingScreeningDate() {
         return upcomingScreeningDate;
     }


### PR DESCRIPTION
Remove redundant comments (and rewrite a couple to be more useful).  Delete empty constructor and trailing whitespace; pluralize table name, rename columns, and use Hibernate to generate IDs.  See the commit message for 2831094 for more details.

Issue #36 Use Hibernate 5, instead of 4