### PR TITLE
Hibernate-5-ify License

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1124,7 +1124,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                             }
                             license.setAttachmentId(attachmentMapping.get(license.getAttachmentId()));
                         }
-                        license.setId(getSequence().getNextValue(Sequences.LICENSE_SEQ));
+                        license.setId(0);
                         getEm().persist(license);
                     }
                 }
@@ -1196,7 +1196,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                 }
                 license.setAttachmentId(attachmentMapping.get(license.getAttachmentId()));
             }
-            license.setId(getSequence().getNextValue(Sequences.LICENSE_SEQ));
+            license.setId(0);
             getEm().persist(license);
         }
     }

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -132,53 +132,6 @@
 			<column name="STATUS" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.License" table="LICENSE">
-		<id column="LICENSE_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKET_ID" />
-		</property>
-		<property generated="never" lazy="false" name="affiliateId"
-			type="long">
-			<column name="AFFILIATE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="objectType"
-			type="string">
-			<column length="1" name="OBJECT_TYP" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.SpecialtyType"
-			name="specialty" outer-join="true">
-			<column name="SPECIALTY_TYP_CD" />
-		</many-to-one>
-		<many-to-one class="gov.medicaid.entities.LicenseType"
-			name="type" outer-join="true">
-			<column name="LICENSE_TYP_CD" />
-		</many-to-one>
-		<property column="LICENSE_NUMBER" generated="never" lazy="false"
-			length="45" name="licenseNumber" type="string" />
-		<property column="ORIGINAL_ISSUE_DT" generated="never" lazy="false"
-			name="originalIssueDate" type="date" />
-		<property column="RENEWAL_END_DT" generated="never" lazy="false"
-			name="renewalEndDate" type="date" />
-		<property column="ISSUING_US_STATE" generated="never" lazy="false"
-			length="2" name="issuingUSState" type="string" />
-		<property column="ATTACHMENT_ID" generated="never" lazy="false"
-			name="attachmentId" type="long" />
-		<many-to-one class="gov.medicaid.entities.LicenseStatus"
-			name="status">
-			<column name="LICENSE_STATUS_CD" />
-		</many-to-one>
-		<many-to-one class="gov.medicaid.entities.IssuingBoard"
-			name="issuingBoard">
-			<column name="ISSUING_BOARD_CD" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.ProviderStatement" table="PROVIDER_STATEMENT">
 		<id column="PROVIDER_STATEMENT_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -62,6 +62,7 @@
     <class>gov.medicaid.entities.EntityStructureType</class>
     <class>gov.medicaid.entities.HelpItem</class>
     <class>gov.medicaid.entities.IssuingBoard</class>
+    <class>gov.medicaid.entities.License</class>
     <class>gov.medicaid.entities.LicenseStatus</class>
     <class>gov.medicaid.entities.LicenseType</class>
     <class>gov.medicaid.entities.Organization</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -25,6 +25,7 @@ DROP TABLE IF EXISTS
   issuing_boards,
   license_statuses,
   license_types,
+  licenses,
   organizations,
   ownership_types,
   pay_to_provider_types,
@@ -1058,3 +1059,24 @@ INSERT INTO screening_schedules(
   interval_value
 ) VALUES
   (1, null, null, 0);
+
+CREATE TABLE licenses(
+  license_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  affiliate_id BIGINT,
+  object_type TEXT,
+  license_number TEXT,
+  issued_at DATE,
+  expires_at DATE,
+  issuing_us_state TEXT,
+  issuing_board_code CHARACTER VARYING(2)
+    REFERENCES issuing_boards(code),
+  license_status_code CHARACTER VARYING(2)
+    REFERENCES license_statuses(code),
+  license_type_code CHARACTER VARYING(2)
+    REFERENCES license_types(code),
+  specialty_type_code CHARACTER VARYING(2)
+    REFERENCES specialty_types(code),
+  attachment_id BIGINT
+);

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -16,50 +16,90 @@
 package gov.medicaid.entities;
 
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.io.Serializable;
 import java.util.Date;
 
 /**
  * Represents a license or specialty certification.
  */
-public class License extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "licenses")
+public class License implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "license_id")
+    private long id;
 
     /**
      * The owner profile.
      */
+    @Column(name = "profile_id")
     private long profileId;
 
     /**
      * The owner ticket.
      */
+    @Column(name = "ticket_id")
     private long ticketId;
 
     /**
      * The affiliate id if it belongs to a QP.
      */
+    @Column(name = "affiliate_id")
     private Long affiliateId;
 
     /**
      * Specialty, Tribal Cert or License.
      */
+    @Column(name = "object_type")
     private String objectType;
 
+    @Column(name = "license_number")
     private String licenseNumber;
 
+    @Column(name = "issued_at")
     private Date originalIssueDate;
 
+    @Column(name = "expires_at")
     private Date renewalEndDate;
 
+    @Column(name = "issuing_us_state")
     private String issuingUSState;
 
+    @ManyToOne
+    @JoinColumn(name = "issuing_board_code")
     private IssuingBoard issuingBoard;
 
+    @ManyToOne
+    @JoinColumn(name = "license_status_code")
     private LicenseStatus status;
 
+    @ManyToOne
+    @JoinColumn(name = "license_type_code")
     private LicenseType type;
 
+    @ManyToOne
+    @JoinColumn(name = "specialty_type_code")
     private SpecialtyType specialty;
 
+    @Column(name = "attachment_id")
     private long attachmentId;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getLicenseNumber() {
         return licenseNumber;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -63,12 +63,6 @@ public class License extends IdentifiableEntity {
 
     private long attachmentId;
 
-    /**
-     * Default empty constructor.
-     */
-    public License() {
-    }
-
     public String getLicenseNumber() {
         return licenseNumber;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class License extends IdentifiableEntity {
      * The owner ticket.
      */
     private long ticketId;
-    
+
     /**
      * The affiliate id if it belongs to a QP.
      */

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -59,8 +59,6 @@ public class License extends IdentifiableEntity {
 
     private SpecialtyType specialty;
 
-    private String verified;
-
     private long attachmentId;
 
     public String getLicenseNumber() {
@@ -117,14 +115,6 @@ public class License extends IdentifiableEntity {
 
     public void setSpecialty(SpecialtyType specialty) {
         this.specialty = specialty;
-    }
-
-    public String getVerified() {
-        return verified;
-    }
-
-    public void setVerified(String verified) {
-        this.verified = verified;
     }
 
     public IssuingBoard getIssuingBoard() {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -20,9 +20,6 @@ import java.util.Date;
 
 /**
  * Represents a license or specialty certification.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class License extends IdentifiableEntity {
 
@@ -46,54 +43,24 @@ public class License extends IdentifiableEntity {
      */
     private String objectType;
 
-    /**
-     * License number.
-     */
     private String licenseNumber;
 
-    /**
-     * Original issue date.
-     */
     private Date originalIssueDate;
 
-    /**
-     * Renewal date.
-     */
     private Date renewalEndDate;
 
-    /**
-     * Issuing state.
-     */
     private String issuingUSState;
 
-    /**
-     * The issuing board.
-     */
     private IssuingBoard issuingBoard;
 
-    /**
-     * Status.
-     */
     private LicenseStatus status;
 
-    /**
-     * License type.
-     */
     private LicenseType type;
 
-    /**
-     * Specialty type.
-     */
     private SpecialtyType specialty;
 
-    /**
-     * Verified.
-     */
     private String verified;
 
-    /**
-     * Attachment id.
-     */
     private long attachmentId;
 
     /**
@@ -102,250 +69,114 @@ public class License extends IdentifiableEntity {
     public License() {
     }
 
-    /**
-     * Gets the value of the field <code>licenseNumber</code>.
-     *
-     * @return the licenseNumber
-     */
     public String getLicenseNumber() {
         return licenseNumber;
     }
 
-    /**
-     * Sets the value of the field <code>licenseNumber</code>.
-     *
-     * @param licenseNumber the licenseNumber to set
-     */
     public void setLicenseNumber(String licenseNumber) {
         this.licenseNumber = licenseNumber;
     }
 
-    /**
-     * Gets the value of the field <code>originalIssueDate</code>.
-     *
-     * @return the originalIssueDate
-     */
     public Date getOriginalIssueDate() {
         return originalIssueDate;
     }
 
-    /**
-     * Sets the value of the field <code>originalIssueDate</code>.
-     *
-     * @param originalIssueDate the originalIssueDate to set
-     */
     public void setOriginalIssueDate(Date originalIssueDate) {
         this.originalIssueDate = originalIssueDate;
     }
 
-    /**
-     * Gets the value of the field <code>renewalEndDate</code>.
-     *
-     * @return the renewalEndDate
-     */
     public Date getRenewalEndDate() {
         return renewalEndDate;
     }
 
-    /**
-     * Sets the value of the field <code>renewalEndDate</code>.
-     *
-     * @param renewalEndDate the renewalEndDate to set
-     */
     public void setRenewalEndDate(Date renewalEndDate) {
         this.renewalEndDate = renewalEndDate;
     }
 
-    /**
-     * Gets the value of the field <code>issuingUSState</code>.
-     *
-     * @return the issuingUSState
-     */
     public String getIssuingUSState() {
         return issuingUSState;
     }
 
-    /**
-     * Sets the value of the field <code>issuingUSState</code>.
-     *
-     * @param issuingUSState the issuingUSState to set
-     */
     public void setIssuingUSState(String issuingUSState) {
         this.issuingUSState = issuingUSState;
     }
 
-    /**
-     * Gets the value of the field <code>status</code>.
-     *
-     * @return the status
-     */
     public LicenseStatus getStatus() {
         return status;
     }
 
-    /**
-     * Sets the value of the field <code>status</code>.
-     *
-     * @param status the status to set
-     */
     public void setStatus(LicenseStatus status) {
         this.status = status;
     }
 
-    /**
-     * Gets the value of the field <code>type</code>.
-     *
-     * @return the type
-     */
     public LicenseType getType() {
         return type;
     }
 
-    /**
-     * Sets the value of the field <code>type</code>.
-     *
-     * @param type the type to set
-     */
     public void setType(LicenseType type) {
         this.type = type;
     }
 
-    /**
-     * Gets the value of the field <code>specialty</code>.
-     *
-     * @return the specialty
-     */
     public SpecialtyType getSpecialty() {
         return specialty;
     }
 
-    /**
-     * Sets the value of the field <code>specialty</code>.
-     *
-     * @param specialty the specialty to set
-     */
     public void setSpecialty(SpecialtyType specialty) {
         this.specialty = specialty;
     }
 
-    /**
-     * Gets the value of the field <code>verified</code>.
-     *
-     * @return the verified
-     */
     public String getVerified() {
         return verified;
     }
 
-    /**
-     * Sets the value of the field <code>verified</code>.
-     *
-     * @param verified the verified to set
-     */
     public void setVerified(String verified) {
         this.verified = verified;
     }
 
-    /**
-     * Gets the value of the field <code>issuingBoard</code>.
-     *
-     * @return the issuingBoard
-     */
     public IssuingBoard getIssuingBoard() {
         return issuingBoard;
     }
 
-    /**
-     * Sets the value of the field <code>issuingBoard</code>.
-     *
-     * @param issuingBoard the issuingBoard to set
-     */
     public void setIssuingBoard(IssuingBoard issuingBoard) {
         this.issuingBoard = issuingBoard;
     }
 
-    /**
-     * Gets the value of the field <code>attachmentId</code>.
-     *
-     * @return the attachmentId
-     */
     public long getAttachmentId() {
         return attachmentId;
     }
 
-    /**
-     * Sets the value of the field <code>attachmentId</code>.
-     *
-     * @param attachmentId the attachmentId to set
-     */
     public void setAttachmentId(long attachmentId) {
         this.attachmentId = attachmentId;
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>objectType</code>.
-     * @return the objectType
-     */
     public String getObjectType() {
         return objectType;
     }
 
-    /**
-     * Sets the value of the field <code>objectType</code>.
-     * @param objectType the objectType to set
-     */
     public void setObjectType(String objectType) {
         this.objectType = objectType;
     }
 
-    /**
-     * Gets the value of the field <code>affiliateId</code>.
-     * @return the affiliateId
-     */
     public long getAffiliateId() {
         return affiliateId == null ? 0L : affiliateId;
     }
 
-    /**
-     * Sets the value of the field <code>affiliateId</code>.
-     * @param affiliateId the affiliateId to set
-     */
     public void setAffiliateId(Long affiliateId) {
         if (affiliateId == null) {
             this.affiliateId = 0L;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -28,11 +28,6 @@ public class Sequences {
     public static final String PROV_GRP_SEQ = "PROV_GRP_SEQ";
 
     /**
-     * Used for provider license table.
-     */
-    public static final String LICENSE_SEQ = "LICENSE_SEQ";
-
-    /**
      * Used for provider statement table.
      */
     public static final String STATEMENT_ID = "STATEMENT_ID";


### PR DESCRIPTION
Remove redundant comments, empty constructor, and trailing whitespace from `License`.

Remove unused `verified` field; see commit message for more details.

Pluralize the table name, rename columns for clarity, and use Hibernate to auto-generate IDs.

Issue #36 Use Hibernate 5, instead of 4