### PR TITLE
Replace placeholder footer text: #108

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/footer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/footer.jsp
@@ -8,15 +8,13 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<jsp:useBean id="date" class="java.util.Date" />
                     <!-- /.tabSection -->
                 </div>
             </div>
             <!-- /#mainContent -->
 
-            <div id="footer">
-                <strong>Copyright <fmt:formatDate value="${date}" pattern="yyyy" />.</strong> Companyname Lorem Ipsum
-            </div>
+            <%@include file="/WEB-INF/pages/includes/footer.jsp" %>
+            
             <!-- #footer -->
             <div class="clear"></div>
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_user_profile.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_user_profile.jsp
@@ -93,9 +93,8 @@
             </div>
             <!-- /#mainContent -->
 
-            <div id="footer">
-                <strong>Copyright 2012.</strong> Companyname Lorem Ipsum
-            </div>
+            <%@include file="/WEB-INF/pages/includes/footer.jsp" %>
+
             <!-- #footer -->
         </div>
         <!-- /#wrapper -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/includes/footer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/includes/footer.jsp
@@ -5,6 +5,6 @@
     @version 1.0
  --%>
 <div id="footer">
-    <strong>Copyright 2012.</strong> Companyname Lorem Ipsum
+    <strong>This module is open source.</strong>  <a href="https://github.com/OpenTechStrategies/psm">Contributions welcome</a>.
 </div>
 <!-- #footer -->


### PR DESCRIPTION
Remove "Companyname Lorem Ipsum" in the footer and replace with a link
to the repository.  Use the included footer in two files where it had
been set manually, so that we only need to change it in one place in the
future.

This handles the most consistently visible part of #108.