### PR TITLE
Migrated OwnershipInfo to H5

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -991,7 +991,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         ownership.setProfileId(details.getProfileId());
         ownership.setTicketId(details.getTicketId());
 
-        ownership.setId(getSequence().getNextValue(Sequences.OWNERSHIP_SEQ));
+        ownership.setId(0);
         // save owners
         insertBeneficialOwners(ownership);
 
@@ -2466,7 +2466,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             } else {
                 ownership.setProfileId(profileId);
                 ownership.setTicketId(ticketId);
-                ownership.setId(getSequence().getNextValue(Sequences.OWNERSHIP_SEQ));
+                ownership.setId(0);
                 insertBeneficialOwners(ownership);
                 getEm().persist(ownership);
             }

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -138,45 +138,6 @@
 			<column name="EXTERNAL_PROFILE_ID" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.OwnershipInformation" table="OWNERSHIP_INFO">
-		<id column="OWNERSHIP_INFO_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKET_ID" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.EntityStructureType"
-			fetch="join" name="entityType">
-			<column name="ENTITY_TYP_CD" />
-		</many-to-one>
-		<many-to-one class="gov.medicaid.entities.EntityStructureType"
-			fetch="join" name="entitySubType">
-			<column name="ENTITY_SUBTYP_CD" />
-		</many-to-one>
-		<property generated="never" lazy="false" name="otherEntityTypeDesc"
-			type="string">
-			<column name="OTH_ENTITY_TYP_DESC" />
-		</property>
-		<list name="beneficialOwners" table="BENEFICIAL_OWNER">
-			<key>
-				<column name="OWNERSHIP_INFO_ID" />
-			</key>
-			<list-index base="0" />
-			<one-to-many class="gov.medicaid.entities.BeneficialOwner" />
-		</list>
-		<list name="assets" table="ASSET">
-			<key>
-				<column name="OWNERSHIP_INFO_ID" />
-			</key>
-			<list-index base="0" />
-			<one-to-many class="gov.medicaid.entities.Asset" />
-		</list>
-	</class>
 	<class name="gov.medicaid.entities.ProviderTypeSetting" table="PROVIDER_SETTING">
 		<id column="PROVIDER_SETTING_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -70,6 +70,7 @@
     <class>gov.medicaid.entities.LicenseType</class>
     <class>gov.medicaid.entities.Organization</class>
     <class>gov.medicaid.entities.OrganizationBeneficialOwner</class>
+    <class>gov.medicaid.entities.OwnershipInformation</class>
     <class>gov.medicaid.entities.OwnershipType</class>
     <class>gov.medicaid.entities.PayToProviderType</class>
     <class>gov.medicaid.entities.Person</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -30,6 +30,7 @@ DROP TABLE IF EXISTS
   licenses,
   organizations,
   owner_assets,
+  ownership_info,
   ownership_types,
   pay_to_provider_types,
   people,
@@ -1106,6 +1107,17 @@ CREATE TABLE affiliations(
   bgs_clearance_date DATE
 );
 
+CREATE TABLE ownership_info (
+  ownership_info_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  entity_structure_type_code CHARACTER VARYING(2)
+    REFERENCES entity_structure_types(code),
+  entity_structure_subtype_code CHARACTER VARYING(2)
+    REFERENCES entity_structure_types(code),
+  other_entity_type_desc TEXT
+);
+
 CREATE TABLE beneficial_owner (
   beneficial_owner_id       BIGINT PRIMARY KEY,
   person_ind                CHARACTER VARYING(1),
@@ -1129,7 +1141,8 @@ CREATE TABLE beneficial_owner (
   hired_at                  DATE,
   relationship_type_code    CHARACTER VARYING(2)
     REFERENCES relationship_types (code),
-  ownership_info_id         BIGINT,
+  ownership_info_id         BIGINT
+    REFERENCES ownership_info(ownership_info_id),
   fein                      CHARACTER VARYING(20),
   legal_name                TEXT
 );
@@ -1142,6 +1155,7 @@ CREATE TABLE owner_assets(
   address_id BIGINT
     REFERENCES addresses(address_id),
   ownership_info_id BIGINT
+    REFERENCES ownership_info(ownership_info_id)
 ) ;
 
 CREATE TABLE provider_statements(
@@ -1152,3 +1166,6 @@ CREATE TABLE provider_statements(
   title TEXT,
   "date" DATE
 );
+
+
+

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
@@ -94,7 +94,6 @@ public abstract class BeneficialOwner implements Serializable {
     @JoinColumn(name = "oth_provider_address_id")
     private Address otherProviderAddress;
 
-
     public long getId() {
         return id;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -15,55 +15,71 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.*;
+import java.io.Serializable;
 import java.util.List;
 
-/**
- * Ownership information.
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class OwnershipInformation extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "ownership_info")
+public class OwnershipInformation implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "ownership_info_id")
+    private long id;
 
     /**
      * If enrolled, the profile identifier.
      */
+    @Column(name = "profile_id")
     private long profileId;
 
     /**
      * References the ticket for this request.
      */
+    @Column(name= "ticket_id")
     private long ticketId;
 
     /**
      * Type of entity for disclosure.
      */
+    @ManyToOne
+    @JoinColumn(name = "entity_structure_type_code")
     private EntityStructureType entityType;
 
     /**
      * Type of entity for disclosure.
      */
+    @ManyToOne
+    @JoinColumn(name = "entity_structure_subtype_code")
     private EntityStructureType entitySubType;
 
     /**
      * If type is OTHER, specify here.
      */
+    @Column(name = "other_entity_type_desc")
     private String otherEntityTypeDesc;
 
     /**
      * Beneficial owners.
      */
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "ownership_info_id", referencedColumnName = "ownership_info_id")
     private List<BeneficialOwner> beneficialOwners;
 
     /**
-     * Disclosed property ownership.
+     * Owned Assets
      */
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "ownership_info_id", referencedColumnName = "ownership_info_id")
     private List<Asset> assets;
 
-    /**
-     * Ownership information records.
-     */
-    public OwnershipInformation() {
 
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -38,11 +38,6 @@ public class Sequences {
     public static final String ACOUNT_LINK_SEQ = "ACOUNT_LINK_SEQ";
 
     /**
-     * Ownership information.
-     */
-    public static final String OWNERSHIP_SEQ = "OWNERSHIP_SEQ";
-    
-    /**
      * External profile link.
      */
     public static final String EXT_PROF_LINK_SEQ = "EXT_PROF_LINK_SEQ";


### PR DESCRIPTION
The ownershipInfo entity has one to many relationships with Asset and BeneficialOwner

In this change I changed the baseclass of OwnershipInfo to make the id more readable.

Had to change Asset and BeneficialOwner classes to reflect their manyToOne side of the relation.

Created a new table ins seed.sql

Eliminated the explicit Sequence