### PR TITLE
36 hibernate 5 external account link

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -270,7 +270,7 @@ public class RegistrationServiceBean extends BaseService implements Registration
     public void addAccountLink(String userId, ExternalAccountLink link) throws PortalServiceException {
         ExternalAccountLink existing = findAccountLink(userId, link.getSystemId(), link.getExternalUserId());
         if (existing == null) {
-            link.setId(getSequence().getNextValue(Sequences.ACOUNT_LINK_SEQ));
+            link.setId(0);
             link.setUserId(userId);
             getEm().persist(link);
             auditNewAccountLink(userId, link);

--- a/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/Medicaid.hbm.xml
@@ -2,26 +2,6 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                    "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-lazy="false">
-	<class name="gov.medicaid.entities.ExternalAccountLink" table="EXTERNAL_ACCOUNT_LINK">
-		<id name="id" type="long">
-			<column name="EXTERNAL_ACCOUNT_LINK_ID" />
-			<generator class="assigned" />
-		</id>
-		<property generated="never" lazy="false" name="userId" type="string">
-			<column name="USER_ID" />
-		</property>
-		<property generated="never" lazy="false" name="systemId">
-			<column name="SYSTEM_ID" />
-			<type name="org.hibernate.type.EnumType">
-				<param name="type">12</param>
-				<param name="enumClass">gov.medicaid.entities.SystemId</param>
-			</type>
-		</property>
-		<property generated="never" lazy="false" name="externalUserId"
-			type="string">
-			<column name="EXTERNAL_USER_ID" />
-		</property>
-	</class>
 	<class name="gov.medicaid.entities.ExternalProfileLink" table="EXTERNAL_PROFILE_LINK">
 		<id name="id" type="long">
 			<column name="EXTERNAL_PROFILE_LINK_ID" />

--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -64,6 +64,7 @@
     <class>gov.medicaid.entities.Entity</class>
     <class>gov.medicaid.entities.EntityStructureType</class>
     <class>gov.medicaid.entities.Event</class>
+    <class>gov.medicaid.entities.ExternalAccountLink</class>
     <class>gov.medicaid.entities.HelpItem</class>
     <class>gov.medicaid.entities.IssuingBoard</class>
     <class>gov.medicaid.entities.License</class>

--- a/psm-app/db/legacy_seed.sql
+++ b/psm-app/db/legacy_seed.sql
@@ -1,18 +1,6 @@
 DROP TABLE IF EXISTS
-  external_account_link,
   external_profile_link
 CASCADE ;
-
-create table external_account_link
-(
-	external_account_link_id bigint not null
-		constraint external_account_link_pkey
-			primary key,
-	user_id varchar(255),
-	system_id varchar(255),
-	external_user_id varchar(255)
-)
-;
 
 create table external_profile_link
 (

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -24,6 +24,7 @@ DROP TABLE IF EXISTS
   entities,
   entity_structure_types,
   events,
+  external_account_links,
   help_items,
   issuing_boards,
   license_statuses,
@@ -1356,4 +1357,11 @@ CREATE TABLE provider_services(
   ticket_id BIGINT DEFAULT 0 NOT NULL,
   service_category_code CHARACTER VARYING(2)
     REFERENCES service_categories(code)
+);
+
+CREATE TABLE external_account_links(
+  external_account_link_id BIGINT PRIMARY KEY,
+  user_id TEXT,
+  system_id TEXT,
+  external_user_id TEXT
 );

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
@@ -15,26 +15,12 @@
  */
 package gov.medicaid.entities;
 
-/**
- * Represents a link to an external user.
- * @author TCSASSEMBLER
- * @version 1.0
- */
 public class ExternalAccountLink extends IdentifiableEntity {
 
-    /**
-     * The user id.
-     */
     private String userId;
 
-    /**
-     * The external system id.
-     */
     private SystemId systemId;
 
-    /**
-     * The external user id.
-     */
     private String externalUserId;
 
     /**
@@ -44,56 +30,26 @@ public class ExternalAccountLink extends IdentifiableEntity {
 
     }
 
-    /**
-     * Gets the value of the field <code>userId</code>.
-     *
-     * @return the userId
-     */
     public String getUserId() {
         return userId;
     }
 
-    /**
-     * Sets the value of the field <code>userId</code>.
-     *
-     * @param userId the userId to set
-     */
     public void setUserId(String userId) {
         this.userId = userId;
     }
 
-    /**
-     * Gets the value of the field <code>externalUserId</code>.
-     *
-     * @return the externalUserId
-     */
     public String getExternalUserId() {
         return externalUserId;
     }
 
-    /**
-     * Sets the value of the field <code>externalUserId</code>.
-     *
-     * @param externalUserId the externalUserId to set
-     */
     public void setExternalUserId(String externalUserId) {
         this.externalUserId = externalUserId;
     }
 
-    /**
-     * Gets the value of the field <code>systemId</code>.
-     *
-     * @return the systemId
-     */
     public SystemId getSystemId() {
         return systemId;
     }
 
-    /**
-     * Sets the value of the field <code>systemId</code>.
-     *
-     * @param systemId the systemId to set
-     */
     public void setSystemId(SystemId systemId) {
         this.systemId = systemId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
@@ -15,13 +15,40 @@
  */
 package gov.medicaid.entities;
 
-public class ExternalAccountLink extends IdentifiableEntity {
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
 
+@javax.persistence.Entity
+@Table(name = "external_account_links")
+public class ExternalAccountLink implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "external_account_link_id")
+    private long id;
+
+    @Column(name = "user_id")
     private String userId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "system_id")
     private SystemId systemId;
 
+    @Column(name = "external_user_id")
     private String externalUserId;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 
     public String getUserId() {
         return userId;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
@@ -23,13 +23,6 @@ public class ExternalAccountLink extends IdentifiableEntity {
 
     private String externalUserId;
 
-    /**
-     * Empty constructor.
-     */
-    public ExternalAccountLink() {
-
-    }
-
     public String getUserId() {
         return userId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -23,11 +23,6 @@ package gov.medicaid.services.util;
  */
 public class Sequences {
     /**
-     * Used for each account link.
-     */
-    public static final String ACOUNT_LINK_SEQ = "ACOUNT_LINK_SEQ";
-
-    /**
      * External profile link.
      */
     public static final String EXT_PROF_LINK_SEQ = "EXT_PROF_LINK_SEQ";


### PR DESCRIPTION
Remove redundant comments, constructor, and trailing whitespace; rename table and columns for clarity; use Hibernate to generate IDs.

The external account functionality is not working, so I'm converting this blind. We'll need to revisit this once we have a better understanding of what we want external accounts to look like.

Given that, I tested by building, deploying, and logging in.

Issue #36 Use Hibernate 5, instead of 4