### PR TITLE
Remove lorem text on account setup: #108

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
@@ -5,7 +5,8 @@
   -
   - Description: it is used to render the high risk level.
 --%>
-<!-- Commenting this alert out for now, as per
+<!-- 
+     Commenting this alert out for now, as per
      github.com/OpenTechStrategies/psm/issues/53.
      We can put it back when a) we know how to
      conditionalize it on the presence of some
@@ -18,7 +19,8 @@
      between this snippet and a block in
      ../../provider/dashboard/list.jsp (look
      for a comment similar to this one).  
-
+-->
+<!--
 <div class="row infoRow">
     <div class="row red">
         <b>* High risk level means:</b>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -42,6 +42,21 @@
                             <div class="bl"></div>
                             <div class="br"></div>
                         </div>
+
+<!-- Commented out the "Linked Profiles" section below because that
+     functionality isn't enabled right now.  See commit f5d70d7bb93
+     and any followup commits that refer to it. 
+
+     The commenting-out actually uses two separate comment blocks
+     below, in order to avoid a comment nesting situation with the
+     "/.section" comment that appears in the block.  The first block
+     comments out the opening "div" element followed by a nested (but
+     balanced) div block, and the second comments out four small
+     balanced divs followed by the closing /div that corresponds to
+     that first opening div.
+-->
+
+<!--
                         <div class="detailPanel">
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
@@ -56,12 +71,15 @@
                                     </div>
                                 </div>
                             </div>
+-->
                             <!-- /.section -->
+<!--
                             <div class="tl"></div>
                             <div class="tr"></div>
                             <div class="bl"></div>
                             <div class="br"></div>
                         </div>
+-->
                     </div>
                     <!-- /.tabSection -->
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -27,15 +27,7 @@
                                     <div class="row">
 				                        <h3>New Enrollments</h3>
 				                        <p>
-				                            You can now start with the enrollment process. <br/>
-                                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                                            do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                                            Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                                            laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                                            irure dolor in reprehenderit in voluptate velit esse cillum
-                                            dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                                            cupidatat non proident, sunt in culpa qui officia deserunt
-                                            mollit anim id est laborum.
+				                            You can now begin the enrollment process.
 				                        </p>
 				                        <div class="">
 				                            <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
@@ -50,28 +42,20 @@
                             <div class="bl"></div>
                             <div class="br"></div>
                         </div>
-                        <div class="detailPanel">
+<!--                        <div class="detailPanel">
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
                                     <div class="row">
                                         <h3>Linked Profiles</h3>
                                         <p>
-                                            You can link your online account to any existing profiles in XXXXX partner services.
-                                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                                            do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                                            Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                                            laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                                            irure dolor in reprehenderit in voluptate velit esse cillum
-                                            dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                                            cupidatat non proident, sunt in culpa qui officia deserunt
-                                            mollit anim id est laborum.
+                                            You can link your online account to any existing profiles in partner services.
                                         </p>
                                         <div class="">
                                             <a href="<c:url value="/provider/onboarding/link" />" class="purpleBtn"><span class="btR"><span class="btM">Get Profiles</span></span></a>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
+                            </div> -->
                             <!-- /.section -->
                             <div class="tl"></div>
                             <div class="tr"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -42,7 +42,7 @@
                             <div class="bl"></div>
                             <div class="br"></div>
                         </div>
-<!--                        <div class="detailPanel">
+                        <div class="detailPanel">
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
                                     <div class="row">
@@ -55,7 +55,7 @@
                                         </div>
                                     </div>
                                 </div>
-                            </div> -->
+                            </div>
                             <!-- /.section -->
                             <div class="tl"></div>
                             <div class="tr"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -90,7 +90,7 @@
                              the way various other places in the
                              PSM tree do? 
                         --%>
-                        <--
+                        <!--
                         <div class="row infoRow">
                             <div class="row red">
                                 <b>* High risk level means:</b>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -72,7 +72,8 @@
                         </div>
                         <!-- /#tabApproved -->
 
-                        <!-- Commenting this alert out for now, as per
+                        <%!-- 
+                             Commenting this alert out for now, as per
                              github.com/OpenTechStrategies/psm/issues/53.
                              We can put it back when a) we know how to
                              conditionalize it on the presence of some
@@ -86,9 +87,10 @@
                              ../../admin/includes/high_risk_level_means.jsp.
                              And why isn't the code here doing
                              <%@ include file="/WEB-INF/pages/admin/includes/high_risk_level_means.jsp" %>
-                        <!-- the way various other places in the
-                             PSM tree do?
-
+                             the way various other places in the
+                             PSM tree do? 
+                        --%>
+                        <--
                         <div class="row infoRow">
                             <div class="row red">
                                 <b>* High risk level means:</b>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -72,7 +72,7 @@
                         </div>
                         <!-- /#tabApproved -->
 
-                        <%!-- 
+                        <%--
                              Commenting this alert out for now, as per
                              github.com/OpenTechStrategies/psm/issues/53.
                              We can put it back when a) we know how to

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -86,7 +86,7 @@
                              ../../admin/includes/high_risk_level_means.jsp.
                              And why isn't the code here doing
                              <%@ include file="/WEB-INF/pages/admin/includes/high_risk_level_means.jsp" %>
-                             the way various other places in the
+                        <!-- the way various other places in the
                              PSM tree do?
 
                         <div class="row infoRow">


### PR DESCRIPTION
The lorem ipsum text that showed up when a new provider logged in was
distracting.  Remove it.  I commented out the "Linked Profiles" section
on that same page, too, because that functionality isn't enabled right
now.

Also, fix #152 by adding a new comment-beginning mark to properly escape
the end of the comment and the high-risk helptext.

Please let me know if you'd rather I split this into different commits or even different PRs.