### PR TITLE
Fix lazy initialization bug with agreement docs & organizations

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -29,7 +29,6 @@ import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.ProviderStatement;
-import gov.medicaid.entities.ProviderType;
 import gov.medicaid.entities.dto.FormError;
 
 import java.util.ArrayList;
@@ -97,8 +96,9 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
             exceptions.add(e);
         }
 
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> docs = pt.getAgreementDocuments();
+        List<AgreementDocument> docs = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        ).getAgreementDocuments();
 
         List<ProviderAgreementType> xList = new ArrayList<ProviderAgreementType>();
         HashSet<String> agreed = new HashSet<String>();
@@ -149,8 +149,9 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
 
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> docs = pt.getAgreementDocuments();
+        List<AgreementDocument> docs = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        ).getAgreementDocuments();
 
         if (enrollment.getRequestType() == RequestType.RENEWAL && "Y".equals(provider.getRenewalShowBlankStatement())) {
             attr(mv, "renewalBlankInit", "YY");
@@ -259,8 +260,9 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
         List<AcceptedAgreements> hList = profile.getAgreements();
 
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> activeList = pt.getAgreementDocuments();
+        List<AgreementDocument> activeList = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        ).getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         // Retain any previously accepted agreements that is no longer shown in the page
@@ -363,8 +365,9 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         ProviderProfile profile = ticket.getDetails();
 
-        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-        List<AgreementDocument> activeList = pt.getAgreementDocuments();
+        List<AgreementDocument> activeList = getLookupService().getProviderTypeWithAgreementDocuments(
+                provider
+        ).getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         AcceptedAgreementsType acceptedAgreements = XMLUtility.nsGetAcceptedAgreements(enrollment);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -149,10 +149,12 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
 
+        ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
+        List<AgreementDocument> docs = pt.getAgreementDocuments();
+
         if (enrollment.getRequestType() == RequestType.RENEWAL && "Y".equals(provider.getRenewalShowBlankStatement())) {
             attr(mv, "renewalBlankInit", "YY");
-            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-            List<AgreementDocument> docs = pt.getAgreementDocuments();
+
             int i = 0;
             for (AgreementDocument doc : docs) {
                 attr(mv, "documentId", i, "" + doc.getId());
@@ -170,8 +172,6 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
             AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
 
-            ProviderType pt = getLookupService().findLookupByDescription(ProviderType.class, provider.getProviderType());
-            List<AgreementDocument> docs = pt.getAgreementDocuments();
             int i = 0;
             for (AgreementDocument doc : docs) {
                 attr(mv, "documentId", i, "" + doc.getId());


### PR DESCRIPTION
This is nearly identical to #110 Fix lazy initialization bug with agreement docs, because the code seems to be suspiciously similar.

The downside to copy-pasted code is you have to fix the same bug in multiple places. The upside to copy-pasted bugs is the fix is easy to deploy in multiple places.

We should, at some point, come back and refactor this duplicated code out into a helper method used by both `IndividualDisclosureFormBinder` and `OrganizationStatementFormBinder`, and look for copies of this code everywhere else, too, but sadly now is not the time for that.

Issue #36 Use Hibernate 5, instead of 4