### PR TITLE
Hibernate-5-ify provider categories of service

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -67,6 +67,7 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
+import javax.persistence.EntityGraph;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.sql.rowset.serial.SerialBlob;
@@ -2164,11 +2165,15 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     private TypedQuery<ProviderCategoryOfService> queryCategoriesOfService(
             String condition
     ) {
+        EntityGraph graph = getEm()
+                .getEntityGraph("ProviderCategoryOfService with categories");
         return getEm()
-                .createQuery("FROM ProviderCategoryOfService p " +
+                .createQuery("SELECT DISTINCT p " +
+                                "FROM ProviderCategoryOfService p " +
                                 "WHERE " + condition + " " +
                                 "ORDER BY p.startDate",
-                        ProviderCategoryOfService.class);
+                        ProviderCategoryOfService.class)
+                .setHint("javax.persistence.loadgraph", graph);
     }
 
     /**
@@ -2184,7 +2189,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     public void addCOSToProfile(CMSUser user, ProviderCategoryOfService categoryOfService, long prevCatServiceId,
         Date prevCatEndDate) throws PortalServiceException {
         checkProfileEntitlement(user, categoryOfService.getProfileId());
-        categoryOfService.setId(getSequence().getNextValue(Sequences.PROVIDER_COS_SEQ));
+        categoryOfService.setId(0);
         getEm().persist(categoryOfService);
         if (prevCatServiceId != 0) {
             ProviderCategoryOfService service = getEm().find(ProviderCategoryOfService.class, prevCatServiceId);
@@ -2226,7 +2231,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     public void addCOSToTicket(CMSUser user, ProviderCategoryOfService categoryOfService, long prevCatServiceId,
         Date prevCatEndDate) throws PortalServiceException {
         checkTicketEntitlement(user, categoryOfService.getTicketId());
-        categoryOfService.setId(getSequence().getNextValue(Sequences.PROVIDER_COS_SEQ));
+        categoryOfService.setId(0);
         getEm().persist(categoryOfService);
         if (prevCatServiceId != 0) {
             ProviderCategoryOfService service = getEm().find(ProviderCategoryOfService.class, prevCatServiceId);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -68,6 +68,7 @@ import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 import javax.sql.rowset.serial.SerialBlob;
 import javax.sql.rowset.serial.SerialException;
 import java.io.IOException;
@@ -2149,14 +2150,25 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @return the list of services
      * @throws PortalServiceException for any errors encountered
      */
-    @SuppressWarnings("unchecked")
     @Override
-    public List<ProviderCategoryOfService> getProviderCategoryOfServices(CMSUser user, long profileId)
-        throws PortalServiceException {
+    public List<ProviderCategoryOfService> getProviderCategoryOfServices(
+            CMSUser user,
+            long profileId
+    ) throws PortalServiceException {
         checkProfileEntitlement(user, profileId);
-        return getEm().createQuery("from ProviderCategoryOfService p where p.profileId = :id order by p.startDate")
-            .setParameter("id", profileId).getResultList();
+        return queryCategoriesOfService("p.profileId = :id")
+                .setParameter("id", profileId)
+                .getResultList();
+    }
 
+    private TypedQuery<ProviderCategoryOfService> queryCategoriesOfService(
+            String condition
+    ) {
+        return getEm()
+                .createQuery("FROM ProviderCategoryOfService p " +
+                                "WHERE " + condition + " " +
+                                "ORDER BY p.startDate",
+                        ProviderCategoryOfService.class);
     }
 
     /**
@@ -2234,13 +2246,15 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      *
      * @throws PortalServiceException for any errors encountered
      */
-    @SuppressWarnings("unchecked")
     @Override
-    public List<ProviderCategoryOfService> getPendingCategoryOfServices(CMSUser user, long ticketId)
-        throws PortalServiceException {
+    public List<ProviderCategoryOfService> getPendingCategoryOfServices(
+            CMSUser user,
+            long ticketId
+    ) throws PortalServiceException {
         checkTicketEntitlement(user, ticketId);
-        return getEm().createQuery("from ProviderCategoryOfService p where ticketId = :id order by p.startDate")
-            .setParameter("id", ticketId).getResultList();
+        return queryCategoriesOfService("ticketId = :id")
+                .setParameter("id", ticketId)
+                .getResultList();
     }
 
     /**

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -75,29 +75,4 @@
 			<column name="EXTERNAL_PROFILE_ID" />
 		</property>
 	</class>
-	<class name="gov.medicaid.entities.ProviderCategoryOfService" table="PROVIDER_COS_XREF">
-		<id column="PROVIDER_COS_ID" name="id" type="long">
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="profileId"
-			type="long">
-			<column default="0" name="PROFILE_ID" />
-		</property>
-		<property generated="never" lazy="false" name="ticketId"
-			type="long">
-			<column default="0" name="TICKET_ID" />
-		</property>
-		<property generated="never" name="startDate" type="timestamp">
-			<column name="START_DT" not-null="true" />
-		</property>
-		<property generated="never" name="endDate" type="timestamp">
-			<column name="END_DT" />
-		</property>
-		<bag name="categories" table="PROVIDER_COS">
-			<key>
-				<column name="PROVIDER_COS_ID" not-null="true" />
-			</key>
-			<many-to-many class="gov.medicaid.entities.CategoryOfService" column="PROVIDER_COS_CD" unique="false" />
-		</bag>
-	</class>
 </hibernate-mapping>

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -79,6 +79,7 @@
     <class>gov.medicaid.entities.Person</class>
     <class>gov.medicaid.entities.PersonBeneficialOwner</class>
     <class>gov.medicaid.entities.ProfileStatus</class>
+    <class>gov.medicaid.entities.ProviderCategoryOfService</class>
     <class>gov.medicaid.entities.ProviderProfile</class>
     <class>gov.medicaid.entities.ProviderService</class>
     <class>gov.medicaid.entities.ProviderStatement</class>

--- a/psm-app/db/legacy_seed.sql
+++ b/psm-app/db/legacy_seed.sql
@@ -3,8 +3,6 @@ DROP TABLE IF EXISTS
   external_profile_link,
   profile_assured_ext_svcs,
   profile_assured_svc_xref,
-  provider_cos,
-  provider_cos_xref,
   required_fld
 CASCADE ;
 
@@ -53,30 +51,6 @@ create table profile_assured_svc_xref
 alter table profile_assured_ext_svcs
 	add constraint fknpq45dvbn0v9qxjrp3ccs81uy
 		foreign key (profile_assured_svc_id) references profile_assured_svc_xref
-;
-
-create table provider_cos
-(
-	provider_cos_id bigint not null,
-	provider_cos_cd varchar(255) not null
-)
-;
-
-create table provider_cos_xref
-(
-	provider_cos_id bigint not null
-		constraint provider_cos_xref_pkey
-			primary key,
-	profile_id bigint default 0,
-	ticket_id bigint default 0,
-	start_dt timestamp not null,
-	end_dt timestamp
-)
-;
-
-alter table provider_cos
-	add constraint fk2ciqibe0u9h2cmyeut8q5alir
-		foreign key (provider_cos_id) references provider_cos_xref
 ;
 
 create table required_fld

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -34,11 +34,13 @@ DROP TABLE IF EXISTS
   owner_assets,
   ownership_info,
   ownership_types,
-  pay_to_providers,
   pay_to_provider_types,
+  pay_to_providers,
   people,
   persistent_logins,
   profile_statuses,
+  provider_approved_categories_of_service,
+  provider_category_of_service_approvals,
   provider_profiles,
   provider_statements,
   provider_services,
@@ -783,6 +785,20 @@ CREATE TABLE provider_profiles(
   created_at TIMESTAMP WITH TIME ZONE,
   last_modified_by TEXT,
   last_modified_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE provider_category_of_service_approvals(
+  provider_category_of_service_approval_id BIGINT PRIMARY KEY,
+  profile_id BIGINT,
+  ticket_id BIGINT,
+  start_date DATE,
+  end_date DATE
+);
+CREATE TABLE provider_approved_categories_of_service(
+  provider_category_of_service_approval_id BIGINT
+    REFERENCES provider_category_of_service_approvals(provider_category_of_service_approval_id),
+  category_of_service_code CHARACTER VARYING(2)
+    REFERENCES categories_of_service(code)
 );
 
 CREATE TABLE addresses(

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
@@ -1,19 +1,65 @@
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
+import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
 /**
  * Represents services allowed for the given provider.
  */
-public class ProviderCategoryOfService extends IdentifiableEntity {
+@javax.persistence.Entity
+@Table(name = "provider_category_of_service_approvals")
+@NamedEntityGraph(
+        name = "ProviderCategoryOfService with categories",
+        attributeNodes = {@NamedAttributeNode("categories")}
+)
+public class ProviderCategoryOfService implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "provider_category_of_service_approval_id")
+    private long id;
 
+    @ManyToMany
+    @JoinTable(
+            name = "provider_approved_categories_of_service",
+            joinColumns = @JoinColumn(
+                    name = "provider_category_of_service_approval_id"
+            ),
+            inverseJoinColumns = @JoinColumn(
+                    name = "category_of_service_code"
+            )
+    )
     private List<CategoryOfService> categories;
 
+    @Column(name = "profile_id")
     private long profileId;
+
+    @Column(name = "ticket_id")
     private long ticketId;
+
+    @Column(name = "start_date")
     private Date startDate;
+
+    @Column(name = "end_date")
     private Date endDate;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public long getProfileId() {
         return profileId;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
@@ -15,9 +15,6 @@ public class ProviderCategoryOfService extends IdentifiableEntity {
     private Date startDate;
     private Date endDate;
 
-    public ProviderCategoryOfService() {
-    }
-
     public long getProfileId() {
         return profileId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
@@ -5,9 +5,6 @@ import java.util.List;
 
 /**
  * Represents services allowed for the given provider.
- * 
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ProviderCategoryOfService extends IdentifiableEntity {
 
@@ -21,94 +18,42 @@ public class ProviderCategoryOfService extends IdentifiableEntity {
     public ProviderCategoryOfService() {
     }
 
-    /**
-     * Gets the value of the field <code>profileId</code>.
-     * 
-     * @return the profileId
-     */
     public long getProfileId() {
         return profileId;
     }
 
-    /**
-     * Sets the value of the field <code>profileId</code>.
-     * 
-     * @param profileId
-     *            the profileId to set
-     */
     public void setProfileId(long profileId) {
         this.profileId = profileId;
     }
 
-    /**
-     * Gets the <code>categories</code>.
-     * 
-     * @return the categories
-     */
     public List<CategoryOfService> getCategories() {
         return categories;
     }
 
-    /**
-     * Sets the <code>categories</code>.
-     * 
-     * @param categories
-     *            the categories to set
-     */
     public void setCategories(List<CategoryOfService> categories) {
         this.categories = categories;
     }
 
-    /**
-     * Gets the <code>startDate</code>.
-     * 
-     * @return the startDate
-     */
     public Date getStartDate() {
         return startDate;
     }
 
-    /**
-     * Sets the <code>startDate</code>.
-     * 
-     * @param startDate
-     *            the startDate to set
-     */
     public void setStartDate(Date startDate) {
         this.startDate = startDate;
     }
 
-    /**
-     * Gets the <code>endDate</code>.
-     * 
-     * @return the endDate
-     */
     public Date getEndDate() {
         return endDate;
     }
 
-    /**
-     * Sets the <code>endDate</code>.
-     * 
-     * @param endDate
-     *            the endDate to set
-     */
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
     }
 
-    /**
-     * Gets the <code>ticketId</code>.
-     * @return the ticketId
-     */
     public long getTicketId() {
         return ticketId;
     }
 
-    /**
-     * Sets the <code>ticketId</code>.
-     * @param ticketId the ticketId to set
-     */
     public void setTicketId(long ticketId) {
         this.ticketId = ticketId;
     }


### PR DESCRIPTION
Enrollments can be scoped to certain limited categories of service by an admin, by going to Enrollments and clicking on `COS` on an enrollment.

This feature feels incomplete to me, like a video game level that has a finished map but no items or characters or enemies. Notably, instead of showing you the *names* of the categories of service, it shows you the numbers. There's also only one way to reach this interface, and it does not appear to be connected to any other parts of the interface: just this one link on an enrollment from this one particular page.

---

Remove redundant comments and default constructor; extract a helper method to look up provider categories of service, and then refactor it as part of converting `ProviderCategoryOfService` over to Hibernate 5 / JPA annotations.

Issue #36 Use Hibernate 5, instead of 4