### PR TITLE
Hibernate-5-ify Affiliation

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1132,7 +1132,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                 affiliation.setTargetEntityId(0);
             }
 
-            affiliation.setId(getSequence().getNextValue(Sequences.PROV_GRP_SEQ));
+            affiliation.setId(0);
             getEm().persist(affiliation);
         }
     }

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -2,65 +2,6 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                    "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-lazy="false">
-	<class name="gov.medicaid.entities.Affiliation" table="PROFILE_GRP_XREF">
-		<id name="id" type="long">
-			<column name="PROFILE_GRP_XREF_ID" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="primaryInd"
-			not-null="true" type="string">
-			<column length="1" name="PRIMARY_IND" />
-		</property>
-		<property generated="never" lazy="false" name="effectiveDate"
-			type="date">
-			<column name="EFF_DT" />
-		</property>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKET_ID" />
-		</property>
-		<property generated="never" lazy="false" name="objectType"
-			type="string">
-			<column length="1" name="OBJECT_TYP" />
-		</property>
-		<property generated="never" lazy="false" name="targetProfileId"
-			type="long">
-			<column name="TARGET_PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="targetEntityId"
-			type="long">
-			<column name="TARGET_ENTITY_ID" />
-		</property>
-		<property generated="never" lazy="false" name="terminatedInd"
-			type="string">
-			<column length="1" name="TERM_IND" />
-		</property>
-		<property generated="never" lazy="false" name="terminationDate"
-			type="date">
-			<column name="TERM_DT" />
-		</property>
-		<property generated="never" lazy="false"
-			name="acknowledgementAttachmentId" type="string">
-			<column name="ACK_ID" />
-		</property>
-		<property generated="never" lazy="false" name="mhpType" type="string">
-			<column name="MHP_TYPE" />
-		</property>
-		<property generated="never" lazy="false" name="bgsStudyId" type="string">
-			<column name="BGS_STUDY_ID" />
-		</property>
-		<property generated="never" lazy="false" name="bgsClearanceDate" type="date">
-			<column name="BGS_CLEARANCE_DT" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.QPType" fetch="join"
-			name="qpType">
-			<column name="QP_TYP_CD" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.PayToProvider" table="PROFILE_PAYTO_XREF">
 		<id name="id" type="long">
 			<column name="PROFILE_PAYTO_XREF_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -43,6 +43,7 @@
 
     <class>gov.medicaid.entities.AcceptedAgreements</class>
     <class>gov.medicaid.entities.Address</class>
+    <class>gov.medicaid.entities.Affiliation</class>
     <class>gov.medicaid.entities.AgreementDocument</class>
     <class>gov.medicaid.entities.AuditDetail</class>
     <class>gov.medicaid.entities.AuditRecord</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -4,6 +4,7 @@ CASCADE;
 DROP TABLE IF EXISTS
   accepted_agreements,
   addresses,
+  affiliations,
   agreement_documents,
   audit_details,
   audit_records,
@@ -1079,4 +1080,23 @@ CREATE TABLE licenses(
   specialty_type_code CHARACTER VARYING(2)
     REFERENCES specialty_types(code),
   attachment_id BIGINT
+);
+
+CREATE TABLE affiliations(
+  affiliation_id BIGINT PRIMARY KEY,
+  is_primary CHARACTER VARYING(1),
+  profile_id BIGINT,
+  object_type TEXT,
+  ticket_id BIGINT,
+  effective_at DATE,
+  target_profile_id BIGINT,
+  target_entity_id BIGINT,
+  qualified_professional_type_code CHARACTER VARYING(2)
+    REFERENCES qualified_professional_types(code),
+  mental_health_professional_type TEXT,
+  acknowledgement_attachment_id TEXT,
+  is_terminated CHARACTER VARYING(1),
+  terminated_at DATE,
+  bgs_study_id TEXT,
+  bgs_clearance_date DATE
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
@@ -88,12 +88,6 @@ public class Affiliation extends IdentifiableEntity {
      */
     private Date bgsClearanceDate;
 
-    /**
-     * Empty constructor.
-     */
-    public Affiliation() {
-    }
-
     public long getTargetProfileId() {
         return targetProfileId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -48,46 +48,46 @@ public class Affiliation extends IdentifiableEntity {
     private long targetProfileId;
 
     private long targetEntityId;
-    
+
     /**
      * For qualified professionals.
      */
     private QPType qpType;
-    
+
     /**
      * Subtype for mental health professional.
      */
     private String mhpType;
-    
+
     /**
      * Acknowledgement attachment (QP).
      */
     private String acknowledgementAttachmentId;
-    
+
     /**
      * Ended flag.
      */
     private String terminatedInd;
-    
+
     /**
      * End date.
      */
     private Date terminationDate;
 
     private List<License> affiliateLicenses;
-    
+
     private Entity entity;
 
     /**
      * The BGS Study ID for Personal Care Provider Org.
      */
     private String bgsStudyId;
-    
+
     /**
      * The BGS Clearance Date for Personal Care Provide Org.
      */
     private Date bgsClearanceDate;
-    
+
     /**
      * Empty constructor.
      */
@@ -206,19 +206,19 @@ public class Affiliation extends IdentifiableEntity {
         this.mhpType = mhpType;
     }
 
-	public String getBgsStudyId() {
-		return bgsStudyId;
-	}
+    public String getBgsStudyId() {
+        return bgsStudyId;
+    }
 
-	public void setBgsStudyId(String bgsStudyId) {
-		this.bgsStudyId = bgsStudyId;
-	}
+    public void setBgsStudyId(String bgsStudyId) {
+        this.bgsStudyId = bgsStudyId;
+    }
 
-	public Date getBgsClearanceDate() {
-		return bgsClearanceDate;
-	}
+    public Date getBgsClearanceDate() {
+        return bgsClearanceDate;
+    }
 
-	public void setBgsClearanceDate(Date bgsClearanceDate) {
-		this.bgsClearanceDate = bgsClearanceDate;
-	}
+    public void setBgsClearanceDate(Date bgsClearanceDate) {
+        this.bgsClearanceDate = bgsClearanceDate;
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
@@ -20,9 +20,6 @@ import java.util.List;
 
 /**
  * Represents group/member affiliation.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class Affiliation extends IdentifiableEntity {
 
@@ -46,19 +43,10 @@ public class Affiliation extends IdentifiableEntity {
      */
     private long ticketId;
 
-    /**
-     * Effective date.
-     */
     private Date effectiveDate;
 
-    /**
-     * Target profile.
-     */
     private long targetProfileId;
 
-    /**
-     * Target entity.
-     */
     private long targetEntityId;
     
     /**
@@ -86,14 +74,8 @@ public class Affiliation extends IdentifiableEntity {
      */
     private Date terminationDate;
 
-    /**
-     * Affiliates licenses.
-     */
     private List<License> affiliateLicenses;
     
-    /**
-     * The entity.
-     */
     private Entity entity;
 
     /**
@@ -112,274 +94,130 @@ public class Affiliation extends IdentifiableEntity {
     public Affiliation() {
     }
 
-    /**
-     * Gets the value of the field <code>targetProfileId</code>.
-     *
-     * @return the targetProfileId
-     */
     public long getTargetProfileId() {
         return targetProfileId;
     }
 
-    /**
-     * Sets the value of the field <code>targetProfileId</code>.
-     *
-     * @param targetProfileId the targetProfileId to set
-     */
     public void setTargetProfileId(long targetProfileId) {
         this.targetProfileId = targetProfileId;
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>targetEntityId</code>.
-     *
-     * @return the targetEntityId
-     */
     public long getTargetEntityId() {
         return targetEntityId;
     }
 
-    /**
-     * Sets the value of the field <code>targetEntityId</code>.
-     *
-     * @param targetEntityId the targetEntityId to set
-     */
     public void setTargetEntityId(long targetEntityId) {
         this.targetEntityId = targetEntityId;
     }
 
-    /**
-     * Gets the value of the field <code>entity</code>.
-     *
-     * @return the entity
-     */
     public Entity getEntity() {
         return entity;
     }
 
-    /**
-     * Sets the value of the field <code>entity</code>.
-     *
-     * @param entity the entity to set
-     */
     public void setEntity(Entity entity) {
         this.entity = entity;
     }
 
-    /**
-     * Gets the value of the field <code>primaryInd</code>.
-     *
-     * @return the primaryInd
-     */
     public String getPrimaryInd() {
         return primaryInd;
     }
 
-    /**
-     * Sets the value of the field <code>primaryInd</code>.
-     *
-     * @param primaryInd the primaryInd to set
-     */
     public void setPrimaryInd(String primaryInd) {
         this.primaryInd = primaryInd;
     }
 
-    /**
-     * Gets the value of the field <code>effectiveDate</code>.
-     *
-     * @return the effectiveDate
-     */
     public Date getEffectiveDate() {
         return effectiveDate;
     }
 
-    /**
-     * Sets the value of the field <code>effectiveDate</code>.
-     *
-     * @param effectiveDate the effectiveDate to set
-     */
     public void setEffectiveDate(Date effectiveDate) {
         this.effectiveDate = effectiveDate;
     }
 
-    /**
-     * Gets the value of the field <code>objectType</code>.
-     *
-     * @return the objectType
-     */
     public String getObjectType() {
         return objectType;
     }
 
-    /**
-     * Sets the value of the field <code>objectType</code>.
-     *
-     * @param objectType the objectType to set
-     */
     public void setObjectType(String objectType) {
         this.objectType = objectType;
     }
 
-    /**
-     * Gets the value of the field <code>qpType</code>.
-     * @return the qpType
-     */
     public QPType getQpType() {
         return qpType;
     }
 
-    /**
-     * Sets the value of the field <code>qpType</code>.
-     * @param qpType the qpType to set
-     */
     public void setQpType(QPType qpType) {
         this.qpType = qpType;
     }
 
-    /**
-     * Gets the value of the field <code>acknowledgementAttachmentId</code>.
-     * @return the acknowledgementAttachmentId
-     */
     public String getAcknowledgementAttachmentId() {
         return acknowledgementAttachmentId;
     }
 
-    /**
-     * Sets the value of the field <code>acknowledgementAttachmentId</code>.
-     * @param acknowledgementAttachmentId the acknowledgementAttachmentId to set
-     */
     public void setAcknowledgementAttachmentId(String acknowledgementAttachmentId) {
         this.acknowledgementAttachmentId = acknowledgementAttachmentId;
     }
 
-    /**
-     * Gets the value of the field <code>terminatedInd</code>.
-     * @return the terminatedInd
-     */
     public String getTerminatedInd() {
         return terminatedInd;
     }
 
-    /**
-     * Sets the value of the field <code>terminatedInd</code>.
-     * @param terminatedInd the terminatedInd to set
-     */
     public void setTerminatedInd(String terminatedInd) {
         this.terminatedInd = terminatedInd;
     }
 
-    /**
-     * Gets the value of the field <code>terminationDate</code>.
-     * @return the terminationDate
-     */
     public Date getTerminationDate() {
         return terminationDate;
     }
 
-    /**
-     * Sets the value of the field <code>terminationDate</code>.
-     * @param terminationDate the terminationDate to set
-     */
     public void setTerminationDate(Date terminationDate) {
         this.terminationDate = terminationDate;
     }
 
-    /**
-     * Gets the value of the field <code>affiliateLicenses</code>.
-     * @return the affiliateLicenses
-     */
     public List<License> getAffiliateLicenses() {
         return affiliateLicenses;
     }
 
-    /**
-     * Sets the value of the field <code>affiliateLicenses</code>.
-     * @param affiliateLicenses the affiliateLicenses to set
-     */
     public void setAffiliateLicenses(List<License> affiliateLicenses) {
         this.affiliateLicenses = affiliateLicenses;
     }
 
-    /**
-     * Gets the <code>mhpType</code>.
-     * @return the mhpType
-     */
     public String getMhpType() {
         return mhpType;
     }
 
-    /**
-     * Sets the <code>mhpType</code>.
-     * @param mhpType the mhpType to set
-     */
     public void setMhpType(String mhpType) {
         this.mhpType = mhpType;
     }
 
-    /**
-     * Gets the <code>bgsStudyId</code>.
-     * @return the bgsStudyId
-     */
 	public String getBgsStudyId() {
 		return bgsStudyId;
 	}
 
-	/**
-     * Sets the <code>bgsStudyId</code>.
-     * @param mhpType the bgsStudyId to set
-     */
 	public void setBgsStudyId(String bgsStudyId) {
 		this.bgsStudyId = bgsStudyId;
 	}
 
-	/**
-     * Gets the <code>bgsClearanceDate</code>.
-     * @return the bgsClearanceDate
-     */
 	public Date getBgsClearanceDate() {
 		return bgsClearanceDate;
 	}
 
-	/**
-     * Sets the <code>bgsClearanceDate</code>.
-     * @param mhpType the bgsClearanceDate to set
-     */
 	public void setBgsClearanceDate(Date bgsClearanceDate) {
 		this.bgsClearanceDate = bgsClearanceDate;
 	}

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
@@ -15,78 +15,118 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
 /**
  * Represents group/member affiliation.
  */
-public class Affiliation extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "affiliations")
+public class Affiliation implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "affiliation_id")
+    private long id;
 
     /**
      * Primary indicator.
      */
+    @Column(name = "is_primary")
     private String primaryInd;
 
     /**
      * Owning profile id.
      */
+    @Column(name = "profile_id")
     private long profileId;
 
     /**
      * Additional location, member, etc.
      */
+    @Column(name = "object_type")
     private String objectType;
 
     /**
      * Owning ticket id.
      */
+    @Column(name = "ticket_id")
     private long ticketId;
 
+    @Column(name = "effective_at")
     private Date effectiveDate;
 
+    @Column(name = "target_profile_id")
     private long targetProfileId;
 
+    @Column(name = "target_entity_id")
     private long targetEntityId;
 
     /**
      * For qualified professionals.
      */
+    @ManyToOne
+    @JoinColumn(name = "qualified_professional_type_code")
     private QPType qpType;
 
     /**
      * Subtype for mental health professional.
      */
+    @Column(name = "mental_health_professional_type")
     private String mhpType;
 
     /**
      * Acknowledgement attachment (QP).
      */
+    @Column(name = "acknowledgement_attachment_id")
     private String acknowledgementAttachmentId;
 
     /**
      * Ended flag.
      */
+    @Column(name = "is_terminated")
     private String terminatedInd;
 
     /**
      * End date.
      */
+    @Column(name = "terminated_at")
     private Date terminationDate;
 
+    @Transient
     private List<License> affiliateLicenses;
 
+    @Transient
     private Entity entity;
 
     /**
      * The BGS Study ID for Personal Care Provider Org.
      */
+    @Column(name = "bgs_study_id")
     private String bgsStudyId;
 
     /**
      * The BGS Clearance Date for Personal Care Provide Org.
      */
+    @Column(name = "bgs_clearance_date")
     private Date bgsClearanceDate;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public long getTargetProfileId() {
         return targetProfileId;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -23,11 +23,6 @@ package gov.medicaid.services.util;
  */
 public class Sequences {
     /**
-     * Used for provider group association table.
-     */
-    public static final String PROV_GRP_SEQ = "PROV_GRP_SEQ";
-
-    /**
      * Used for provider statement table.
      */
     public static final String STATEMENT_ID = "STATEMENT_ID";


### PR DESCRIPTION
Remove redundant comments, clean up whitespace, and remove empty constructor; rename the table, rename some columns, use Hibernate to generate IDs.

I'm a little worried about the `@Transient` `affiliateLicenses` and `entity`, but if they're broken it's not clear to me how they ever worked - the old schema definitely doesn't have them, either in `Medicaid.hbm.xml` or in the Oracle instance.

Issue #36 Use Hibernate 5, instead of 4