### PR TITLE
Add JAXB generated files to gradle clean task

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -186,6 +186,10 @@ project(':cms-business-model') {
             generatePackage = 'gov.medicaid.domain.model'
         }
     }
+    clean {
+        delete jaxb.xjc.destinationDir
+        delete "${rootDir}/schema/"
+    }
 }
 
 project(':cms-portal-services') {


### PR DESCRIPTION
They are ignored, but were previously left behind by the cms-business-model:clean task. Include them in the task so that `./gradlew clean` does what it says on the tin.

You can test this, before and after, by running `./gradlew cms-business-model:build`, examining the generated files with `git status --ignored`, and then running `./gradlew clean`: the generated files should be deleted.

Issue #16 Manage sets of dependencies via Gradle or another tool