### PR TITLE
Remove unused constant

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
@@ -311,11 +311,6 @@ public class ViewStatics {
     /**
      * License option relationship.
      */
-    public static final String REL_LICENSE_OPTIONS = "LO";
-    
-    /**
-     * License option relationship.
-     */
     public static final String REL_QP_LICENSE_OPTIONS = "QL";
 
     /**


### PR DESCRIPTION
When the ProviderType-LicenseType link was extracted in #99, this constant was no longer used and should have been deleted. Delete it now.