### PR TITLE
ETL download reinstatements

### DIFF
--- a/etl/leie/leie/etl.py
+++ b/etl/leie/leie/etl.py
@@ -20,7 +20,7 @@ import time
 # Our modules
 import log
 import model
-from path import get_existing_file
+from path import get_datadir, get_dbdir, get_existing_file
 
 warn, info, debug, fatal = log.reporters()
 
@@ -258,30 +258,20 @@ def dload_if_stale(fname, url):
 
         assert int(r.headers["Content-Length"]) == os.path.getsize(fname)
 
-def extract(datadir):
+def download(datadir):
+    """Download UPDATED.csv and reinstatements to the DATADIR"""
     dload_if_stale(os.path.join(datadir, "UPDATED.csv"), 'https://oig.hhs.gov/exclusions/downloadables/UPDATED.csv')
 
     # TODO: download reinstatement csv (https://oig.hhs.gov/exclusions/downloadables/2017/1705REIN.csv)
 
 def main():
-    # Find data dir
-    datadir = get_existing_file(["/var/etl/leie/data",
-                                 "data",
-                                 "../data",
-                                 os.path.join(os.path.dirname(__file__), "data"),
-                                 os.path.join(os.path.dirname(__file__), "..", "data")],
-                                default="data",
-                                create=True)
-    info("Using '%s' as data directory" % datadir)
+    os.chdir(os.path.dirname(__file__))
+    logger = log.logger()
+    info('Starting ETL of LEIE data.')
 
-    # Figure out where our db is
-    dbdir = get_existing_file(["/var/etl/leie/db",
-                               "db",
-                               "../db",
-                               os.path.join(os.path.dirname(__file__), "db"),
-                               os.path.join(os.path.dirname(__file__), "..", "db")],
-                              "db")
-    info("Using '%s' as db directory" % dbdir)
+    # Figure out where we put data
+    datadir = get_datadir()
+    dbdir = get_dbdir()
 
     # Get a database connection, create db if needed
     conn = model.LEIE("development", db_conf_file=os.path.join(dbdir, "dbconf.yml"))
@@ -292,7 +282,7 @@ def main():
     assert os.path.exists(datadir)
 
     # Do our ETL
-    extract(datadir)
+    download(datadir)
     excl = Exclusions(conn)
     excl.etl_from_dir(datadir)
     rein = Reinstatements(conn)
@@ -301,9 +291,7 @@ def main():
     # Close the db connection
     conn.close()
 
-if __name__ == '__main__':
-    os.chdir(os.path.dirname(__file__))
-    logger = log.logger()
-    info('Starting ETL of LEIE data.')
-    main()
     info('Finished ETL of LEIE data.')
+
+if __name__ == '__main__':
+    main()

--- a/etl/leie/leie/etl.py
+++ b/etl/leie/leie/etl.py
@@ -230,8 +230,10 @@ def fname_is_stale(fname, url):
         warn("Can't get head information about %s" % url)
         return False
 
-    # TODO: If size indicated in header differ from size on disk, then
+    # If size indicated in header differ from size on disk, then
     # the file is stale.
+    if int(r.headers["Content-Length"]) != os.path.getsize(fname):
+        return False
 
     # Get mod times of url and fname
     mtime = datetime.fromtimestamp(os.path.getmtime(fname))  # file's mtime
@@ -254,7 +256,7 @@ def dload_if_stale(fname, url):
                 if chunk: # filter out keep-alive new chunks
                     f.write(chunk)
 
-        # TODO: check file size in headers vs what we got.
+        assert int(r.headers["Content-Length"]) == os.path.getsize(fname)
 
 def extract(datadir):
     dload_if_stale(os.path.join(datadir, "UPDATED.csv"), 'https://oig.hhs.gov/exclusions/downloadables/UPDATED.csv')

--- a/etl/leie/leie/log.py
+++ b/etl/leie/leie/log.py
@@ -10,6 +10,10 @@ And in main, do:
 
 logger = log.logger()
 
+There is a second log of activities related to the database.  It is
+contained in the db and the code reads and writes it to record etl
+transactions.  Code for that is in dblog.py and model.py.
+
 """
 
 import logging

--- a/etl/leie/leie/model.py
+++ b/etl/leie/leie/model.py
@@ -217,6 +217,7 @@ DROP TABLE business_reinstatement;"""
             out = out.decode("utf-8")
             err = err.decode("utf-8")
             if err != '':
+                sys.stderr.write("%s\n%s" % (out, err))
                 raise subprocess.CalledProcessError(0, cmd, out+err)
             return out
 

--- a/etl/leie/leie/path.py
+++ b/etl/leie/leie/path.py
@@ -3,6 +3,10 @@
 from contextlib import contextmanager
 import os
 
+# Import our modules
+import log
+warn, info, debug, fatal = log.reporters()
+
 @contextmanager
 def cd(path):
     """Temporarily change directory"""
@@ -12,6 +16,29 @@ def cd(path):
         yield
     finally:
         os.chdir(old)
+
+def get_datadir():
+    """Figure out where the data directory is and return that as a string."""
+    datadir = get_existing_file(["/var/etl/leie/data",
+                                 "data",
+                                 "../data",
+                                 os.path.join(os.path.dirname(__file__), "data"),
+                                 os.path.join(os.path.dirname(__file__), "..", "data")],
+                                default="data",
+                                create=True)
+    info("Using '%s' as data directory" % datadir)
+    return datadir
+
+def get_dbdir():
+    """Figure out where our db is and return that path as a string."""
+    dbdir = get_existing_file(["/var/etl/leie/db",
+                               "db",
+                               "../db",
+                               os.path.join(os.path.dirname(__file__), "db"),
+                               os.path.join(os.path.dirname(__file__), "..", "db")],
+                              default="db")
+    info("Using '%s' as db directory" % dbdir)
+    return dbdir
 
 def get_existing_file(files, default=None, create=False):
     """FILES is a list of files or directories.  We cycle through and return a

--- a/etl/leie/leie/tests/test_etl.py
+++ b/etl/leie/leie/tests/test_etl.py
@@ -86,6 +86,20 @@ def test_exclusion(conn):
     rows = int(subprocess.check_output("wc -l tests/data/UPDATED.csv", shell=True).decode("utf-8").split(' ')[0])
     assert conn.count_exclusions() == rows - 1
 
+def test_get_datadir():
+    """We can't really know what this will return because if it is run on a
+    running system, there might be a /etc file.  All we can really do is see if
+    we have a string or not."""
+
+    assert type(etl.get_datadir()) == type("")
+
+def test_get_dbdir():
+    """We can't really know what this will return because if it is run on a
+    running system, there might be a /etc file.  All we can really do is see if
+    we have a string or not."""
+
+    assert type(etl.get_dbdir()) == type("")
+
 def test_reinstatement(conn):
     print("We just do a complete reinstatement ETL and then see if the results are as expected.")
     rein = etl.Reinstatements(conn)

--- a/etl/leie/leie/tests/test_model.py
+++ b/etl/leie/leie/tests/test_model.py
@@ -35,6 +35,18 @@ def test_goose_write():
     for fname in fnames:
         assert os.path.exists(fname)
 
+def test_log(conn):
+    import random
+    msg = "Test %d" % random.randint(0,9999999999)
+    conn.log("updated", msg)
+    crsr = conn.conn.cursor()
+    cols = crsr.execute("Select * from log where msg=?", [msg]).fetchall()
+    print("Log columns returned: ", cols)
+    assert len(cols) == 1
+    cols = cols[0]
+    assert cols[1] == "updated"
+    assert cols[2] == msg
+
 def test_main():
     """Main just does goose_write, so this is the mostly same test as
     test_goose_write"""

--- a/etl/leie/leie/tests/test_model.py
+++ b/etl/leie/leie/tests/test_model.py
@@ -66,7 +66,7 @@ def test_migrate():
     assert subprocess.check_output("echo .schema | sqlite3 %s" % conn.db_conf['open'], shell=True).decode("utf-8") == ""
     conn.migrate()
     assert subprocess.check_output("echo .schema | sqlite3 %s" % conn.db_conf['open'], shell=True).decode("utf-8") != ""
-    assert conn.get_header("individual_exclusion")[0] == "lastname"
+    assert conn.get_header("exclusion")[0] == "lastname"
     conn.close()
 
     # Check that migrate complains about non-existent directory

--- a/etl/leie/test
+++ b/etl/leie/test
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+cd $(dirname $0)
+
 if [[ "$1" == "dist" ]]; then
 	shift
 	rm -rf dist


### PR DESCRIPTION
This is based on etl-refactor (and the first few commits are from that branch).

This adds the ability to log certain actions to the database, which we do to keep a transaction log for downloading files.  Then it downloads the reinstatement files as needed from the LEIE website.  

Along the way, we tossed out the distinction between individual and business exclusion entries.  That distinction wasn't in the original data.  We can redraw the distinction as we need it, so nothing is lost.  Best of all, it lets us treat all the exclusions data as one thing instead of maintaining multiple code paths for the business vs individual records.

This stuff needs tests written.  I didn't want to hold up other dev work that needs to connect to the LEIE stuff, so I'm submitting it.  I'll write tests next week.