### PR TITLE
Disable gradle daemon in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 
 cache:
   directories:
-    - $HOME/.gradle/caches
+    - $HOME/.gradle/
 
 # We depend on a wildfly deploment for some of the production
 # jar files. Download it and install just above our repo
@@ -19,4 +19,4 @@ install: true
 
 script:
   - cd psm-app
-  - ./gradlew clean build
+  - ./gradlew --no-daemon --console=plain clean build


### PR DESCRIPTION
The gradle daemon is designed to speed up multiple runs of gradle by keeping some computations in memory. Since each build on Travis CI is on its own container, and our build script involves only a single build, the additional startup time does not benefit us.

Additionally, the daemon keeps some state, such as its PID, in `~/.gradle/daemon`, which prevents us from caching `~/.gradle`. This means we have to download the gradle distribution each time, adding unnecessary time to our build.

Disable the gradle daemon, and cache the entire `~/.gradle` directory.

Also, since I'm touching the same line anyway, disable the rich text output which is poorly captured in the Travis CI build log.

Resolves #210 Disable Gradle Daemon for Travis Build