### PR TITLE
Fix initial database setup instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -335,10 +335,10 @@ repository, update its location in your local properties:
    If you have a previous build deployed already, you can replace the
    deployment in the UI or add the `--force` switch after `deploy`.
 
-1. Create database schema and initial data. Use the `seed.sql` data to
-   create most of the necessary tables, and `legacy_seed.sql` to
-   create tables for entities that have not yet been migrated to
-   Hibernate 5:
+1. Create database schema and initial data. Use `seed.sql` to create tables and
+   data for the application, `jbpm.sql` to create tables and data for the
+   embedded jBPM engine, and `legacy_seed.sql` to create tables for entities
+   that have not yet been migrated to Hibernate 5:
 
       ```ShellSession
       $ cat {/path/to/psm}/psm-app/db/legacy_seed.sql \


### PR DESCRIPTION
These were inadvertently reverted during merge conflict resolution in 1354001429aba3bc78b5dca3373329a9996e8a9d as part of PR #197. Restore the previous wording.

