### PR TITLE
Allow Optometrist enrollment

### DIFF
--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -563,7 +563,7 @@ INSERT INTO license_types (code, description) VALUES
   ('L0', 'Marriage And Family Therapist'),
   ('L1', 'Audiologist License'),
   ('L2', 'Registration with the Department Of Health'),
-  ('L3', 'Optometrist License'),
+  ('L3', 'Optometrist'),
   ('L4', 'Registered Nurse'),
   ('L5', 'PCA Training Certificate'),
   ('L6', 'Traditional Midwife'),


### PR DESCRIPTION
The name of the license for optometrists did not match between the database and the [XML](https://github.com/OpenTechStrategies/psm/blob/1eb266646234131693d9e7ea886e8e79a68bf7ff/psm-app/cms-business-model/src/main/resources/Entities.xsd#L761), as [the rules required](https://github.com/OpenTechStrategies/psm/blob/1eb266646234131693d9e7ea886e8e79a68bf7ff/psm-app/cms-business-process/src/main/resources/cms.validation.drl#L14054). Update the database to match the XML.

Bug found by @brainwane yesterday. We should probably do a comprehensive review of license names & rules to ensure there are no further instances of this class of bug.