### PR TITLE
Hibernate-5-ify ProviderStatement

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -919,7 +919,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         insertAffiliations(details, attachmentMapping);
 
         // save statement
-        insertStatement(details, attachmentMapping);
+        insertStatement(details);
 
         // save agreement documents
         insertAgreements(details);
@@ -1063,10 +1063,9 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * Inserts the provider profile statement.
      *
      * @param details the provider profile
-     * @param attachmentMapping the attachment id mapping
      * @throws PortalServiceException for any errors encountered
      */
-    private void insertStatement(ProviderProfile details, Map<Long, Long> attachmentMapping)
+    private void insertStatement(ProviderProfile details)
         throws PortalServiceException {
         ProviderStatement statement = details.getStatement();
         if (statement == null) {
@@ -1075,13 +1074,6 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
 
         statement.setTicketId(details.getTicketId());
         statement.setProfileId(details.getProfileId());
-
-        if (statement.getSignatureAttachmentId() > 0) {
-            if (!attachmentMapping.containsKey(statement.getSignatureAttachmentId())) {
-                throw new PortalServiceException("Signature references an invalid attachment");
-            }
-            statement.setSignatureAttachmentId(attachmentMapping.get(statement.getSignatureAttachmentId()));
-        }
 
         statement.setId(getSequence().getNextValue(Sequences.STATEMENT_ID));
         getEm().persist(statement);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1075,7 +1075,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         statement.setTicketId(details.getTicketId());
         statement.setProfileId(details.getProfileId());
 
-        statement.setId(getSequence().getNextValue(Sequences.STATEMENT_ID));
+        statement.setId(0);
         getEm().persist(statement);
     }
 

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -73,25 +73,6 @@
 			<column name="STATUS" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.ProviderStatement" table="PROVIDER_STATEMENT">
-		<id column="PROVIDER_STATEMENT_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILEID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKETID" />
-		</property>
-		<property column="NAME" generated="never" lazy="false"
-			length="45" name="name" type="string" />
-		<property column="TITLE" generated="never" lazy="false"
-			length="45" name="title" type="string" />
-		<property column="STATEMENT_DT" generated="never" lazy="false"
-			name="date" type="date" />
-	</class>
 	<class name="gov.medicaid.entities.Note" table="PROFILE_NOTES">
 		<id column="PROVIDER_NOTE_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -91,8 +91,6 @@
 			length="45" name="title" type="string" />
 		<property column="STATEMENT_DT" generated="never" lazy="false"
 			name="date" type="date" />
-		<property column="SIGN_ATTACHEMENT_ID" generated="never"
-			lazy="false" name="signatureAttachmentId" not-null="true" type="long" />
 	</class>
 	<class name="gov.medicaid.entities.Note" table="PROFILE_NOTES">
 		<id column="PROVIDER_NOTE_ID" name="id" type="long">

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -76,6 +76,7 @@
     <class>gov.medicaid.entities.PersonBeneficialOwner</class>
     <class>gov.medicaid.entities.ProfileStatus</class>
     <class>gov.medicaid.entities.ProviderProfile</class>
+    <class>gov.medicaid.entities.ProviderStatement</class>
     <class>gov.medicaid.entities.ProviderType</class>
     <class>gov.medicaid.entities.QPType</class>
     <class>gov.medicaid.entities.RelationshipType</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -36,6 +36,7 @@ DROP TABLE IF EXISTS
   persistent_logins,
   profile_statuses,
   provider_profiles,
+  provider_statements,
   provider_type_agreement_documents,
   provider_type_license_types,
   provider_types,
@@ -1140,3 +1141,12 @@ CREATE TABLE owner_assets(
     REFERENCES addresses(address_id),
   ownership_info_id BIGINT
 ) ;
+
+CREATE TABLE provider_statements(
+  provider_statement_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  name TEXT,
+  title TEXT,
+  "date" DATE
+);

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -15,15 +15,29 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.Date;
 
-public class ProviderStatement extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "provider_statements")
+public class ProviderStatement implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "provider_statement_id")
+    private long id;
 
     /**
      * If enrolled, the profile identifier.
      */
+    @Column(name = "profile_id")
     private long profileId;
 
+    @Column(name = "ticket_id")
     private long ticketId;
 
     private String name;
@@ -31,6 +45,14 @@ public class ProviderStatement extends IdentifiableEntity {
     private String title;
 
     private Date date;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getName() {
         return name;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -17,12 +17,6 @@ package gov.medicaid.entities;
 
 import java.util.Date;
 
-/**
- * Represents a provider statement.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 public class ProviderStatement extends IdentifiableEntity {
 
     /**
@@ -30,19 +24,10 @@ public class ProviderStatement extends IdentifiableEntity {
      */
     private long profileId;
 
-    /**
-     * References the ticket for this request.
-     */
     private long ticketId;
 
-    /**
-     * Statement name.
-     */
     private String name;
 
-    /**
-     * Statement title.
-     */
     private String title;
 
     /**
@@ -50,9 +35,6 @@ public class ProviderStatement extends IdentifiableEntity {
      */
     private long signatureAttachmentId;
 
-    /**
-     * Statement date.
-     */
     private Date date;
 
     /**
@@ -61,110 +43,50 @@ public class ProviderStatement extends IdentifiableEntity {
     public ProviderStatement() {
     }
 
-    /**
-     * Gets the value of the field <code>name</code>.
-     *
-     * @return the name
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * Sets the value of the field <code>name</code>.
-     *
-     * @param name the name to set
-     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /**
-     * Gets the value of the field <code>title</code>.
-     *
-     * @return the title
-     */
     public String getTitle() {
         return title;
     }
 
-    /**
-     * Sets the value of the field <code>title</code>.
-     *
-     * @param title the title to set
-     */
     public void setTitle(String title) {
         this.title = title;
     }
 
-    /**
-     * Gets the value of the field <code>date</code>.
-     *
-     * @return the date
-     */
     public Date getDate() {
         return date;
     }
 
-    /**
-     * Sets the value of the field <code>date</code>.
-     *
-     * @param date the date to set
-     */
     public void setDate(Date date) {
         this.date = date;
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>signatureAttachmentId</code>.
-     *
-     * @return the signatureAttachmentId
-     */
     public long getSignatureAttachmentId() {
         return signatureAttachmentId;
     }
 
-    /**
-     * Sets the value of the field <code>signatureAttachmentId</code>.
-     *
-     * @param signatureAttachmentId the signatureAttachmentId to set
-     */
     public void setSignatureAttachmentId(long signatureAttachmentId) {
         this.signatureAttachmentId = signatureAttachmentId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -37,12 +37,6 @@ public class ProviderStatement extends IdentifiableEntity {
 
     private Date date;
 
-    /**
-     * Default empty constructor.
-     */
-    public ProviderStatement() {
-    }
-
     public String getName() {
         return name;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -30,11 +30,6 @@ public class ProviderStatement extends IdentifiableEntity {
 
     private String title;
 
-    /**
-     * Reference to an attachment with the signature.
-     */
-    private long signatureAttachmentId;
-
     private Date date;
 
     public String getName() {
@@ -75,13 +70,5 @@ public class ProviderStatement extends IdentifiableEntity {
 
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
-    }
-
-    public long getSignatureAttachmentId() {
-        return signatureAttachmentId;
-    }
-
-    public void setSignatureAttachmentId(long signatureAttachmentId) {
-        this.signatureAttachmentId = signatureAttachmentId;
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -23,11 +23,6 @@ package gov.medicaid.services.util;
  */
 public class Sequences {
     /**
-     * Used for provider statement table.
-     */
-    public static final String STATEMENT_ID = "STATEMENT_ID";
-
-    /**
      * Used for notes.
      */
     public static final String NOTES_SEQ = "NOTES_SEQ";


### PR DESCRIPTION
Remove redundant comments, empty constructor, trailing whitespace, and unused `signature field` from `ProviderStatement`. Rename the table, rename some columns, and use Hibernate to generate IDs.

Issue #36 Use Hibernate 5, instead of 4