### PR TITLE
Migrated Asset to H5

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -342,29 +342,6 @@
 			<one-to-many class="gov.medicaid.entities.Asset" />
 		</list>
 	</class>
-	<class name="gov.medicaid.entities.Asset" table="OWNER_ASSET">
-		<id column="OWNER_ASSET_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="type">
-			<column name="TYPE" />
-			<type name="org.hibernate.type.EnumType">
-				<param name="type">12</param>
-				<param name="enumClass">gov.medicaid.entities.AssetType</param>
-			</type>
-		</property>
-		<property generated="never" lazy="false" name="name" type="string">
-			<column name="NAME" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.Address" fetch="join"
-			name="location">
-			<column name="ADDRESS_ID" />
-		</many-to-one>
-		<many-to-one class="gov.medicaid.entities.OwnershipType"
-			fetch="join" name="ownershipType">
-			<column name="OWNERSHIP_TYP_CD" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.ProviderTypeSetting" table="PROVIDER_SETTING">
 		<id column="PROVIDER_SETTING_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -44,6 +44,7 @@
     <class>gov.medicaid.entities.AcceptedAgreements</class>
     <class>gov.medicaid.entities.Address</class>
     <class>gov.medicaid.entities.AgreementDocument</class>
+    <class>gov.medicaid.entities.Asset</class>
     <class>gov.medicaid.entities.AuditDetail</class>
     <class>gov.medicaid.entities.AuditRecord</class>
     <class>gov.medicaid.entities.Authentication</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -27,6 +27,7 @@ DROP TABLE IF EXISTS
   license_types,
   licenses,
   organizations,
+  owner_assets,
   ownership_types,
   pay_to_provider_types,
   people,
@@ -459,14 +460,14 @@ CREATE TABLE beneficial_owner_types(
   description TEXT UNIQUE,
   owner_type CHARACTER VARYING(1)
 );
-INSERT INTO beneficial_owner_types (code, description, owner_type) VALUES
-  ('01', 'Non Profit', 'O'),
-  ('02', 'Sole Proprietership', 'O'),
-  ('03', 'Hospital', 'O'),
-  ('04', 'Corporation', 'O'),
-  ('05', 'Partnership', 'O'),
-  ('06', 'State', 'A'),
-  ('07', 'Public', 'P');
+INSERT INTO beneficial_owner_types (code, owner_type, description) VALUES
+  ('01', 'A', 'Subcontractor'),
+  ('02', 'P', 'Managing Employee'),
+  ('03', 'A', 'Owner - 5% or more of Ownership Interest'),
+  ('04', 'P', 'Board Member or Officer'),
+  ('05', 'P', 'Program Manager'),
+  ('06', 'P', 'Managing Director'),
+  ('99', 'A', 'Other');
 
 CREATE TABLE risk_levels(
   code CHARACTER VARYING(2) PRIMARY KEY,
@@ -1080,3 +1081,15 @@ CREATE TABLE licenses(
     REFERENCES specialty_types(code),
   attachment_id BIGINT
 );
+
+CREATE TABLE owner_assets(
+  owner_asset_id BIGINT PRIMARY KEY ,
+  type CHARACTER VARYING(255),
+  name CHARACTER VARYING(255),
+  address_id BIGINT
+    REFERENCES addresses(address_id),
+  ownership_typ_cd CHARACTER VARYING(2)
+    REFERENCES ownership_types(code),
+  ownership_info_id BIGINT,
+  idx INTEGER
+   ) ;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Asset.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Asset.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -15,108 +15,86 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.*;
+import java.io.Serializable;
+
 /**
  * Represents owned assets.
  *
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class Asset extends IdentifiableEntity {
+
+@javax.persistence.Entity
+@Table(name = "owner_assets")
+public class Asset implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "owner_asset_id")
+    private long id;
 
     /**
      * The asset type.
      */
+    @Column(name ="ownership_typ_cd")
     private AssetType type;
 
     /**
      * Asset name.
      */
+    @Column(name = "name")
     private String name;
 
     /**
      * Asset location.
      */
+    @ManyToOne
+    @JoinColumn(name = "address_id")
     private Address location;
 
     /**
      * Ownership type.
      */
+    @ManyToOne
+    @JoinColumn(name = "ownership_typ_cd")
     private OwnershipType ownershipType;
 
-    /**
-     * Empty constructor.
-     */
-    public Asset() {
+    public long getId() {
+        return id;
     }
 
-    /**
-     * Gets the value of the field <code>type</code>.
-     *
-     * @return the type
-     */
+    public void setId(long id) {
+        this.id = id;
+    }
+
     public AssetType getType() {
         return type;
     }
 
-    /**
-     * Sets the value of the field <code>type</code>.
-     *
-     * @param type the type to set
-     */
     public void setType(AssetType type) {
         this.type = type;
     }
 
-    /**
-     * Gets the value of the field <code>name</code>.
-     *
-     * @return the name
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * Sets the value of the field <code>name</code>.
-     *
-     * @param name the name to set
-     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /**
-     * Gets the value of the field <code>location</code>.
-     *
-     * @return the location
-     */
     public Address getLocation() {
         return location;
     }
 
-    /**
-     * Sets the value of the field <code>location</code>.
-     *
-     * @param location the location to set
-     */
     public void setLocation(Address location) {
         this.location = location;
     }
 
-    /**
-     * Gets the value of the field <code>ownershipType</code>.
-     *
-     * @return the ownershipType
-     */
     public OwnershipType getOwnershipType() {
         return ownershipType;
     }
 
-    /**
-     * Sets the value of the field <code>ownershipType</code>.
-     *
-     * @param ownershipType the ownershipType to set
-     */
     public void setOwnershipType(OwnershipType ownershipType) {
         this.ownershipType = ownershipType;
     }


### PR DESCRIPTION
Moved the Asset entity (owner_asset table) to H5.

Removed the base class to give this a recognizable id column. 

Added annotations and removed from medicade.hbn.xml