### PR TITLE
Use Hibernate to generate IDs for new help items

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HelpServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HelpServiceBean.java
@@ -75,7 +75,7 @@ public class HelpServiceBean extends BaseService implements HelpService {
         }
 
         try {
-            help.setId(getSequence().getNextValue(Sequences.HELP_ITEM_SEQ));
+            help.setId(0);
             getEm().persist(help);
             return LogUtil.traceExit(getLog(), signature, help.getId());
         } catch (PersistenceException e) {

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -37,11 +37,6 @@ public class Sequences {
      */
     public static final String EXT_PROF_LINK_SEQ = "EXT_PROF_LINK_SEQ";
 
-    /**
-     * For help items.
-     */
-    public static final String HELP_ITEM_SEQ = "HELP_ITEM_SEQ";
-
     public static final String SERVICE_SEQ = "SERVICE_SEQ";
 
     /**


### PR DESCRIPTION
When the HelpItem class was converted for Hibernate 5 in PR #71, we missed the sequence generation. Remove the old, application-generated sequence and allow Hibernate to generate IDs for new help items.

I still haven't been able to find a way to see help items as a non-admin, but at least now we can create them without causing a stack trace!

Issue #36 Use Hibernate 5, instead of 4
Resolves #172 cannot create a help topic