### PR TITLE
Reuse provider profile IDs for secondary key

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -59,6 +59,7 @@ import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.util.Sequences;
 import gov.medicaid.services.util.Util;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.NotImplementedException;
 
 import javax.ejb.Local;
 import javax.ejb.Stateless;
@@ -740,23 +741,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      */
     public long importProfile(CMSUser user, SystemId sourceSystem, ProviderProfile profile)
         throws PortalServiceException {
-
-        List<Document> attachments = profile.getAttachments();
-        for (Document document : attachments) {
-            saveContentsAndCloseStreams(document);
-        }
-
-        ProviderProfile clone = profile.clone();
-        clone.getEntity().setLegacyIndicator("Y");
-
-        long internalProfileId = getSequence().getNextValue(Sequences.PROVIDER_NUMBER_SEQ);
-        Enrollment ticket = new Enrollment();
-        ticket.setRequestType(findLookupByDescription(RequestType.class, ViewStatics.IMPORT_REQUEST));
-
-        clone.setProfileId(internalProfileId);
-        ticket.setDetails(clone);
-        bypassJBPM(user, ticket);
-        return internalProfileId;
+        throw new NotImplementedException();
     }
 
     /**

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -185,14 +185,19 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
 
         if (ticket.getRequestType().getDescription().equals(ViewStatics.ENROLLMENT_REQUEST)) {
             profile.setProfileStatus(findLookupByDescription(ProfileStatus.class, "Active"));
-            profile.setProfileId(getSequence().getNextValue(Sequences.PROVIDER_NUMBER_SEQ));
             profile.setOwnerId(ticket.getSubmittedBy());
             profile.setCreatedBy(ticket.getSubmittedBy());
             profile.setCreatedOn(ticket.getStatusDate());
 
             profile.getEntity().setEnrolled("Y");
-            // generate profile id
-            insertProfile(0, profile);
+
+            profile.setId(0);
+            profile.setTicketId(0);
+            getEm().persist(profile);
+
+            profile.setProfileId(profile.getId());
+
+            saveRelatedEntities(profile);
         } else if (ticket.getRequestType().getDescription().equals(ViewStatics.IMPORT_REQUEST)) {
             profile.setProfileStatus(findLookupByDescription(ProfileStatus.class, "Active"));
             profile.setOwnerId(ticket.getSubmittedBy());
@@ -861,6 +866,10 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         details.setId(0);
         getEm().persist(details);
 
+        saveRelatedEntities(details);
+    }
+
+    private void saveRelatedEntities(ProviderProfile details) throws PortalServiceException {
         // save profile owner
         insertProviderEntity(details);
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -58,7 +58,17 @@ import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.util.Sequences;
 import gov.medicaid.services.util.Util;
+import org.apache.commons.io.IOUtils;
 
+import javax.ejb.Local;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.persistence.Query;
+import javax.sql.rowset.serial.SerialBlob;
+import javax.sql.rowset.serial.SerialException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -71,18 +81,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.ejb.Local;
-import javax.ejb.Stateless;
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.TransactionManagement;
-import javax.ejb.TransactionManagementType;
-import javax.persistence.Query;
-import javax.sql.rowset.serial.SerialBlob;
-import javax.sql.rowset.serial.SerialException;
-
-import org.apache.commons.io.IOUtils;
 
 /**
  * This implementation of the persistence interface takes full control of mapping relationships in order to support

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -23,11 +23,6 @@ package gov.medicaid.services.util;
  */
 public class Sequences {
     /**
-     * Used for each new provider enrollment.
-     */
-    public static final String PROVIDER_NUMBER_SEQ = "PROVIDER_NUMBER_SEQ";
-
-    /**
      * Used for each account link.
      */
     public static final String ACOUNT_LINK_SEQ = "ACOUNT_LINK_SEQ";


### PR DESCRIPTION
`ProviderProfile` uses `control_no` as its primary key, but it also has `profile_id`, which is only assigned when an enrollment is approved. Previously, the app was generating this profile ID the same way as it was generating all the other primary keys, but with the migration to Hibernate 5 that approach no longer works.

~The best short-term solution I have been able to find is to create a new entity that just has a primary key, and use that to generate IDs. This fixes the immediate problem (approving an enrollment fails).~

Implement @slifty's suggestion of reusing `control_no` for `profile_id`, which avoids introducing a new entity, allows us to defer a complete rewrite of `ProviderProfile`, and avoids any race conditions with ID generation.

It feels like `ProviderProfile` has at least two classes/entities/tables in it, and maybe more; we should look into it more closely, understand what all it contains, and break it up. ~This new class, perhaps, could be one of the starting points.~

Issue #36 Use Hibernate 5, instead of 4