### PR TITLE
Remove unused sequence name

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Sequences.java
@@ -32,8 +32,6 @@ public class Sequences {
      */
     public static final String EXT_PROF_LINK_SEQ = "EXT_PROF_LINK_SEQ";
 
-    public static final String PROVIDER_COS_SEQ = "PROVIDER_COS_SEQ";
-
     /**
      * Private constructor.
      */


### PR DESCRIPTION
While converting ProviderCategoryOfService in #244, I was so focused on the complicated bits that I missed one of the simple bits: deleting the now-unused sequence name.

Issue #36 Use Hibernate 5, instead of 4