### PR TITLE
Annotate endpoints and verbs with Javadoc comments

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -354,3 +354,12 @@ repository, update its location in your local properties:
     `system` is a "system administrator" account that can create new
     accounts.  Username `admin` with password `admin` is a "service
     admin" account that can create new provider enrollments.
+
+# Documentation
+
+Generate the API documentation from Javadoc annotations by invoking
+gradle:
+
+    ./gradlew cms-web:apiDocs
+
+The generated documentation will go into `psm-app/cms-web/build/reports/api-docs`.

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -87,6 +87,13 @@ project(':cms-web') {
         providedCompile fileTree(dir: 'WebContent/WEB-INF/lib')
     }
     webAppDirName = 'WebContent'
+
+    task apiDocs(type: Javadoc) {
+      source = sourceSets.main.allJava
+      classpath += configurations.compile
+      destinationDir = reporting.file('api-docs')
+      options.optionFiles << file('javadoc.options')
+    }
 }
 
 project(':cms-business-model') {

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -143,4 +143,3 @@ project(':cms-portal-services') {
     }
 }
 
-

--- a/psm-app/cms-web/javadoc.options
+++ b/psm-app/cms-web/javadoc.options
@@ -1,0 +1,1 @@
+-subpackages . -tag 'endpoint:a:Endpoint:' -tag 'verb:a:HTTP Verbs Allowed:'

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -215,7 +215,7 @@ public class EnrollmentPageFlowController extends BaseController {
      *             for read/write errors
      * @throws PortalServiceException
      *             for any other errors
-     * @endpoint "/attachment"
+     * @endpoint "/provider/enrollment/attachment"
      * @verb GET
      */
     @RequestMapping(value = "/attachment", method = RequestMethod.GET)
@@ -244,7 +244,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/start"
+     * @endpoint "/provider/enrollment/start"
      * @verb GET
      */
     @RequestMapping(value = "/start", method = RequestMethod.GET)
@@ -265,7 +265,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/renew"
+     * @endpoint "/provider/enrollment/renew"
      * @verb GET
      */
     @RequestMapping(value = "/renew", method = RequestMethod.GET)
@@ -287,7 +287,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/renewTicket"
+     * @endpoint "/provider/enrollment/renewTicket"
      * @verb GET
      */
     @RequestMapping(value = "/renewTicket", method = RequestMethod.GET)
@@ -311,7 +311,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/bulkRenewTickets"
+     * @endpoint "/provider/enrollment/bulkRenewTickets"
      * @verb POST
      */
     @RequestMapping(value = "/bulkRenewTickets", method = RequestMethod.POST)
@@ -423,7 +423,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/edit"
+     * @endpoint "/provider/enrollment/edit"
      * @verb GET
      */
     @RequestMapping(value = "/edit", method = RequestMethod.GET)
@@ -444,7 +444,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/profile"
+     * @endpoint "/provider/enrollment/profile"
      * @verb GET
      */
     @RequestMapping(value = "/profile", method = RequestMethod.GET)
@@ -471,7 +471,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the provider type selection page.
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/steps/type"
+     * @endpoint "/provider/enrollment/steps/type"
      * @verb GET
      */
     @RequestMapping(value = "/steps/type", method = RequestMethod.GET)
@@ -492,7 +492,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the previous page, or the same page if there were errors
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoin "/steps/prev"
+     * @endpoint "provider/enrollment/steps/prev"
      * @verb POST
      */
     @RequestMapping(value = "/steps/prev", method = RequestMethod.POST)
@@ -526,7 +526,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the next page, or the same page if there were errors
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/steps/next"
+     * @endpoint "/provider/enrollment/steps/next"
      * @verb POST
      */
     @RequestMapping(value = "/steps/next", method = RequestMethod.POST)
@@ -599,7 +599,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the next page, or the same page if there were errors
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/steps/rebind"
+     * @endpoint "/provider/enrollment/steps/rebind"
      * @verb POST
      */
     @RequestMapping(value = "/steps/rebind", method = RequestMethod.POST)
@@ -630,7 +630,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the current page of the enrollment process
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/page"
+     * @endpoint "/provider/enrollment/page"
      * @verb GET
      */
     @RequestMapping(value = "/page", method = RequestMethod.GET)
@@ -646,7 +646,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the current page of the enrollment process
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/print"
+     * @endpoint "/provider/enrollment/print"
      * @verb GET
      */
     @RequestMapping(value = "/print", method = RequestMethod.GET)
@@ -665,7 +665,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the print preview
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/preview"
+     * @endpoint "/provider/enrollment/preview"
      * @verb GET
      */
     @RequestMapping(value = "/preview", method = RequestMethod.GET)
@@ -682,7 +682,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the print preview
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/reviewPrint"
+     * @endpoint "/provider/enrollment/reviewPrint"
      * @verb GET
      */
     @RequestMapping(value = "/reviewPrint", method = RequestMethod.GET)
@@ -704,7 +704,7 @@ public class EnrollmentPageFlowController extends BaseController {
      *             for read/write errors
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/exportTicket"
+     * @endpoint "/provider/enrollment/exportTicket"
      * @verb GET
      */
     @RequestMapping(value = "/exportTicket", method = RequestMethod.GET)
@@ -725,7 +725,7 @@ public class EnrollmentPageFlowController extends BaseController {
      *             for IO related errors
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/export"
+     * @endpoint "/provider/enrollment/export"
      * @verb GET
      */
     @RequestMapping(value = "/export", method = RequestMethod.GET)
@@ -747,7 +747,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/lookup"
+     * @endpoint "/provider/enrollment/lookup"
      * @verb POST
      */
     @RequestMapping(value = "/lookup", method = RequestMethod.POST)
@@ -773,7 +773,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/lookupProvider"
+     * @endpoint "/provider/enrollment/lookupProvider"
      * @verb POST
      */
     @RequestMapping(value = "/lookupProvider", method = RequestMethod.POST)
@@ -797,7 +797,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/ownerTypes"
+     * @endpoint "/provider/enrollment/ownerTypes"
      * @verb POST
      */
     @RequestMapping(value = "/ownerTypes", method = RequestMethod.POST)
@@ -815,7 +815,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/lookupMinimumLicenses"
+     * @endpoint "/provider/enrollment/lookupMinimumLicenses"
      * @verb POST
      */
     @RequestMapping(value = "/lookupMinimumLicenses", method = RequestMethod.POST)
@@ -838,7 +838,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/view"
+     * @endpoint "/provider/enrollment/view"
      * @verb GET
      */
     @RequestMapping(value = "/view", method = RequestMethod.GET)
@@ -862,7 +862,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/reopen"
+     * @endpoint "/provider/enrollment/reopen"
      * @verb GET
      */
     @RequestMapping(value = "/reopen", method = RequestMethod.GET)
@@ -906,7 +906,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/jump"
+     * @endpoint "/provider/enrollment/jump"
      * @verb GET
      */
     @RequestMapping(value = "/jump", method = RequestMethod.GET)
@@ -927,7 +927,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/jump"
+     * @endpoint "/provider/enrollment/jump"
      * @verb POST
      */
     @RequestMapping(value = "/jump", method = RequestMethod.POST)
@@ -969,7 +969,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/saveNote"
+     * @endpoint "/provider/enrollment/saveNote"
      * @verb POST
      */
     @RequestMapping(value = "/saveNote", method = RequestMethod.POST)
@@ -1021,7 +1021,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/save"
+     * @endpoint "/provider/enrollment/save"
      * @verb POST
      */
     @RequestMapping(value = "/save", method = RequestMethod.POST)
@@ -1081,7 +1081,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/submit"
+     * @endpoint "/provider/enrollment/submit"
      * @verb POST
      */
     @RequestMapping(value = "/submit", method = RequestMethod.POST)
@@ -1152,7 +1152,7 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
-     * @endpoint "/resubmitWithChanges"
+     * @endpoint "/provider/enrollment/resubmitWithChanges"
      * @verb POST
      */
     @RequestMapping(value = "/resubmitWithChanges", method = RequestMethod.POST)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -112,6 +112,7 @@ import com.topcoder.util.log.Level;
  * 
  * @author TCSASSEMBLER
  * @version 1.0
+ * @endpoint "/provider/enrollment/*"
  */
 @Controller
 @RequestMapping("/provider/enrollment/*")
@@ -214,6 +215,8 @@ public class EnrollmentPageFlowController extends BaseController {
      *             for read/write errors
      * @throws PortalServiceException
      *             for any other errors
+     * @endpoint "/attachment"
+     * @verb GET
      */
     @RequestMapping(value = "/attachment", method = RequestMethod.GET)
     public void download(@ModelAttribute("enrollment") EnrollmentType enrollment,
@@ -241,6 +244,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/start"
+     * @verb GET
      */
     @RequestMapping(value = "/start", method = RequestMethod.GET)
     public String startEnrollment(Model model) throws PortalServiceException {
@@ -260,6 +265,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/renew"
+     * @verb GET
      */
     @RequestMapping(value = "/renew", method = RequestMethod.GET)
     public ModelAndView startRenewal(@RequestParam("profileId") long profileId, Model model)
@@ -280,6 +287,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/renewTicket"
+     * @verb GET
      */
     @RequestMapping(value = "/renewTicket", method = RequestMethod.GET)
     public ModelAndView startRenewalUsingTicket(@RequestParam("id") long ticketId, Model model)
@@ -302,6 +311,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/bulkRenewTickets"
+     * @verb POST
      */
     @RequestMapping(value = "/bulkRenewTickets", method = RequestMethod.POST)
     @ResponseBody
@@ -412,6 +423,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/edit"
+     * @verb GET
      */
     @RequestMapping(value = "/edit", method = RequestMethod.GET)
     public ModelAndView startEdit(@RequestParam("profileId") long profileId, Model model) throws PortalServiceException {
@@ -431,6 +444,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the enrollment start page.
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/profile"
+     * @verb GET
      */
     @RequestMapping(value = "/profile", method = RequestMethod.GET)
     public ModelAndView viewProfile(@RequestParam("id") long profileId, Model model) throws PortalServiceException {
@@ -456,6 +471,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the provider type selection page.
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/steps/type"
+     * @verb GET
      */
     @RequestMapping(value = "/steps/type", method = RequestMethod.GET)
     public ModelAndView selectProviderType(@ModelAttribute("enrollment") EnrollmentType enrollment)
@@ -475,6 +492,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the previous page, or the same page if there were errors
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoin "/steps/prev"
+     * @verb POST
      */
     @RequestMapping(value = "/steps/prev", method = RequestMethod.POST)
     public ModelAndView previousPage(@ModelAttribute("enrollment") EnrollmentType enrollment,
@@ -507,6 +526,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the next page, or the same page if there were errors
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/steps/next"
+     * @verb POST
      */
     @RequestMapping(value = "/steps/next", method = RequestMethod.POST)
     public ModelAndView nextPage(@ModelAttribute("enrollment") EnrollmentType enrollment, HttpServletRequest request,
@@ -578,6 +599,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the next page, or the same page if there were errors
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/steps/rebind"
+     * @verb POST
      */
     @RequestMapping(value = "/steps/rebind", method = RequestMethod.POST)
     public ModelAndView rebind(@ModelAttribute("enrollment") EnrollmentType enrollment, HttpServletRequest request,
@@ -607,6 +630,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the current page of the enrollment process
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/page"
+     * @verb GET
      */
     @RequestMapping(value = "/page", method = RequestMethod.GET)
     public ModelAndView showPage(@ModelAttribute("enrollment") EnrollmentType enrollment) throws PortalServiceException {
@@ -621,6 +646,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the current page of the enrollment process
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/print"
+     * @verb GET
      */
     @RequestMapping(value = "/print", method = RequestMethod.GET)
     public ModelAndView showPrint(@ModelAttribute("enrollment") EnrollmentType enrollment)
@@ -638,6 +665,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the print preview
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/preview"
+     * @verb GET
      */
     @RequestMapping(value = "/preview", method = RequestMethod.GET)
     public ModelAndView showPreview(@RequestParam("id") long ticketId) throws PortalServiceException {
@@ -653,6 +682,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the print preview
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/reviewPrint"
+     * @verb GET
      */
     @RequestMapping(value = "/reviewPrint", method = RequestMethod.GET)
     public ModelAndView reviewPrint(@RequestParam("id") long ticketId) throws PortalServiceException {
@@ -673,6 +704,8 @@ public class EnrollmentPageFlowController extends BaseController {
      *             for read/write errors
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/exportTicket"
+     * @verb GET
      */
     @RequestMapping(value = "/exportTicket", method = RequestMethod.GET)
     public void exportTicket(@RequestParam("id") long ticketId, HttpServletResponse response)
@@ -692,6 +725,8 @@ public class EnrollmentPageFlowController extends BaseController {
      *             for IO related errors
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/export"
+     * @verb GET
      */
     @RequestMapping(value = "/export", method = RequestMethod.GET)
     public void export(@ModelAttribute("enrollment") EnrollmentType enrollment, HttpServletResponse response)
@@ -712,6 +747,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/lookup"
+     * @verb POST
      */
     @RequestMapping(value = "/lookup", method = RequestMethod.POST)
     @ResponseBody
@@ -736,6 +773,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/lookupProvider"
+     * @verb POST
      */
     @RequestMapping(value = "/lookupProvider", method = RequestMethod.POST)
     @ResponseBody
@@ -758,6 +797,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/ownerTypes"
+     * @verb POST
      */
     @RequestMapping(value = "/ownerTypes", method = RequestMethod.POST)
     @ResponseBody
@@ -774,6 +815,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the lookup JSON
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/lookupMinimumLicenses"
+     * @verb POST
      */
     @RequestMapping(value = "/lookupMinimumLicenses", method = RequestMethod.POST)
     @ResponseBody
@@ -795,6 +838,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/view"
+     * @verb GET
      */
     @RequestMapping(value = "/view", method = RequestMethod.GET)
     public ModelAndView viewTicket(@RequestParam("id") long ticketId, Model model) throws PortalServiceException {
@@ -817,6 +862,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/reopen"
+     * @verb GET
      */
     @RequestMapping(value = "/reopen", method = RequestMethod.GET)
     public ModelAndView modifySubmittedTicket(@RequestParam("id") long ticketId, Model model)
@@ -859,6 +906,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/jump"
+     * @verb GET
      */
     @RequestMapping(value = "/jump", method = RequestMethod.GET)
     public ModelAndView jump(@ModelAttribute("enrollment") EnrollmentType enrollment,
@@ -878,6 +927,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the edit ticket page
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/jump"
+     * @verb POST
      */
     @RequestMapping(value = "/jump", method = RequestMethod.POST)
     public ModelAndView jump(@ModelAttribute("enrollment") EnrollmentType enrollment,
@@ -918,6 +969,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/saveNote"
+     * @verb POST
      */
     @RequestMapping(value = "/saveNote", method = RequestMethod.POST)
     public ModelAndView saveNote(@ModelAttribute("enrollment") EnrollmentType enrollment, HttpServletRequest request,
@@ -968,6 +1021,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/save"
+     * @verb POST
      */
     @RequestMapping(value = "/save", method = RequestMethod.POST)
     public ModelAndView save(@ModelAttribute("enrollment") EnrollmentType enrollment, HttpServletRequest request,
@@ -1026,6 +1081,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/submit"
+     * @verb POST
      */
     @RequestMapping(value = "/submit", method = RequestMethod.POST)
     public ModelAndView submit(@ModelAttribute("enrollment") EnrollmentType enrollment, HttpServletRequest request,
@@ -1095,6 +1152,8 @@ public class EnrollmentPageFlowController extends BaseController {
      * @return the same page, with a success/error message
      * @throws PortalServiceException
      *             for any errors encountered
+     * @endpoint "/resubmitWithChanges"
+     * @verb POST
      */
     @RequestMapping(value = "/resubmitWithChanges", method = RequestMethod.POST)
     public ModelAndView resubmitWithChanges(@ModelAttribute("enrollment") EnrollmentType enrollment,

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.ModelAndView;
  *
  * @author TCSASSEMBLER
  * @version 1.0
+ * @endpoint "/forgotpassword"
  */
 @Controller
 @RequestMapping("/forgotpassword")
@@ -77,6 +78,7 @@ public class ForgotPasswordController extends BaseController {
      *
      * @return the form entry.
      * @throws PortalServiceException for any errors encountered
+     * @verb GET
      */
     @RequestMapping(method = RequestMethod.GET)
     public ModelAndView viewPasswordChange() throws PortalServiceException {
@@ -102,6 +104,7 @@ public class ForgotPasswordController extends BaseController {
      * @param errors the binding results
      * @return the redirect to the login page if successful or back to the input if not.
      * @throws PortalServiceException for any errors encountered
+     * @verb POST
      */
     @RequestMapping(method = RequestMethod.POST)
     public ModelAndView processPasswordChange(@ModelAttribute("passwordForm") ForgotPasswordForm form,

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
@@ -44,6 +44,8 @@ public class LandingController extends BaseController {
      *
      * @return the redirect to the appropriate initial page.
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/landing"
+     * @verb GET
      */
     @RequestMapping(value = "/landing", method = RequestMethod.GET)
     public String viewLandingPage() throws PortalServiceException {
@@ -68,6 +70,8 @@ public class LandingController extends BaseController {
      *
      * @return the redirect to the appropriate initial page.
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/myprofile"
+     * @verb GET
      */
     @RequestMapping(value = "/myprofile", method = RequestMethod.GET)
     public String viewProfilePage() throws PortalServiceException {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
@@ -48,6 +48,7 @@ import org.springframework.web.servlet.ModelAndView;
  *
  * @author TCSASSEMBLER
  * @version 1.0
+ * @endpoint "/provider/profile/*"
  */
 @Controller
 @RequestMapping("/provider/profile/*")
@@ -98,6 +99,8 @@ public class MyProfileController extends BaseController {
      *
      * @return the update password page.
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/reset"
+     * @verb GET
      */
     @RequestMapping(value = "/reset", method = RequestMethod.GET)
     public ModelAndView viewPasswordChange() throws PortalServiceException {
@@ -123,6 +126,8 @@ public class MyProfileController extends BaseController {
      * @param errors the binding results
      * @return the redirect to the profiles page, or back to the input page request is not valid
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/reset"
+     * @verb POST
      */
     @RequestMapping(value = "/reset", method = RequestMethod.POST)
     public ModelAndView processPasswordChange(@ModelAttribute("passwordForm") UpdatePasswordForm form,
@@ -149,6 +154,8 @@ public class MyProfileController extends BaseController {
      *
      * @return the my profile model and view
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/"
+     * @verb GET
      */
     @RequestMapping(value = "/", method = RequestMethod.GET)
     public ModelAndView viewDashboard() throws PortalServiceException {
@@ -165,6 +172,8 @@ public class MyProfileController extends BaseController {
      * @param profileId the profile to renew
      * @return the enrollment start page.
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/renew"
+     * @verb GET
      */
     @RequestMapping(value = "/renew", method = RequestMethod.GET)
     public ModelAndView startRenewal(
@@ -208,6 +217,8 @@ public class MyProfileController extends BaseController {
      * @param profileId the profile to be edited
      * @return the enrollment start page.
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/edit"
+     * @verb GET
      */
     @RequestMapping(value = "/edit", method = RequestMethod.GET)
     public ModelAndView startEdit(

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
@@ -99,7 +99,7 @@ public class MyProfileController extends BaseController {
      *
      * @return the update password page.
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/reset"
+     * @endpoint "/provider/profile/reset"
      * @verb GET
      */
     @RequestMapping(value = "/reset", method = RequestMethod.GET)
@@ -126,7 +126,7 @@ public class MyProfileController extends BaseController {
      * @param errors the binding results
      * @return the redirect to the profiles page, or back to the input page request is not valid
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/reset"
+     * @endpoint "/provider/profile/reset"
      * @verb POST
      */
     @RequestMapping(value = "/reset", method = RequestMethod.POST)
@@ -154,7 +154,7 @@ public class MyProfileController extends BaseController {
      *
      * @return the my profile model and view
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/"
+     * @endpoint "/provider/profile/"
      * @verb GET
      */
     @RequestMapping(value = "/", method = RequestMethod.GET)
@@ -172,7 +172,7 @@ public class MyProfileController extends BaseController {
      * @param profileId the profile to renew
      * @return the enrollment start page.
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/renew"
+     * @endpoint "/provider/profile/renew"
      * @verb GET
      */
     @RequestMapping(value = "/renew", method = RequestMethod.GET)
@@ -217,7 +217,7 @@ public class MyProfileController extends BaseController {
      * @param profileId the profile to be edited
      * @return the enrollment start page.
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/edit"
+     * @endpoint "/provider/profile/edit"
      * @verb GET
      */
     @RequestMapping(value = "/edit", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
@@ -98,7 +98,7 @@ public class OnboardingController extends BaseController {
      * @param accountId the account id to use
      * @return the external profiles listing
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/list"
+     * @endpoint "/provider/onboarding/list"
      * @verb GET
      */
     @RequestMapping(value = "/list", method = RequestMethod.GET)
@@ -137,7 +137,7 @@ public class OnboardingController extends BaseController {
      * @param externalProfileIds the selection
      * @return back to the listing page
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/list"
+     * @endpoint "/provider/onboarding/list"
      * @verb POST
      */
     @RequestMapping(value = "/list", method = RequestMethod.POST)
@@ -196,7 +196,7 @@ public class OnboardingController extends BaseController {
      *
      * @return the page to get the account details.
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/link"
+     * @endpoint "/provider/onboarding/link"
      * @verb GET
      */
     @RequestMapping(value = "/link", method = RequestMethod.GET)
@@ -214,7 +214,7 @@ public class OnboardingController extends BaseController {
      * @param errors the binding results
      * @return the view to list the profiles for the account, or back to the input if request is not valid
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/link"
+     * @endpoint "/provider/onboarding/link"
      * @verb POST
      */
     @RequestMapping(value = "/link", method = RequestMethod.POST)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
@@ -45,6 +45,7 @@ import org.springframework.web.servlet.ModelAndView;
  *
  * @author TCSASSEMBLER
  * @version 1.0
+ * @endpoint "/provider/onboarding/*"
  */
 @Controller
 @RequestMapping("/provider/onboarding/*")
@@ -97,6 +98,8 @@ public class OnboardingController extends BaseController {
      * @param accountId the account id to use
      * @return the external profiles listing
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/list"
+     * @verb GET
      */
     @RequestMapping(value = "/list", method = RequestMethod.GET)
     public ModelAndView listExternalProfiles(@RequestParam(value = "systemId", required = false) String systemId,
@@ -134,6 +137,8 @@ public class OnboardingController extends BaseController {
      * @param externalProfileIds the selection
      * @return back to the listing page
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/list"
+     * @verb POST
      */
     @RequestMapping(value = "/list", method = RequestMethod.POST)
     public ModelAndView importExternalProfiles(@RequestParam("systemId") String systemId,
@@ -191,6 +196,8 @@ public class OnboardingController extends BaseController {
      *
      * @return the page to get the account details.
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/link"
+     * @verb GET
      */
     @RequestMapping(value = "/link", method = RequestMethod.GET)
     public ModelAndView viewLinkCreation() throws PortalServiceException {
@@ -207,6 +214,8 @@ public class OnboardingController extends BaseController {
      * @param errors the binding results
      * @return the view to list the profiles for the account, or back to the input if request is not valid
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/link"
+     * @verb POST
      */
     @RequestMapping(value = "/link", method = RequestMethod.POST)
     public ModelAndView processLinkCreation(@ModelAttribute("accountLink") AccountLinkForm accountLinkForm,

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -46,6 +46,7 @@ import org.springframework.web.servlet.ModelAndView;
  *
  * @author TCSASSEMBLER
  * @version 1.0
+ * @endpoint "/provider/dashboard/*"
  */
 @Controller
 @RequestMapping("/provider/dashboard/*")
@@ -90,6 +91,8 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the dashboard page and the needed models
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/"
+     * @verb GET
      */
     @RequestMapping(value = "/", method = RequestMethod.GET)
     public ModelAndView viewDashboard() throws PortalServiceException {
@@ -125,6 +128,8 @@ public class ProviderDashboardController extends BaseController {
      * Shows the account setup page.
      *
      * @return the account setup page (varies depending on user type)
+     * @endpoint "/setup"
+     * @verb GET
      */
     @RequestMapping(value = "/setup", method = RequestMethod.GET)
     private ModelAndView viewAccountSetup() {
@@ -141,6 +146,8 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the dashboard page
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/list"
+     * @verb GET
      */
     @RequestMapping(value = "/list", method = RequestMethod.GET)
     public ModelAndView viewTicketList() throws PortalServiceException {
@@ -152,6 +159,8 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the drafts page
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/drafts"
+     * @verb GET
      */
     @RequestMapping(value = "/drafts", method = RequestMethod.GET)
     public ModelAndView viewDrafts() throws PortalServiceException {
@@ -166,6 +175,8 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the pending page
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/pending"
+     * @verb GET
      */
     @RequestMapping(value = "/pending", method = RequestMethod.GET)
     public ModelAndView viewPending() throws PortalServiceException {
@@ -180,6 +191,8 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the approved page
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/approved"
+     * @verb GET
      */
     @RequestMapping(value = "/approved", method = RequestMethod.GET)
     public ModelAndView viewApproved() throws PortalServiceException {
@@ -194,6 +207,8 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the rejected page
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/rejected"
+     * @verb GET
      */
     @RequestMapping(value = "/rejected", method = RequestMethod.GET)
     public ModelAndView viewRejected() throws PortalServiceException {
@@ -224,6 +239,8 @@ public class ProviderDashboardController extends BaseController {
      * @param criteria the search criteria
      * @return the view to show the results by status
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/filter"
+     * @verb GET
      */
     @RequestMapping(value = "/filter", method = RequestMethod.GET)
     public ModelAndView filterTicketsByStatus(@RequestParam("status") String status, ProviderSearchCriteria criteria)
@@ -244,6 +261,8 @@ public class ProviderDashboardController extends BaseController {
      * @param response the response to write to
      * @throws PortalServiceException for any errors encountered
      * @throws IOException for read/write errors
+     * @endpoint "/export"
+     * @verb GET
      */
     @SuppressWarnings("unchecked")
     @RequestMapping(value = "/export", method = RequestMethod.GET)
@@ -271,6 +290,8 @@ public class ProviderDashboardController extends BaseController {
      * @param criteria the filter
      * @return the dashboard page
      * @throws PortalServiceException for any errors encountered
+     * @endpoint "/list/filter"
+     * @verb GET
      */
     @RequestMapping(value = "/list/filter", method = RequestMethod.GET)
     public ModelAndView filterTicketList(ProviderSearchCriteria criteria) throws PortalServiceException {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -91,7 +91,7 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the dashboard page and the needed models
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/"
+     * @endpoint "/provider/dashboard/"
      * @verb GET
      */
     @RequestMapping(value = "/", method = RequestMethod.GET)
@@ -128,7 +128,7 @@ public class ProviderDashboardController extends BaseController {
      * Shows the account setup page.
      *
      * @return the account setup page (varies depending on user type)
-     * @endpoint "/setup"
+     * @endpoint "/provider/dashboard/setup"
      * @verb GET
      */
     @RequestMapping(value = "/setup", method = RequestMethod.GET)
@@ -146,7 +146,7 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the dashboard page
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/list"
+     * @endpoint "/provider/dashboard/list"
      * @verb GET
      */
     @RequestMapping(value = "/list", method = RequestMethod.GET)
@@ -159,7 +159,7 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the drafts page
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/drafts"
+     * @endpoint "/provider/dashboard/drafts"
      * @verb GET
      */
     @RequestMapping(value = "/drafts", method = RequestMethod.GET)
@@ -175,7 +175,7 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the pending page
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/pending"
+     * @endpoint "/provider/dashboard/pending"
      * @verb GET
      */
     @RequestMapping(value = "/pending", method = RequestMethod.GET)
@@ -191,7 +191,7 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the approved page
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/approved"
+     * @endpoint "/provider/dashboard/approved"
      * @verb GET
      */
     @RequestMapping(value = "/approved", method = RequestMethod.GET)
@@ -207,7 +207,7 @@ public class ProviderDashboardController extends BaseController {
      *
      * @return the rejected page
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/rejected"
+     * @endpoint "/provider/dashboard/rejected"
      * @verb GET
      */
     @RequestMapping(value = "/rejected", method = RequestMethod.GET)
@@ -239,7 +239,7 @@ public class ProviderDashboardController extends BaseController {
      * @param criteria the search criteria
      * @return the view to show the results by status
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/filter"
+     * @endpoint "/provider/dashboard/filter"
      * @verb GET
      */
     @RequestMapping(value = "/filter", method = RequestMethod.GET)
@@ -261,7 +261,7 @@ public class ProviderDashboardController extends BaseController {
      * @param response the response to write to
      * @throws PortalServiceException for any errors encountered
      * @throws IOException for read/write errors
-     * @endpoint "/export"
+     * @endpoint "/provider/dashboard/export"
      * @verb GET
      */
     @SuppressWarnings("unchecked")
@@ -290,7 +290,7 @@ public class ProviderDashboardController extends BaseController {
      * @param criteria the filter
      * @return the dashboard page
      * @throws PortalServiceException for any errors encountered
-     * @endpoint "/list/filter"
+     * @endpoint "/provider/dashboard/list/filter"
      * @verb GET
      */
     @RequestMapping(value = "/list/filter", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
@@ -40,6 +40,7 @@ import org.springframework.web.servlet.ModelAndView;
  *
  * @author TCSASSEMBLER
  * @version 1.0
+ * @endpoint "/accounts/*"
  */
 @Controller
 @RequestMapping("/accounts/*")
@@ -82,6 +83,8 @@ public class SelfRegistrationController extends BaseController {
      * Loads the registration form.
      *
      * @return the view and model for the registration page.
+     * @endpoint "/accounts/new"
+     * @verb GET
      */
     @RequestMapping(value = "/accounts/new", method = RequestMethod.GET)
     public ModelAndView viewRegistrationForm() {
@@ -98,6 +101,8 @@ public class SelfRegistrationController extends BaseController {
      * @return the view and model for the registration result.
      * @throws PortalServiceException for non-recoverable errors encountered
      * @throws UnsupportedEncodingException if the system does not support UTF-8
+     * @endpoint "/accounts/new"
+     * @verb POST
      */
     @RequestMapping(value = "/accounts/new", method = RequestMethod.POST)
     public ModelAndView processRegistrationForm(@ModelAttribute("registrant") RegistrationForm registrant,
@@ -133,6 +138,8 @@ public class SelfRegistrationController extends BaseController {
      * @return the view and model for the registration page.
      * @throws PortalServiceException for any errors encountered
      * @throws UnsupportedEncodingException if the system does not support UTF-8
+     * @endpoint "/accounts/confirm"
+     * @verb GET
      */
     @RequestMapping(value = "/accounts/confirm", method = RequestMethod.GET)
     public ModelAndView viewRegisterSuccess(@RequestParam("id") String username, @RequestParam("token") String token)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
@@ -83,6 +83,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/viewAgreementDocuments"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/viewAgreementDocuments", method = RequestMethod.GET)
     public ModelAndView view() throws PortalServiceException {
@@ -116,6 +118,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/viewAgreementDocuments"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/viewAgreementDocuments", method = RequestMethod.POST)
     public ModelAndView search(@ModelAttribute("criteria") AgreementDocumentSearchCriteria criteria)
@@ -144,6 +148,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/getAgreementDocument"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/getAgreementDocument", method = RequestMethod.GET)
     public ModelAndView get(@RequestParam("agreementId") long id) throws PortalServiceException {
@@ -171,6 +177,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/provider/enrollment/agreement"
+     * @verb GET
      */
     @RequestMapping(value = "/provider/enrollment/agreement", method = RequestMethod.GET)
     public ModelAndView getAgreement(@RequestParam("id") long id) throws PortalServiceException {
@@ -199,6 +207,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/editAgreementDocument"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/editAgreementDocument", method = RequestMethod.GET)
     public ModelAndView beginEdit(@RequestParam("agreementId") long id,
@@ -236,6 +246,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      *
      * @throws IllegalArgumentException if agreementDocument is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/createAgreementDocument"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/createAgreementDocument", method = RequestMethod.POST)
     public ModelAndView create(@ModelAttribute("agreementDocument") AgreementDocument agreementDocument,
@@ -266,6 +278,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      *
      * @throws IllegalArgumentException if agreementDocument is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/updateAgreementDocument"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/updateAgreementDocument", method = RequestMethod.POST)
     public ModelAndView edit(@ModelAttribute("agreementDocument") AgreementDocument agreementDocument,
@@ -294,6 +308,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
      * @return the successful text
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/deleteAgreementDocuments"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/deleteAgreementDocuments", method = RequestMethod.GET)
     @ResponseBody

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/DashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/DashboardController.java
@@ -117,6 +117,8 @@ public class DashboardController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/ops/viewDashboard"
+     * @verb GET
      */
     @RequestMapping(value = { "/ops/viewDashboard" }, method = RequestMethod.GET)
     public ModelAndView view() throws PortalServiceException {
@@ -163,6 +165,8 @@ public class DashboardController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/ops/viewDashboard"
+     * @verb POST
      */
     @RequestMapping(value = { "/ops/viewDashboard" }, method = RequestMethod.POST)
     public ModelAndView search(@ModelAttribute("criteria") ProviderSearchCriteria criteria)
@@ -194,6 +198,8 @@ public class DashboardController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/viewHelp"
+     * @verb GET
      */
     @RequestMapping(value = "/viewHelp", method = RequestMethod.GET)
     public ModelAndView getHelp() throws PortalServiceException {
@@ -222,6 +228,8 @@ public class DashboardController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/viewHelpItem"
+     * @verb GET
      */
     @RequestMapping(value = "/viewHelpItem", method = RequestMethod.GET)
     public ModelAndView getHelpItem(@RequestParam("helpItemId") long id) throws PortalServiceException {
@@ -249,6 +257,8 @@ public class DashboardController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/viewHelp"
+     * @verb POST
      */
     @RequestMapping(value = "/viewHelp", method = RequestMethod.POST)
     public ModelAndView searchHelp(@ModelAttribute("criteria") HelpSearchCriteria criteria)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -214,6 +214,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/"
      */
     @RequestMapping("/agent/enrollment/")
     public ModelAndView view() throws PortalServiceException {
@@ -234,6 +235,8 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             If there are any errors in the action
+     * @endpoint "/agent/enrollment/viewDashboard"
+     * @verb GET
      */
     @RequestMapping(value = "/agent/enrollment/viewDashboard", method = RequestMethod.GET)
     public ModelAndView viewDashboard() throws PortalServiceException {
@@ -270,6 +273,8 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             If there are any errors in the action
+     * @endpoint "/agent/enrollment/viewHelp"
+     * @verb GET
      */
     @RequestMapping(value = "/agent/enrollment/viewHelp", method = RequestMethod.GET)
     public ModelAndView getHelp() throws PortalServiceException {
@@ -301,6 +306,8 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             If there are any errors in the action
+     * @endpoint "/agent/enrollment/viewHelpItem"
+     * @verb GET
      */
     @RequestMapping(value = "/agent/enrollment/viewHelpItem", method = RequestMethod.GET)
     public ModelAndView getHelpItem(@RequestParam("helpItemId") long id) throws PortalServiceException {
@@ -326,6 +333,7 @@ public class EnrollmentController extends BaseController {
      *            the ticket id
      * @return the model and view for
      * @throws PortalServiceException
+     * @endpoint "/agent/enrollment/rejectTicket"
      */
     @RequestMapping("/agent/enrollment/rejectTicket")
     public ModelAndView rejectTicket(@RequestParam("id") long id) throws PortalServiceException {
@@ -347,6 +355,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/screeningReview"
      */
     @RequestMapping("/agent/enrollment/screeningReview")
     public ModelAndView screeningReview(@RequestParam("id") long id) throws PortalServiceException {
@@ -416,6 +425,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/autoScreeningResult"
      */
     @RequestMapping("/agent/enrollment/autoScreeningResult")
     public ModelAndView viewScreeningLog(@RequestParam("id") long id, @RequestParam("type") String type,
@@ -478,6 +488,8 @@ public class EnrollmentController extends BaseController {
      *             for read/write errors
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/exportBatch"
+     * @endpoint "/provider/search/exportBatch"
      */
     @SuppressWarnings("unchecked")
     @RequestMapping({ "/agent/enrollment/exportBatch", "/provider/search/exportBatch" })
@@ -511,6 +523,8 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/search/{view}"
+     * @endpoint "/provider/search/{view}"
      */
     @RequestMapping({ "/agent/enrollment/search/{view}", "/provider/search/{view}" })
     public ModelAndView search(@ModelAttribute("criteria") ProviderSearchCriteria criteria, @PathVariable String view,
@@ -559,6 +573,7 @@ public class EnrollmentController extends BaseController {
      *             - if npi is null/empty
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/status"
      */
     @RequestMapping(value = "/agent/enrollment/status")
     public ModelAndView getByNumber(@RequestParam("npi") String npi) throws PortalServiceException {
@@ -597,6 +612,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/details"
      */
     @RequestMapping("/agent/enrollment/details")
     public ModelAndView getDetails(@RequestParam("id") long ticketId,
@@ -623,6 +639,7 @@ public class EnrollmentController extends BaseController {
      * @throws IllegalArgumentException
      *             - if note is null/empty
      * @return the operation status and message
+     * @endpoint "/agent/enrollment/note"
      */
     @RequestMapping("/agent/enrollment/note")
     @ResponseBody
@@ -656,6 +673,7 @@ public class EnrollmentController extends BaseController {
      *            - any changes to be applied (manual verification) this is optional, and only provided if any changes
      *            are needed
      * @return the operation status and message
+     * @endpoint "/agent/enrollment/approve"
      */
     @RequestMapping("/agent/enrollment/approve")
     public String approve(@RequestParam("id") long id, ApprovalDTO dto) {
@@ -684,6 +702,7 @@ public class EnrollmentController extends BaseController {
      * @return the status result
      * @throws IllegalArgumentException
      *             - if reason is null/empty
+     * @endpoint "/agent/enrollment/reject"
      */
     @RequestMapping("/agent/enrollment/reject")
     @ResponseBody
@@ -713,6 +732,7 @@ public class EnrollmentController extends BaseController {
      * @param id
      *            - the profile ID
      * @return the status
+     * @endpoint "/agent/enrollment/screen"
      */
     @RequestMapping("/agent/enrollment/screen")
     @ResponseBody
@@ -741,6 +761,7 @@ public class EnrollmentController extends BaseController {
      * @return the status
      * @throws IllegalArgumentException
      *             - if date is null or is a date in the past
+     * @endpoint "/agent/enrollment/schedule"
      */
     @RequestMapping("/agent/enrollment/schedule")
     @ResponseBody
@@ -965,6 +986,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/cos"
      */
     @RequestMapping("/agent/enrollment/cos")
     public ModelAndView viewCategoryOfService(@RequestParam("id") long profileId) throws PortalServiceException {
@@ -993,6 +1015,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/pendingcos"
      */
     @RequestMapping("/agent/enrollment/pendingcos")
     public ModelAndView viewPendingCategoryOfService(@RequestParam("id") long ticketId) throws PortalServiceException {
@@ -1031,6 +1054,8 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/addCOS"
+     * @verb POST
      */
     @RequestMapping(value = "/agent/enrollment/addCOS", method = RequestMethod.POST)
     public ModelAndView addCategoryOfService(@RequestParam("id") long profileId,
@@ -1090,6 +1115,8 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/addPendingCOS"
+     * @verb POST
      */
     @RequestMapping(value = "/agent/enrollment/addPendingCOS", method = RequestMethod.POST)
     public ModelAndView addPendingCategoryOfService(@RequestParam("id") long ticketId,
@@ -1141,6 +1168,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/deleteCOS"
      */
     @RequestMapping("/agent/enrollment/deleteCOS")
     public ModelAndView deleteCategoryOfService(@RequestParam("profileId") long profileId, @RequestParam("id") long id)
@@ -1163,6 +1191,7 @@ public class EnrollmentController extends BaseController {
      *         rendering (not null)
      * @throws PortalServiceException
      *             - If there are any errors in the action
+     * @endpoint "/agent/enrollment/deletePendingCOS"
      */
     @RequestMapping("/agent/enrollment/deletePendingCOS")
     public ModelAndView deletePendingCategoryOfService(@RequestParam("ticketId") long ticketId,

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/HelpController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/HelpController.java
@@ -81,6 +81,8 @@ public class HelpController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/searchHelp"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/searchHelp", method = RequestMethod.GET)
     public ModelAndView view() throws PortalServiceException {
@@ -113,6 +115,8 @@ public class HelpController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/searchHelp"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/searchHelp", method = RequestMethod.POST)
     public ModelAndView search(@ModelAttribute("criteria") HelpSearchCriteria criteria) throws PortalServiceException {
@@ -140,6 +144,8 @@ public class HelpController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/getHelpItem"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/getHelpItem", method = RequestMethod.GET)
     public ModelAndView get(@RequestParam("helpItemId") long helpItemId) throws PortalServiceException {
@@ -167,6 +173,8 @@ public class HelpController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/editHelpItem"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/editHelpItem", method = RequestMethod.GET)
     public ModelAndView beginEdit(@RequestParam("helpItemId") long helpItemId) throws PortalServiceException {
@@ -198,6 +206,8 @@ public class HelpController extends BaseServiceAdminController {
      *
      * @throws IllegalArgumentException if helpItem is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/createHelpItem"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/createHelpItem", method = RequestMethod.POST)
     public ModelAndView create(@ModelAttribute("helpItem") HelpItem helpItem, HttpServletRequest request)
@@ -229,6 +239,8 @@ public class HelpController extends BaseServiceAdminController {
      *
      * @throws IllegalArgumentException if helpItem is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/updateHelpItem"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/updateHelpItem", method = RequestMethod.POST)
     public ModelAndView edit(@ModelAttribute("helpItem") HelpItem helpItem, HttpServletRequest request)
@@ -257,6 +269,8 @@ public class HelpController extends BaseServiceAdminController {
      * @param request the http servlet request
      * @return the successful text
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/deleteHelpItem"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/deleteHelpItem", method = RequestMethod.GET)
     @ResponseBody

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -111,6 +111,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/viewProviderTypes"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/viewProviderTypes", method = RequestMethod.GET)
     public ModelAndView view() throws PortalServiceException {
@@ -141,6 +143,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/viewProviderTypes"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/viewProviderTypes", method = RequestMethod.POST)
     public ModelAndView search(@ModelAttribute("criteria") ProviderTypeSearchCriteria criteria)
@@ -167,6 +171,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/getProviderType"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/getProviderType", method = RequestMethod.GET)
     public ModelAndView get(@RequestParam("providerTypeId") String providerTypeId) throws PortalServiceException {
@@ -191,6 +197,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/beginCreateProviderType"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/beginCreateProviderType", method = RequestMethod.GET)
     public ModelAndView beginCreate() throws PortalServiceException {
@@ -230,6 +238,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/beginEditProviderType"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/beginEditProviderType", method = RequestMethod.GET)
     public ModelAndView beginEdit(@RequestParam("providerTypeId") String providerTypeId) throws PortalServiceException {
@@ -274,6 +284,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @return the model and view for creationg result
      * @throws IllegalArgumentException if providerType is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/createProviderType"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/createProviderType", method = RequestMethod.POST)
     public ModelAndView create(@ModelAttribute("providerType") ProviderType providerType, HttpServletRequest request)
@@ -318,6 +330,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @return the model and view for update result
      * @throws IllegalArgumentException if providerType is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/updateProviderType"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/updateProviderType", method = RequestMethod.POST)
     public ModelAndView edit(@ModelAttribute("providerType") ProviderType providerType, HttpServletRequest request)
@@ -350,6 +364,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
      * @param request the http servlet request
      * @return the successful text
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/deleteProviderTypes"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/deleteProviderTypes", method = RequestMethod.GET)
     @ResponseBody

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
@@ -93,6 +93,8 @@ public class ScreeningScheduleController extends BaseServiceAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/getScreeningSchedule"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/getScreeningSchedule", method = RequestMethod.GET)
     public ModelAndView get() throws PortalServiceException {
@@ -117,6 +119,8 @@ public class ScreeningScheduleController extends BaseServiceAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/beginEditScreeningSchedule"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/beginEditScreeningSchedule", method = RequestMethod.GET)
     public ModelAndView beginEdit() throws PortalServiceException {
@@ -143,6 +147,8 @@ public class ScreeningScheduleController extends BaseServiceAdminController {
      * @return the model and view instance
      * @throws IllegalArgumentException if screeningSchedule is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/updateScreeningSchedule"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/updateScreeningSchedule", method = RequestMethod.POST)
     public ModelAndView edit(@ModelAttribute("schedule") ScreeningSchedule schedule, HttpServletRequest request)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ServiceAgentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ServiceAgentController.java
@@ -86,6 +86,8 @@ public class ServiceAgentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/viewAgents"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/viewAgents", method = RequestMethod.GET)
     public ModelAndView view() throws PortalServiceException {
@@ -120,6 +122,8 @@ public class ServiceAgentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/viewAgents"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/viewAgents", method = RequestMethod.POST)
     public ModelAndView search(@ModelAttribute("criteria") UserSearchCriteria criteria) throws PortalServiceException {
@@ -149,6 +153,8 @@ public class ServiceAgentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/getAgent"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/getAgent", method = RequestMethod.GET)
     public ModelAndView get(@RequestParam("userId") String userId) throws PortalServiceException {
@@ -176,6 +182,8 @@ public class ServiceAgentController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/beginEditAgent"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/beginEditAgent", method = RequestMethod.GET)
     public ModelAndView beginEdit(@RequestParam("userId") String userId) throws PortalServiceException {
@@ -209,6 +217,8 @@ public class ServiceAgentController extends BaseServiceAdminController {
      *
      * @throws IllegalArgumentException if user is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/createAgent"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/createAgent", method = RequestMethod.POST)
     public ModelAndView create(@ModelAttribute("user") CMSUser user, HttpServletRequest request)
@@ -244,6 +254,8 @@ public class ServiceAgentController extends BaseServiceAdminController {
      *
      * @throws IllegalArgumentException if user is null/empty
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/updateAgent"
+     * @verb POST
      */
     @RequestMapping(value = "/admin/updateAgent", method = RequestMethod.POST)
     public ModelAndView edit(@ModelAttribute("user") CMSUser user, HttpServletRequest request)
@@ -272,6 +284,8 @@ public class ServiceAgentController extends BaseServiceAdminController {
      * @return the successful text
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/admin/deleteAgents"
+     * @verb GET
      */
     @RequestMapping(value = "/admin/deleteAgents", method = RequestMethod.GET)
     @ResponseBody

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
@@ -92,7 +92,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/list"
+     * @endpoint "/system/user/list"
      */
     @RequestMapping("/list")
     public ModelAndView view() throws PortalServiceException {
@@ -114,7 +114,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles, or if the criteria is null
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/search"
+     * @endpoint "/system/user/search"
      */
     @RequestMapping("/search")
     public ModelAndView search(@RequestParam("role") String role,
@@ -149,7 +149,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/details"
+     * @endpoint "/system/user/details"
      */
     @RequestMapping("/details")
     public ModelAndView get(@RequestParam("role") String role, @RequestParam("userId") String userId)
@@ -174,8 +174,8 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/edit"
-     * @endpoint "/new"
+     * @endpoint "/system/user/edit"
+     * @endpoint "/system/user/new"
      * @verb GET
      */
     @RequestMapping(value = { "/edit", "/new" }, method = RequestMethod.GET)
@@ -204,7 +204,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles, if user is null/empty
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/new"
+     * @endpoint "/system/user/new"
      * @verb POST
      */
     @RequestMapping(value = "/new", method = RequestMethod.POST)
@@ -260,7 +260,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles, if user is null
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/edit"
+     * @endpoint "/system/user/edit"
      * @verb POST
      */
     @RequestMapping(value = "/edit", method = RequestMethod.POST)
@@ -310,7 +310,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/delete"
+     * @endpoint "/system/user/delete"
      */
     @RequestMapping(value = "/delete")
     public ModelAndView delete(@RequestParam("role") String role, @RequestParam("userIds") String[] userIds)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
@@ -47,6 +47,7 @@ import org.springframework.web.servlet.ModelAndView;
  * @author argolite, TCSASSEMBLER
  * @version 1.1
  * @since 1.0
+ * @endpoint "/system/user/*"
  */
 @RequestMapping("/system/user/*")
 public class SystemAdminUserController extends BaseSystemAdminController {
@@ -91,6 +92,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      * @return the model and view instance that contains the name of view to be rendered and data to be used for
      *         rendering (not null)
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/list"
      */
     @RequestMapping("/list")
     public ModelAndView view() throws PortalServiceException {
@@ -112,6 +114,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles, or if the criteria is null
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/search"
      */
     @RequestMapping("/search")
     public ModelAndView search(@RequestParam("role") String role,
@@ -146,6 +149,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/details"
      */
     @RequestMapping("/details")
     public ModelAndView get(@RequestParam("role") String role, @RequestParam("userId") String userId)
@@ -170,6 +174,9 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/edit"
+     * @endpoint "/new"
+     * @verb GET
      */
     @RequestMapping(value = { "/edit", "/new" }, method = RequestMethod.GET)
     public ModelAndView beginEdit(@RequestParam("role") String role,
@@ -197,6 +204,8 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles, if user is null/empty
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/new"
+     * @verb POST
      */
     @RequestMapping(value = "/new", method = RequestMethod.POST)
     public ModelAndView create(@RequestParam(value = "roleName") String role,
@@ -251,6 +260,8 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles, if user is null
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/edit"
+     * @verb POST
      */
     @RequestMapping(value = "/edit", method = RequestMethod.POST)
     public ModelAndView edit(@RequestParam("roleName") String role,
@@ -299,6 +310,7 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/delete"
      */
     @RequestMapping(value = "/delete")
     public ModelAndView delete(@RequestParam("role") String role, @RequestParam("userIds") String[] userIds)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
@@ -44,6 +44,7 @@ import org.springframework.web.servlet.ModelAndView;
  * @author argolite, TCSASSEMBLER
  * @version 1.1
  * @since 1.0
+ * @endpoint "/system/search/*"
  */
 @RequestMapping("/system/search/*")
 public class SystemAdminUserSearchController extends BaseSystemAdminController {
@@ -68,6 +69,7 @@ public class SystemAdminUserSearchController extends BaseSystemAdminController {
      *        rendering (not null)
      * @throws IllegalArgumentException - If the given criteria is null
      * @throws PortalServiceException - If there are any errors in the action
+     * @endpoint "/list"
      */
     @RequestMapping("/list")
     public ModelAndView search(UserSearchCriteria criteria) throws PortalServiceException {
@@ -109,6 +111,7 @@ public class SystemAdminUserSearchController extends BaseSystemAdminController {
      * @param userIds - the entity IDs to be deleted
      * @return the status of the request, including a possible message
      * @throws IllegalArgumentException - If the list given is null
+     * @endpoint "/delete"
      */
     @RequestMapping("/delete")
     @ResponseBody

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
@@ -69,7 +69,7 @@ public class SystemAdminUserSearchController extends BaseSystemAdminController {
      *        rendering (not null)
      * @throws IllegalArgumentException - If the given criteria is null
      * @throws PortalServiceException - If there are any errors in the action
-     * @endpoint "/list"
+     * @endpoint "/system/search/list"
      */
     @RequestMapping("/list")
     public ModelAndView search(UserSearchCriteria criteria) throws PortalServiceException {
@@ -111,7 +111,7 @@ public class SystemAdminUserSearchController extends BaseSystemAdminController {
      * @param userIds - the entity IDs to be deleted
      * @return the status of the request, including a possible message
      * @throws IllegalArgumentException - If the list given is null
-     * @endpoint "/delete"
+     * @endpoint "/system/search/delete"
      */
     @RequestMapping("/delete")
     @ResponseBody

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
@@ -76,6 +76,8 @@ public class UserController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/ops/getUser"
+     * @verb GET
      */
     @RequestMapping(value = "/ops/getUser", method = RequestMethod.GET)
     public ModelAndView get() throws PortalServiceException {
@@ -102,6 +104,8 @@ public class UserController extends BaseServiceAdminController {
      *         rendering (not null)
      *
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/ops/beginEditUser"
+     * @verb GET
      */
     @RequestMapping(value = "/ops/beginEditUser", method = RequestMethod.GET)
     public ModelAndView beginEdit() throws PortalServiceException {
@@ -131,6 +135,8 @@ public class UserController extends BaseServiceAdminController {
      *
      * @throws IllegalArgumentException if user is null
      * @throws PortalServiceException If there are any errors in the action
+     * @endpoint "/ops/updateUser"
+     * @verb POST
      */
     @RequestMapping(value = "/ops/updateUser", method = RequestMethod.POST)
     public ModelAndView edit(@ModelAttribute("user") CMSUser user, HttpServletRequest request)


### PR DESCRIPTION
As a stopgap measure to give us some automated API documentation,
I've annotated the @RequestMapping definitions with custom Javadoc
tags `@endpoint` and `@verb`. To generate the documentation in a new
"doc-endpoints" directory, invoke Javadoc from the psm-app
directory:

`$ javadoc -d doc-endpoints/cms-web/ -sourcepath cms-web/src/main/java/ -subpackages . -tag endpoint:a:"Endpoint: " -tag verb:a:"HTTP Verbs Allowed: "`

Related to #30.