### PR TITLE
Set external sources URL to example domain

### DIFF
--- a/psm-app/services/src/main/resources/cms.properties
+++ b/psm-app/services/src/main/resources/cms.properties
@@ -241,7 +241,8 @@ ldap.groupSearchFilter=(uniqueMember={0})
 display.notifications.max=5
 
 # external sources integration
-extsources.TEST.base=http://50.16.65.237:9080
+extsources.TEST.base=http://test.example.com
+extsources.PROD.base=http://prod.example.com
 
 # use guvnor or embedded rules (no spaces please) Y/N
 rules.embedded=Y


### PR DESCRIPTION
We've removed the source code to the external sources app, but there are still references in the software. This one was pointing at an AWS IP address; for now, redirect it to `example.com`. We'll need to remove this when we remove the code that uses it.

Issue #11 Separate ext-srcs from main application