### PR TITLE
Fix beneficial owner types data

### DIFF
--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -459,14 +459,14 @@ CREATE TABLE beneficial_owner_types(
   description TEXT UNIQUE,
   owner_type CHARACTER VARYING(1)
 );
-INSERT INTO beneficial_owner_types (code, description, owner_type) VALUES
-  ('01', 'Non Profit', 'O'),
-  ('02', 'Sole Proprietership', 'O'),
-  ('03', 'Hospital', 'O'),
-  ('04', 'Corporation', 'O'),
-  ('05', 'Partnership', 'O'),
-  ('06', 'State', 'A'),
-  ('07', 'Public', 'P');
+INSERT INTO beneficial_owner_types (code, owner_type, description) VALUES
+  ('01', 'A', 'Subcontractor'),
+  ('02', 'P', 'Managing Employee'),
+  ('03', 'A', 'Owner - 5% or more of Ownership Interest'),
+  ('04', 'P', 'Board Member or Officer'),
+  ('05', 'P', 'Program Manager'),
+  ('06', 'P', 'Managing Director'),
+  ('99', 'A', 'Other');
 
 CREATE TABLE risk_levels(
   code CHARACTER VARYING(2) PRIMARY KEY,


### PR DESCRIPTION
The seed data for beneficial owner types seems to have been taken from the wrong table, which caused the drools validation to fail when creating an organizational provider. Import the correct data for the table from `mpse-clean-setup.sql`.

[Incorrect data](https://github.com/OpenTechStrategies/psm/blob/cf9933ed1230170d33782bb566904edeb47ad649/psm-app/db/seed.sql#L463-L469), introduced in commit 57c365778028c52c774c7ca3e18bd9b0aa33afe8; [source data](https://github.com/OpenTechStrategies/psm/blob/cf9933ed1230170d33782bb566904edeb47ad649/psm-app/db/mpse-clean-setup.sql#L3007-L3013).

Issue #36 Use Hibernate 5, instead of 4