### PR TITLE
Migrated Provider Services to H5

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -932,7 +932,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         for (ProviderService service : services) {
             service.setTicketId(details.getTicketId());
             service.setProfileId(details.getProfileId());
-            service.setId(getSequence().getNextValue(Sequences.SERVICE_SEQ));
+            service.setId(0);
             getEm().persist(service);
         }
 

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -75,23 +75,6 @@
 			<column name="EXTERNAL_PROFILE_ID" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.ProviderService" table="PROVIDER_SVCS">
-		<id column="PROVIDER_SVCS_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column default="0" name="PROFILE_ID" not-null="true" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column default="0" name="TICKET_ID" not-null="true" />
-		</property>
-		<many-to-one class="gov.medicaid.entities.ServiceCategory"
-			fetch="join" name="category">
-			<column name="SVC_CAT_CD" />
-		</many-to-one>
-	</class>
 	<class name="gov.medicaid.entities.ProviderCategoryOfService" table="PROVIDER_COS_XREF">
 		<id column="PROVIDER_COS_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -80,6 +80,7 @@
     <class>gov.medicaid.entities.PersonBeneficialOwner</class>
     <class>gov.medicaid.entities.ProfileStatus</class>
     <class>gov.medicaid.entities.ProviderProfile</class>
+    <class>gov.medicaid.entities.ProviderService</class>
     <class>gov.medicaid.entities.ProviderStatement</class>
     <class>gov.medicaid.entities.ProviderType</class>
     <class>gov.medicaid.entities.ProviderTypeSetting</class>

--- a/psm-app/db/legacy_seed.sql
+++ b/psm-app/db/legacy_seed.sql
@@ -6,7 +6,6 @@ DROP TABLE IF EXISTS
   profile_assured_svc_xref,
   provider_cos,
   provider_cos_xref,
-  provider_svcs,
   required_fld
 CASCADE ;
 
@@ -91,17 +90,6 @@ create table provider_cos_xref
 alter table provider_cos
 	add constraint fk2ciqibe0u9h2cmyeut8q5alir
 		foreign key (provider_cos_id) references provider_cos_xref
-;
-
-create table provider_svcs
-(
-	provider_svcs_id bigint not null
-		constraint provider_svcs_pkey
-			primary key,
-	profile_id bigint default 0 not null,
-	ticket_id bigint default 0 not null,
-	svc_cat_cd varchar(255)
-)
 ;
 
 create table required_fld

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -41,6 +41,7 @@ DROP TABLE IF EXISTS
   profile_statuses,
   provider_profiles,
   provider_statements,
+  provider_services,
   provider_type_agreement_documents,
   provider_type_license_types,
   provider_type_settings,
@@ -1355,3 +1356,11 @@ INSERT INTO provider_type_settings (
   (100004, '41', 'LicenseType', 'M4', 'QL'),
   (100006, '41', 'LicenseType', 'H1', 'QL'),
   (100007, '41', 'LicenseType', 'H2', 'QL');
+
+CREATE TABLE provider_services(
+  provider_service_id BIGINT PRIMARY KEY,
+  profile_id BIGINT DEFAULT 0 NOT NULL,
+  ticket_id BIGINT DEFAULT 0 NOT NULL,
+  service_category_code CHARACTER VARYING(2)
+    REFERENCES service_categories(code)
+);

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
@@ -2,65 +2,61 @@ package gov.medicaid.entities;
 
 /**
  * Represents services allowed for the given provider.
+ *
  * @author TCSASSEMBLER
  * @version 1.0
  */
-public class ProviderService extends IdentifiableEntity {
 
+import javax.persistence.*;
+import java.io.Serializable;
+
+@javax.persistence.Entity
+@Table(name = "provider_services")
+public class ProviderService implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "provider_service_id")
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "service_category_code")
     private ServiceCategory category;
-    
-    private long profileId;
-    
-    private long ticketId;
-    
-    public ProviderService() {
-    }
 
-    /**
-     * Gets the value of the field <code>category</code>.
-     * @return the category
-     */
+    @Column(name = "profile_id", nullable = false)
+    private long profileId = 0;
+
+    @Column(name = "ticket_id", nullable = false)
+    private long ticketId = 0;
+
     public ServiceCategory getCategory() {
         return category;
     }
 
-    /**
-     * Sets the value of the field <code>category</code>.
-     * @param category the category to set
-     */
     public void setCategory(ServiceCategory category) {
         this.category = category;
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     * @param profileId the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -37,8 +37,6 @@ public class Sequences {
      */
     public static final String EXT_PROF_LINK_SEQ = "EXT_PROF_LINK_SEQ";
 
-    public static final String SERVICE_SEQ = "SERVICE_SEQ";
-
     /**
      * For Assured Services.
      */


### PR DESCRIPTION
Migrated ProviderService entity to H5 by adding annotations.
Moved the table `provider_svcs` from legacy to seed and renamed to `provider_services`. 

## To Test
Validation of this fix depends on PR #199 and #201. 

To test this, 
1. drop all of the tables in `legacy_seed.sql` apart from `provider_setting`
2. execute the test steps outlined in `psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature` the expected result is that it will work to completion and you will see "The enrollment has been saved as Draft." dialog.

Progress on #36 