### PR TITLE
Migrated Note to H5

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2015,7 +2015,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         n.setText(text);
         n.setCreatedBy(user.getUserId());
         n.setCreatedOn(Calendar.getInstance().getTime());
-        n.setId(getSequence().getNextValue(Sequences.NOTES_SEQ));
+        n.setId(0);
         getEm().persist(n);
     }
 

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -73,30 +73,6 @@
 			<column name="STATUS" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.Note" table="PROFILE_NOTES">
-		<id column="PROVIDER_NOTE_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKET_ID" />
-		</property>
-		<property generated="never" lazy="false" name="text" type="string">
-			<column name="NOTE_TXT" />
-		</property>
-		<property generated="never" lazy="false" name="createdBy"
-			type="string">
-			<column name="CREATED_BY" />
-		</property>
-		<property generated="never" lazy="false" name="createdOn"
-			type="date">
-			<column name="CREATE_TS" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.ExternalAccountLink" table="EXTERNAL_ACCOUNT_LINK">
 		<id name="id" type="long">
 			<column name="EXTERNAL_ACCOUNT_LINK_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -68,6 +68,7 @@
     <class>gov.medicaid.entities.License</class>
     <class>gov.medicaid.entities.LicenseStatus</class>
     <class>gov.medicaid.entities.LicenseType</class>
+    <class>gov.medicaid.entities.Note</class>
     <class>gov.medicaid.entities.Organization</class>
     <class>gov.medicaid.entities.OrganizationBeneficialOwner</class>
     <class>gov.medicaid.entities.OwnershipInformation</class>

--- a/psm-app/db/legacy_seed.sql
+++ b/psm-app/db/legacy_seed.sql
@@ -41,7 +41,6 @@ DROP TABLE  IF EXISTS
   processinstanceinfo,
   profile_assured_ext_svcs,
   profile_assured_svc_xref,
-  profile_notes,
   profile_payto_xref,
   provider_cos,
   provider_cos_xref,
@@ -416,19 +415,6 @@ create table profile_assured_svc_xref
 alter table profile_assured_ext_svcs
 	add constraint fknpq45dvbn0v9qxjrp3ccs81uy
 		foreign key (profile_assured_svc_id) references profile_assured_svc_xref
-;
-
-create table profile_notes
-(
-	provider_note_id bigint not null
-		constraint profile_notes_pkey
-			primary key,
-	profile_id bigint,
-	ticket_id bigint,
-	note_txt varchar(255),
-	created_by varchar(255),
-	create_ts date
-)
 ;
 
 create table profile_payto_xref

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -28,6 +28,7 @@ DROP TABLE IF EXISTS
   license_statuses,
   license_types,
   licenses,
+  notes,
   organizations,
   owner_assets,
   ownership_info,
@@ -1167,5 +1168,12 @@ CREATE TABLE provider_statements(
   "date" DATE
 );
 
-
+CREATE TABLE notes(
+  note_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  note_text TEXT,
+  created_by TEXT,
+  created_at TIMESTAMP WITH TIME ZONE
+);
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -17,132 +17,94 @@ package gov.medicaid.entities;
 
 import java.util.Date;
 
-/**
- * Represents an address.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
-public class Note extends IdentifiableEntity {
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.List;
+
+@javax.persistence.Entity
+@Table(name = "notes")
+public class Note implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "note_id")
+    private long id;
 
     /**
      * The owner profile.
      */
+    @Column(name = "profile_id")
     private long profileId;
 
     /**
      * The owner ticket.
      */
+    @Column(name = "ticket_id")
     private long ticketId;
 
     /**
      * Note contents.
      */
+    @Column(name = "note_text")
     private String text;
 
     /**
      * Creator.
      */
+    @Column(name = "created_by")
     private String createdBy;
 
     /**
      * Timestamp.
      */
+    @Column(name = "created_at")
     private Date createdOn;
 
-    /**
-     * Empty constructor.
-     */
-    public Note() {
-    }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>text</code>.
-     *
-     * @return the text
-     */
     public String getText() {
         return text;
     }
 
-    /**
-     * Sets the value of the field <code>text</code>.
-     *
-     * @param text the text to set
-     */
     public void setText(String text) {
         this.text = text;
     }
 
-    /**
-     * Gets the value of the field <code>createdBy</code>.
-     *
-     * @return the createdBy
-     */
     public String getCreatedBy() {
         return createdBy;
     }
 
-    /**
-     * Sets the value of the field <code>createdBy</code>.
-     *
-     * @param createdBy the createdBy to set
-     */
     public void setCreatedBy(String createdBy) {
         this.createdBy = createdBy;
     }
 
-    /**
-     * Gets the value of the field <code>createdOn</code>.
-     *
-     * @return the createdOn
-     */
     public Date getCreatedOn() {
         return createdOn;
     }
 
-    /**
-     * Sets the value of the field <code>createdOn</code>.
-     *
-     * @param createdOn the createdOn to set
-     */
     public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -23,11 +23,6 @@ package gov.medicaid.services.util;
  */
 public class Sequences {
     /**
-     * Used for notes.
-     */
-    public static final String NOTES_SEQ = "NOTES_SEQ";
-
-    /**
      * Used for each new provider enrollment.
      */
     public static final String PROVIDER_NUMBER_SEQ = "PROVIDER_NUMBER_SEQ";


### PR DESCRIPTION
Migrated the Note entity to H5.

Removed old table from `legacy_seed.sql` and renamed it in the process to `notes`

