### PR TITLE
Remove table for deleted RequiredFieldType entity

### DIFF
--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -51,7 +51,6 @@ DROP TABLE IF EXISTS
   qualified_professional_types,
   relationship_types,
   request_types,
-  required_field_types,
   risk_levels,
   roles,
   screening_schedules,
@@ -250,14 +249,6 @@ INSERT INTO profile_statuses (code, description) VALUES
   ('01', 'Active'),
   ('02', 'Suspended'),
   ('03', 'Expired');
-
-CREATE TABLE required_field_types(
-  code CHARACTER VARYING(2) PRIMARY KEY,
-  description TEXT UNIQUE
-);
-INSERT INTO required_field_types (code, description) VALUES
-  ('01', 'Required'),
-  ('02', 'Optional');
 
 CREATE TABLE entity_structure_types(
   code CHARACTER VARYING(2) PRIMARY KEY,


### PR DESCRIPTION
This lookup entity was deleted in #180, but its table was not. Delete the unused and unreferenced table.

Issue #36 Use Hibernate 5, instead of 4
PR #180 Delete unused entity RequiredTypeField