### PR TITLE
Create jBPM sequence for task comments

### DIFF
--- a/psm-app/db/jbpm.sql
+++ b/psm-app/db/jbpm.sql
@@ -355,6 +355,12 @@ CREATE TABLE subtasksstrategy (
     REFERENCES task(id)
 );
 
+CREATE SEQUENCE comment_id_seq
+  START WITH 1
+  INCREMENT BY 1
+  NO MINVALUE
+  NO MAXVALUE
+  CACHE 1;
 CREATE TABLE task_comment (
   id BIGINT PRIMARY KEY,
   addedat TIMESTAMP WITH TIME ZONE,


### PR DESCRIPTION
When adding the database schema for the new version of jBPM in fdc29e552ef92c474b7dbf4d986b7b76607b307c, I missed one of the sequences. This showed up as a warning on running the SQL schema creation multiple times:

    NOTICE:  sequence "comment_id_seq" does not exist, skipping

Presumably there is also some jBPM behavior that is broken without this which we have not yet exercised.

Issue #1 Support PostgreSQL or other open source database