### PR TITLE
Made Asset no longer Eager to avoid Hibernate error

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
@@ -69,7 +69,7 @@ public class OwnershipInformation implements Serializable {
     /**
      * Owned Assets
      */
-    @OneToMany(fetch = FetchType.EAGER)
+    @OneToMany
     @JoinColumn(name = "ownership_info_id", referencedColumnName = "ownership_info_id")
     private List<Asset> assets;
 


### PR DESCRIPTION
Making both BeneficialOwner and Asset eager joins caused an exception in Wildfly. It looks like only one of them can be eager, but more research is needed.

For now we don't know what Asset is used for and so reverting it to lazy.
