### PR TITLE
36 convert pay to provider h5

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -972,7 +972,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         for (PayToProvider payToProvider : payToProviders) {
             payToProvider.setProfileId(details.getProfileId());
             payToProvider.setTicketId(details.getTicketId());
-            payToProvider.setId(getSequence().getNextValue(Sequences.PAY_TO_SEQ));
+            payToProvider.setId(0);
             getEm().persist(payToProvider);
         }
     }

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -2,45 +2,6 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                    "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-lazy="false">
-	<class name="gov.medicaid.entities.PayToProvider" table="PROFILE_PAYTO_XREF">
-		<id name="id" type="long">
-			<column name="PROFILE_PAYTO_XREF_ID" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="effectiveDate"
-			type="date">
-			<column name="EFF_DT" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.PayToProviderType"
-			name="type">
-			<column name="PAYTO_TYP_CD" />
-		</many-to-one>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column name="TICKET_ID" />
-		</property>
-		<property generated="never" lazy="false" name="targetProfileId"
-			type="long">
-			<column name="TARGET_PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="name" type="string">
-			<column name="NAME" />
-		</property>
-		<property generated="never" lazy="false" name="contactName"
-			type="string">
-			<column name="CONTACT_NAME" />
-		</property>
-		<property generated="never" lazy="false" name="npi" type="string">
-			<column name="NPI" />
-		</property>
-		<property generated="never" lazy="false" name="phone" type="string">
-			<column name="PHONE_NUMBER" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.AssuredService" table="PROFILE_ASSURED_SVC_XREF">
 		<id name="id" type="long">
 			<column name="PROFILE_ASSURED_SVC_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -73,6 +73,7 @@
     <class>gov.medicaid.entities.OrganizationBeneficialOwner</class>
     <class>gov.medicaid.entities.OwnershipInformation</class>
     <class>gov.medicaid.entities.OwnershipType</class>
+    <class>gov.medicaid.entities.PayToProvider</class>
     <class>gov.medicaid.entities.PayToProviderType</class>
     <class>gov.medicaid.entities.Person</class>
     <class>gov.medicaid.entities.PersonBeneficialOwner</class>

--- a/psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature
+++ b/psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature
@@ -1,6 +1,6 @@
 Feature: Create a new enrollment
-  We should put here some text on why a user would want to
-  create a new enrollment
+  A provider wishes to create an enrollment so they can be reimbursed for the
+  work they do serving Medicaid patients.
 
   Scenario: Should save a draft after entering data on the
   "organizational information" page
@@ -11,6 +11,6 @@ Feature: Create a new enrollment
       And: I click "Next"
       And: I enter data into all of the required fields
       And: I click "Next"
-    When: I click on "Save as Draft"
-    Then: I should see a success page
-    
+     When: I click on "Save as Draft"
+     Then: I should see a success page
+

--- a/psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature
+++ b/psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature
@@ -1,0 +1,16 @@
+Feature: Create a new enrollment
+  We should put here some text on why a user would want to
+  create a new enrollment
+
+  Scenario: Should save a draft after entering data on the
+  "organizational information" page
+    Given: The database is fresh from seed.sql
+      And: I am logged into the application as a provider
+      And: I click on "Create new enrollment"
+      And: I select "Dental Clinic" as provider type
+      And: I click "Next"
+      And: I enter data into all of the required fields
+      And: I click "Next"
+    When: I click on "Save as Draft"
+    Then: I should see a success page
+    

--- a/psm-app/db/legacy_seed.sql
+++ b/psm-app/db/legacy_seed.sql
@@ -5,7 +5,6 @@ DROP TABLE IF EXISTS
   legacy_mapping,
   profile_assured_ext_svcs,
   profile_assured_svc_xref,
-  profile_payto_xref,
   provider_cos,
   provider_cos_xref,
   provider_setting,
@@ -83,23 +82,6 @@ create table profile_assured_svc_xref
 alter table profile_assured_ext_svcs
 	add constraint fknpq45dvbn0v9qxjrp3ccs81uy
 		foreign key (profile_assured_svc_id) references profile_assured_svc_xref
-;
-
-create table profile_payto_xref
-(
-	profile_payto_xref_id bigint not null
-		constraint profile_payto_xref_pkey
-			primary key,
-	eff_dt date,
-	payto_typ_cd varchar(255),
-	profile_id bigint,
-	ticket_id bigint,
-	target_profile_id bigint,
-	name varchar(255),
-	contact_name varchar(255),
-	npi varchar(255),
-	phone_number varchar(255)
-)
 ;
 
 create table provider_cos

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -33,6 +33,7 @@ DROP TABLE IF EXISTS
   owner_assets,
   ownership_info,
   ownership_types,
+  pay_to_providers,
   pay_to_provider_types,
   people,
   persistent_logins,
@@ -1177,3 +1178,16 @@ CREATE TABLE notes(
   created_at TIMESTAMP WITH TIME ZONE
 );
 
+CREATE TABLE pay_to_providers(
+  pay_to_providers_id  BIGINT PRIMARY KEY,
+  effective_date DATE,
+  pay_to_type_code CHARACTER VARYING(2)
+    REFERENCES pay_to_provider_types(code),
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  target_profile_id BIGINT,
+  name TEXT,
+  contact_name TEXT,
+  npi TEXT,
+  phone TEXT
+);

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -23,198 +23,137 @@ import java.util.Date;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class PayToProvider extends IdentifiableEntity {
+import javax.persistence.*;
+import java.io.Serializable;
+
+@javax.persistence.Entity
+@Table(name = "pay_to_providers")
+public class PayToProvider implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "pay_to_providers_id")
+    private long id;
 
     /**
      * The owning profile id.
      */
+    @Column(name = "profile_id")
     private long profileId;
 
     /**
      * The owning ticket id.
      */
+    @Column(name = "ticket_id")
     private long ticketId;
 
     /**
      * The effective date.
      */
+    @Column(name = "effective_date")
     private Date effectiveDate;
 
     /**
      * The pay-to provider type.
      */
+    @ManyToOne
+    @JoinColumn(name = "pay_to_type_code")
     private PayToProviderType type;
 
     /**
      * The target profile id.
      */
+    @Column(name = "target_profile_id")
     private long targetProfileId;
-    
+
+    @Column(name = "contact_name")
     private String contactName;
-    
+
+    @Column
     private String name;
-    
+
+    @Column
     private String phone;
-    
+
+    @Column
     private String npi;
 
-    /**
-     * Empty constructor.
-     */
-    public PayToProvider() {
-    }
-
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     *
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     *
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     *
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     *
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }
 
-    /**
-     * Gets the value of the field <code>effectiveDate</code>.
-     *
-     * @return the effectiveDate
-     */
     public Date getEffectiveDate() {
         return effectiveDate;
     }
 
-    /**
-     * Sets the value of the field <code>effectiveDate</code>.
-     *
-     * @param effectiveDate the effectiveDate to set
-     */
     public void setEffectiveDate(Date effectiveDate) {
         this.effectiveDate = effectiveDate;
     }
 
-    /**
-     * Gets the value of the field <code>type</code>.
-     *
-     * @return the type
-     */
     public PayToProviderType getType() {
         return type;
     }
 
-    /**
-     * Sets the value of the field <code>type</code>.
-     *
-     * @param type the type to set
-     */
     public void setType(PayToProviderType type) {
         this.type = type;
     }
 
-    /**
-     * Gets the value of the field <code>targetProfileId</code>.
-     *
-     * @return the targetProfileId
-     */
     public long getTargetProfileId() {
         return targetProfileId;
     }
 
-    /**
-     * Sets the value of the field <code>targetProfileId</code>.
-     *
-     * @param targetProfileId the targetProfileId to set
-     */
     public void setTargetProfileId(long targetProfileId) {
         this.targetProfileId = targetProfileId;
     }
 
-    /**
-     * Gets the value of the field <code>contactName</code>.
-     * @return the contactName
-     */
     public String getContactName() {
         return contactName;
     }
 
-    /**
-     * Sets the value of the field <code>contactName</code>.
-     * @param contactName the contactName to set
-     */
     public void setContactName(String contactName) {
         this.contactName = contactName;
     }
 
-    /**
-     * Gets the value of the field <code>name</code>.
-     * @return the name
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * Sets the value of the field <code>name</code>.
-     * @param name the name to set
-     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /**
-     * Gets the value of the field <code>phone</code>.
-     * @return the phone
-     */
     public String getPhone() {
         return phone;
     }
 
-    /**
-     * Sets the value of the field <code>phone</code>.
-     * @param phone the phone to set
-     */
     public void setPhone(String phone) {
         this.phone = phone;
     }
 
-    /**
-     * Gets the value of the field <code>npi</code>.
-     * @return the npi
-     */
     public String getNpi() {
         return npi;
     }
 
-    /**
-     * Sets the value of the field <code>npi</code>.
-     * @param npi the npi to set
-     */
     public void setNpi(String npi) {
         this.npi = npi;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -47,8 +47,6 @@ public class Sequences {
      */
     public static final String EVENT_SEQ = "CMS_EVENT_SEQ";
 
-    public static final String PAY_TO_SEQ = "PAY_TO_SEQ";
-
     public static final String SERVICE_SEQ = "SERVICE_SEQ";
 
     /**


### PR DESCRIPTION
Migrated PayToProvider from Hibernate 4 to 5

Moved the table profile_payto_xref from `legacy_seed.sql` and renamed it pay_to_providers in `seed.sql`.

To test this, 
1. drop all of the tables in `legacy_seed.sql` apart from `provider_setting`
2. execute the test steps outlined in `psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature` the expected result is that it will get further than with the previous test, but fail on the next unmigrated table:
` org.postgresql.util.PSQLException: ERROR: relation "provider_svcs" does not exist`