### PR TITLE
Associate labels with inputs in tribal information question

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
@@ -19,8 +19,18 @@
             <div>
                 <c:set var="formName" value="_13_worksOnReservation"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="radio" onchange="showHideForm('tableLicense3', true);" value="Y" name="${formName}" ${formValue eq 'Y' ? 'checked' : ''}><label class="span">Yes</label>
-                <input type="radio" onchange="showHideForm('tableLicense3', false);" value="N" name="${formName}" ${formValue eq 'N' ? 'checked' : ''}><label class="span">No</label>            
+                <input type="radio"
+                       onchange="showHideForm('tableLicense3', true);"
+                       value="Y"
+                       name="${formName}"
+                       ${formValue eq 'Y' ? 'checked' : ''}>
+                <label class="span">Yes</label>
+                <input type="radio"
+                       onchange="showHideForm('tableLicense3', false);"
+                       value="N"
+                       name="${formName}"
+                       ${formValue eq 'N' ? 'checked' : ''}>
+                <label class="span">No</label>
             </div>
         </div>
         <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
@@ -19,18 +19,22 @@
             <div>
                 <c:set var="formName" value="_13_worksOnReservation"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="radio"
-                       onchange="showHideForm('tableLicense3', true);"
-                       value="Y"
-                       name="${formName}"
-                       ${formValue eq 'Y' ? 'checked' : ''}>
-                <label class="span">Yes</label>
-                <input type="radio"
-                       onchange="showHideForm('tableLicense3', false);"
-                       value="N"
-                       name="${formName}"
-                       ${formValue eq 'N' ? 'checked' : ''}>
-                <label class="span">No</label>
+                <label class="span">
+                    <input type="radio"
+                           onchange="showHideForm('tableLicense3', true);"
+                           value="Y"
+                           name="${formName}"
+                           ${formValue eq 'Y' ? 'checked' : ''}>
+                    Yes
+                </label>
+                <label class="span">
+                    <input type="radio"
+                           onchange="showHideForm('tableLicense3', false);"
+                           value="N"
+                           name="${formName}"
+                           ${formValue eq 'N' ? 'checked' : ''}>
+                    No
+                </label>
             </div>
         </div>
         <div class="clearFixed"></div>


### PR DESCRIPTION
I noticed that some of the labels were unassociated with their corresponding radio buttons. The first example is the radio buttons used to answer the question "Is applicant a provider at a Public Health Service (PHS) Indian Hospital?" Leaving them unassociated means there is a smaller target to click, which is inconvenient for us as we fill out enrollments for testing; it may also make it harder for screen readers to understand the page.

I verified that the computed CSS rules using Firebug had no meaningful change - the only difference is that the radio buttons now have the style `font-weight: normal`.

To test, create a new enrollment as, say, an Acupuncturist, fill out the personal info, click next, and then click on the "Yes" or "No" text and see the corresponding radio button become selected.