### PR TITLE
Hibernate-5-ify Event

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
@@ -26,8 +26,6 @@ import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.FileNetService;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
-import gov.medicaid.services.SequenceGenerator;
-import gov.medicaid.services.util.Sequences;
 import gov.medicaid.services.util.XMLAdapter;
 
 import javax.persistence.EntityManager;
@@ -55,11 +53,6 @@ public class AcceptedHandler extends GenericHandler {
     private final EntityManager entityManager;
 
     /**
-     * Sequence generator.
-     */
-    private final SequenceGenerator sequenceGenerator;
-
-    /**
      * Filenet service.
      */
     private final FileNetService fileNetService;
@@ -71,7 +64,6 @@ public class AcceptedHandler extends GenericHandler {
         CMSConfigurator config = new CMSConfigurator();
         this.providerService = config.getEnrollmentService();
         this.entityManager = config.getPortalEntityManager();
-        this.sequenceGenerator = config.getSequenceGenerator();
         this.fileNetService = config.getFileNetService();
     }
 
@@ -102,7 +94,7 @@ public class AcceptedHandler extends GenericHandler {
             Event e = new Event();
             e.setCreatedBy(actorId);
             e.setCreatedOn(new Date());
-            e.setId(sequenceGenerator.getNextValue(Sequences.EVENT_SEQ));
+            e.setId(0);
             e.setNpi(model.getEnrollment().getProviderInformation().getNPI());
             e.setStatus("04");
             e.setTicketId(ticket.getTicketId());

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/DisqualificationHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/DisqualificationHandler.java
@@ -24,8 +24,6 @@ import gov.medicaid.entities.Event;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
-import gov.medicaid.services.SequenceGenerator;
-import gov.medicaid.services.util.Sequences;
 import gov.medicaid.services.util.XMLAdapter;
 
 import java.util.Date;
@@ -60,11 +58,6 @@ public class DisqualificationHandler extends GenericHandler {
     private final EntityManager entityManager;
 
     /**
-     * Sequence generator.
-     */
-    private final SequenceGenerator sequenceGenerator;
-
-    /**
      * The screening system user.
      */
     private CMSUser systemUser;
@@ -76,7 +69,6 @@ public class DisqualificationHandler extends GenericHandler {
         CMSConfigurator config = new CMSConfigurator();
         this.providerService = config.getEnrollmentService();
         this.entityManager = config.getPortalEntityManager();
-        sequenceGenerator = config.getSequenceGenerator();
         systemUser = config.getSystemUser();
     }
 
@@ -106,7 +98,7 @@ public class DisqualificationHandler extends GenericHandler {
                 Event e = new Event();
                 e.setCreatedBy(systemUser.getUserId());
                 e.setCreatedOn(new Date());
-                e.setId(sequenceGenerator.getNextValue(Sequences.EVENT_SEQ));
+                e.setId(0);
                 e.setNpi(model.getEnrollment().getProviderInformation().getNPI());
                 e.setStatus("03");
                 e.setTicketId(ticket.getTicketId());

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
@@ -26,8 +26,6 @@ import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.FileNetService;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
-import gov.medicaid.services.SequenceGenerator;
-import gov.medicaid.services.util.Sequences;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -54,11 +52,6 @@ public class RejectedHandler extends GenericHandler {
     private final EntityManager entityManager;
 
     /**
-     * Sequence generator.
-     */
-    private final SequenceGenerator sequenceGenerator;
-
-    /**
      * Filenet service.
      */
     private final FileNetService fileNetService;
@@ -70,7 +63,6 @@ public class RejectedHandler extends GenericHandler {
         CMSConfigurator config = new CMSConfigurator();
         this.providerService = config.getEnrollmentService();
         this.entityManager = config.getPortalEntityManager();
-        sequenceGenerator = config.getSequenceGenerator();
         this.fileNetService = config.getFileNetService();
     }
 
@@ -100,7 +92,7 @@ public class RejectedHandler extends GenericHandler {
             Event e = new Event();
             e.setCreatedBy(actorId);
             e.setCreatedOn(new Date());
-            e.setId(sequenceGenerator.getNextValue(Sequences.EVENT_SEQ));
+            e.setId(0);
             e.setNpi(model.getEnrollment().getProviderInformation().getNPI());
             e.setStatus("03");
             e.setTicketId(ticket.getTicketId());

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -138,21 +138,6 @@
 			<many-to-many class="gov.medicaid.entities.CategoryOfService" column="PROVIDER_COS_CD" unique="false" />
 		</bag>
 	</class>
-	<class name="gov.medicaid.entities.Event" table="EVENT">
-		<id column="EVENT_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property column="NPI" generated="never" lazy="false" length="10"
-			name="npi" type="string" />
-		<property column="TICKET_ID" generated="never" lazy="false"
-			name="ticketId" type="long" />
-		<property column="STATUS_CD" generated="never" lazy="false"
-			length="2" name="status" type="string" />
-		<property column="CREATED_BY" generated="never" lazy="false"
-			length="50" name="createdBy" type="string" />
-		<property column="CREATE_TS" generated="never" lazy="false"
-			name="createdOn" type="timestamp" />
-	</class>
 	<class name="gov.medicaid.entities.LegacySystemMapping" table="LEGACY_MAPPING">
 		<id column="LEGACY_MAPPING_ID" name="id" type="long">
 			<generator class="assigned" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -63,6 +63,7 @@
     <class>gov.medicaid.entities.EnrollmentStatus</class>
     <class>gov.medicaid.entities.Entity</class>
     <class>gov.medicaid.entities.EntityStructureType</class>
+    <class>gov.medicaid.entities.Event</class>
     <class>gov.medicaid.entities.HelpItem</class>
     <class>gov.medicaid.entities.IssuingBoard</class>
     <class>gov.medicaid.entities.License</class>

--- a/psm-app/db/legacy_seed.sql
+++ b/psm-app/db/legacy_seed.sql
@@ -1,5 +1,4 @@
 DROP TABLE IF EXISTS
-  event,
   external_account_link,
   external_profile_link,
   legacy_mapping,
@@ -11,19 +10,6 @@ DROP TABLE IF EXISTS
   provider_svcs,
   required_fld
 CASCADE ;
-
-create table event
-(
-	event_id bigint not null
-		constraint event_pkey
-			primary key,
-	npi varchar(10),
-	ticket_id bigint,
-	status_cd varchar(2),
-	created_by varchar(50),
-	create_ts timestamp
-)
-;
 
 create table external_account_link
 (

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -23,6 +23,7 @@ DROP TABLE IF EXISTS
   enrollments,
   entities,
   entity_structure_types,
+  events,
   help_items,
   issuing_boards,
   license_statuses,
@@ -1174,6 +1175,15 @@ CREATE TABLE notes(
   profile_id BIGINT,
   ticket_id BIGINT,
   note_text TEXT,
+  created_by TEXT,
+  created_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE events(
+  event_id BIGINT PRIMARY KEY,
+  ticket_id BIGINT,
+  npi TEXT,
+  status TEXT,
   created_by TEXT,
   created_at TIMESTAMP WITH TIME ZONE
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
@@ -17,33 +17,16 @@ package gov.medicaid.entities;
 
 import java.util.Date;
 
-/**
- * Represents an event.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
- */
 public class Event extends IdentifiableEntity {
 
-    /**
-     * The ticket id.
-     */
     private long ticketId;
 
-    /** The NPI. */
     private String npi;
 
-    /** The status. */
     private String status;
 
-    /**
-     * Creator.
-     */
     private String createdBy;
 
-    /**
-     * Timestamp.
-     */
     private Date createdOn;
 
     /**
@@ -52,86 +35,42 @@ public class Event extends IdentifiableEntity {
     public Event() {
     }
 
-    /**
-     * Get the Npi.
-     *
-     * @return the Npi
-     */
     public String getNpi() {
         return npi;
     }
 
-    /**
-     * Set the Npi.
-     *
-     * @param npi to be set
-     */
     public void setNpi(String npi) {
         this.npi = npi;
     }
 
-    /**
-     * Get the status.
-     *
-     * @return the status
-     */
     public String getStatus() {
         return status;
     }
 
-    /**
-     * Set the status.
-     *
-     * @param status the status to be set
-     */
     public void setStatus(String status) {
         this.status = status;
     }
 
-    /**
-     * Gets the value of the field <code>createdBy</code>.
-     * @return the createdBy
-     */
     public String getCreatedBy() {
         return createdBy;
     }
 
-    /**
-     * Sets the value of the field <code>createdBy</code>.
-     * @param createdBy the createdBy to set
-     */
     public void setCreatedBy(String createdBy) {
         this.createdBy = createdBy;
     }
 
-    /**
-     * Gets the value of the field <code>createdOn</code>.
-     * @return the createdOn
-     */
     public Date getCreatedOn() {
         return createdOn;
     }
 
-    /**
-     * Sets the value of the field <code>createdOn</code>.
-     * @param createdOn the createdOn to set
-     */
     public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
     }
 
-    /**
-     * Gets the value of the field <code>ticketId</code>.
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the value of the field <code>ticketId</code>.
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
@@ -29,12 +29,6 @@ public class Event extends IdentifiableEntity {
 
     private Date createdOn;
 
-    /**
-     * Default empty constructor.
-     */
-    public Event() {
-    }
-
     public String getNpi() {
         return npi;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
@@ -15,19 +15,42 @@
  */
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.Date;
 
-public class Event extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "events")
+public class Event implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "event_id")
+    private long id;
 
+    @Column(name = "ticket_id")
     private long ticketId;
 
     private String npi;
 
     private String status;
 
+    @Column(name = "created_by")
     private String createdBy;
 
+    @Column(name = "created_at")
     private Date createdOn;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getNpi() {
         return npi;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -42,11 +42,6 @@ public class Sequences {
      */
     public static final String HELP_ITEM_SEQ = "HELP_ITEM_SEQ";
 
-    /**
-     * Event sequence.
-     */
-    public static final String EVENT_SEQ = "CMS_EVENT_SEQ";
-
     public static final String SERVICE_SEQ = "SERVICE_SEQ";
 
     /**


### PR DESCRIPTION
Remove redundant comments, empty constructor, and trailing whitespace; rename the table and some of its columns, and use Hibernate to generate IDs.

I was able to test this by creating an enrollment as a provider, reviewing the enrollment as admin, and approving the enrollment. Before this change, I saw an error about `Event`; after this change, I saw a different error.

Issue #36 Use Hibernate 5, instead of 4