### PR TITLE
Remove previously-deleted table from legacy_seed

### DIFF
--- a/psm-app/db/legacy_seed.sql
+++ b/psm-app/db/legacy_seed.sql
@@ -2,8 +2,7 @@ DROP TABLE IF EXISTS
   external_account_link,
   external_profile_link,
   profile_assured_ext_svcs,
-  profile_assured_svc_xref,
-  required_fld
+  profile_assured_svc_xref
 CASCADE ;
 
 create table external_account_link
@@ -51,16 +50,4 @@ create table profile_assured_svc_xref
 alter table profile_assured_ext_svcs
 	add constraint fknpq45dvbn0v9qxjrp3ccs81uy
 		foreign key (profile_assured_svc_id) references profile_assured_svc_xref
-;
-
-create table required_fld
-(
-	code varchar(2) not null
-		constraint required_fld_pkey
-			primary key,
-	description varchar(255),
-	required_fld_type_id varchar(2)
-		constraint fk3pj5itnxvpohvq0q8skilyal0
-			references required_fld
-)
 ;


### PR DESCRIPTION
The entity backing this table, RequiredField, was deleted in bb0267174dec87fd53fe390b23d377557cdde222. The legacy seed SQL script was developed in parallel before the deletion was merged.

Delete the unused table.

Issue #36 Use Hibernate 5, instead of 4
Pull request #180 Delete unused entity RequiredField
Pull request #182 Created a separate SQL file to create tables for the unmigrated entities