### PR TITLE
Add branch and PR constraints for Javadoc publication

### DIFF
--- a/scripts/push-javadoc-to-gh-pages.sh
+++ b/scripts/push-javadoc-to-gh-pages.sh
@@ -4,7 +4,9 @@ set -ex
 # Adaptation of code from https://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
 if [ "$TRAVIS_REPO_SLUG" == "OpenTechStrategies/psm" ] \
-       && [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then
+       && [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] \
+       && [ "$TRAVIS_PULL_REQUEST" == "false" ] \
+       && [ "$TRAVIS_BRANCH" == "master" ]; then
 
   echo -e "Publishing Javadoc...\n"
 


### PR DESCRIPTION
Reverting 3d8dd9ed41556f3f4ff7e65bcebcf4cadeab4255 which should not have been merged. We should only publish Javadocs to GitHub Pages on merges to the master branch. (I apologize for not being clear in #249 that the second of the two commits there should not have been merged, and for thoughtlessly saying "yeah go ahead and merge that" in IRC.)