### PR TITLE
Added cache directive and forcing clean build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ jdk:
   - openjdk8
 dist: trusty
 
+cache:
+  directories:
+    - $HOME/.gradle/caches
+
 # We depend on a wildfly deploment for some of the production
 # jar files. Download it and install just above our repo
 before_script:
@@ -15,4 +19,4 @@ install: true
 
 script:
   - cd psm-app
-  - ./gradlew build
+  - ./gradlew clean build


### PR DESCRIPTION
This resolves #206 

Added a cache directive for $HOME/.gradle/caches

Added a `clean` target to the script to insure none of our artifacts are re-used between CI jobs.

Tested that second build from the branch did not download any jars.