### PR TITLE
ETL serve exclusions

### DIFF
--- a/etl/leie/README.mdwn
+++ b/etl/leie/README.mdwn
@@ -188,6 +188,8 @@ newer versions will break anything.  If you change versions, use the
 test suite.
 
     $ pip install \
+        dicttoxml \
+        flask \
         petl==1.1.1 \
         python-dateutil==2.6.0
         pyyaml=3.12 \

--- a/etl/leie/leie/etl.py
+++ b/etl/leie/leie/etl.py
@@ -20,7 +20,7 @@ import time
 # Our modules
 import log
 import model
-from path import get_existing_file
+from path import get_datadir, get_dbdir, get_existing_file
 
 warn, info, debug, fatal = log.reporters()
 
@@ -258,30 +258,20 @@ def dload_if_stale(fname, url):
 
         assert int(r.headers["Content-Length"]) == os.path.getsize(fname)
 
-def extract(datadir):
+def download(datadir):
+    """Download UPDATED.csv and reinstatements to the DATADIR"""
     dload_if_stale(os.path.join(datadir, "UPDATED.csv"), 'https://oig.hhs.gov/exclusions/downloadables/UPDATED.csv')
 
     # TODO: download reinstatement csv (https://oig.hhs.gov/exclusions/downloadables/2017/1705REIN.csv)
 
 def main():
-    # Find data dir
-    datadir = get_existing_file(["/var/etl/leie/data",
-                                 "data",
-                                 "../data",
-                                 os.path.join(os.path.dirname(__file__), "data"),
-                                 os.path.join(os.path.dirname(__file__), "..", "data")],
-                                default="data",
-                                create=True)
-    info("Using '%s' as data directory" % datadir)
+    os.chdir(os.path.dirname(__file__))
+    logger = log.logger()
+    info('Starting ETL of LEIE data.')
 
-    # Figure out where our db is
-    dbdir = get_existing_file(["/var/etl/leie/db",
-                               "db",
-                               "../db",
-                               os.path.join(os.path.dirname(__file__), "db"),
-                               os.path.join(os.path.dirname(__file__), "..", "db")],
-                              "db")
-    info("Using '%s' as db directory" % dbdir)
+    # Figure out where we put data
+    datadir = get_datadir()
+    dbdir = get_dbdir()
 
     # Get a database connection, create db if needed
     conn = model.LEIE("development", db_conf_file=os.path.join(dbdir, "dbconf.yml"))
@@ -292,7 +282,7 @@ def main():
     assert os.path.exists(datadir)
 
     # Do our ETL
-    extract(datadir)
+    download(datadir)
     excl = Exclusions(conn)
     excl.etl_from_dir(datadir)
     rein = Reinstatements(conn)
@@ -301,9 +291,7 @@ def main():
     # Close the db connection
     conn.close()
 
-if __name__ == '__main__':
-    os.chdir(os.path.dirname(__file__))
-    logger = log.logger()
-    info('Starting ETL of LEIE data.')
-    main()
     info('Finished ETL of LEIE data.')
+
+if __name__ == '__main__':
+    main()

--- a/etl/leie/leie/etl.py
+++ b/etl/leie/leie/etl.py
@@ -230,8 +230,10 @@ def fname_is_stale(fname, url):
         warn("Can't get head information about %s" % url)
         return False
 
-    # TODO: If size indicated in header differ from size on disk, then
+    # If size indicated in header differ from size on disk, then
     # the file is stale.
+    if int(r.headers["Content-Length"]) != os.path.getsize(fname):
+        return False
 
     # Get mod times of url and fname
     mtime = datetime.fromtimestamp(os.path.getmtime(fname))  # file's mtime
@@ -254,7 +256,7 @@ def dload_if_stale(fname, url):
                 if chunk: # filter out keep-alive new chunks
                     f.write(chunk)
 
-        # TODO: check file size in headers vs what we got.
+        assert int(r.headers["Content-Length"]) == os.path.getsize(fname)
 
 def extract(datadir):
     dload_if_stale(os.path.join(datadir, "UPDATED.csv"), 'https://oig.hhs.gov/exclusions/downloadables/UPDATED.csv')

--- a/etl/leie/leie/log.py
+++ b/etl/leie/leie/log.py
@@ -10,6 +10,10 @@ And in main, do:
 
 logger = log.logger()
 
+There is a second log of activities related to the database.  It is
+contained in the db and the code reads and writes it to record etl
+transactions.  Code for that is in dblog.py and model.py.
+
 """
 
 import logging

--- a/etl/leie/leie/model.py
+++ b/etl/leie/leie/model.py
@@ -217,6 +217,7 @@ DROP TABLE business_reinstatement;"""
             out = out.decode("utf-8")
             err = err.decode("utf-8")
             if err != '':
+                sys.stderr.write("%s\n%s" % (out, err))
                 raise subprocess.CalledProcessError(0, cmd, out+err)
             return out
 

--- a/etl/leie/leie/path.py
+++ b/etl/leie/leie/path.py
@@ -3,6 +3,10 @@
 from contextlib import contextmanager
 import os
 
+# Import our modules
+import log
+warn, info, debug, fatal = log.reporters()
+
 @contextmanager
 def cd(path):
     """Temporarily change directory"""
@@ -12,6 +16,29 @@ def cd(path):
         yield
     finally:
         os.chdir(old)
+
+def get_datadir():
+    """Figure out where the data directory is and return that as a string."""
+    datadir = get_existing_file(["/var/etl/leie/data",
+                                 "data",
+                                 "../data",
+                                 os.path.join(os.path.dirname(__file__), "data"),
+                                 os.path.join(os.path.dirname(__file__), "..", "data")],
+                                default="data",
+                                create=True)
+    info("Using '%s' as data directory" % datadir)
+    return datadir
+
+def get_dbdir():
+    """Figure out where our db is and return that path as a string."""
+    dbdir = get_existing_file(["/var/etl/leie/db",
+                               "db",
+                               "../db",
+                               os.path.join(os.path.dirname(__file__), "db"),
+                               os.path.join(os.path.dirname(__file__), "..", "db")],
+                              default="db")
+    info("Using '%s' as db directory" % dbdir)
+    return dbdir
 
 def get_existing_file(files, default=None, create=False):
     """FILES is a list of files or directories.  We cycle through and return a

--- a/etl/leie/leie/serve.py
+++ b/etl/leie/leie/serve.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+"""
+Run this with:
+
+`FLASK_APP=serve.py flask run`
+"""
+
+import dateutil
+import dicttoxml
+from flask import Flask, make_response, request, Response, url_for
+import math
+import os
+import simplejson as json
+import sys
+
+# Make sure we can load modules from this directory
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Load my modules
+import etl
+import model
+
+app = Flask("leie")
+
+baseurl = ""
+
+# Get a database connection, create db if needed
+conn = model.LEIE("development", db_conf_file=os.path.join(etl.get_dbdir(), "dbconf.yml"))
+
+def slurp(fname):
+    """Read file named FNAME and return contents."""
+    with open(fname) as fh:
+        return fh.read()
+
+@app.errorhandler(404)
+def not_found(error):
+        return make_response(json.dumps({'error': 'Not found'}), 404)
+
+@app.route("/")
+def home():
+    return slurp("api.html")
+
+@app.route("/exclusion", methods=["DELETE", "PATCH", "POST", "PUT"])
+def method_not_allowed():
+    return "", 405
+
+def parse_param_date(param_date):
+    """Try to parse the date. Return None if there's nothing there to parse."""
+    if not param_date:
+        return None
+    return dateutil.parser.parse(param_date)
+
+@app.route('/exclusion/<rowid>')
+@app.route("/exclusion")
+def get_exclusions(rowid=None):
+    """Search the exclusions table and return rows.
+
+    ROWID is the id of the exclusion record
+
+    This function checks the http request parameter string for
+    parameters whose names match fields in the exclusion table.  Anything
+    specified there must be matched exactly by matching entries.
+
+    Specify a PAGE param and (optionally) a PAGE_SIZE param to do
+    paging.
+
+    """
+    # Handle parameters that apply to both single row and bundles
+    params = {}
+    filter = dict(busname=request.args.get('busname'),
+                  firstname=request.args.get('firstname'),
+                  lastname=request.args.get('lastname'),
+                  npi=request.args.get('npi'),
+                  rowid=rowid or request.args.get('rowid'), # rowid can come in as a param or part of the url
+                  state=request.args.get('state'),
+                  zip=request.args.get('zip'),
+                  address=request.args.get('address'),
+                  excltype=request.args.get('excltype'),
+                  waiverstate=request.args.get('waiverstate'),
+                  city=request.args.get('city'),
+                  upin=request.args.get('upin'),
+                  general=request.args.get('general'),
+                  midname=request.args.get('midname'),
+                  specialty=request.args.get('specialty'),
+                  excldate=parse_param_date(request.args.get('excldate')),
+                  waiverdate=parse_param_date(request.args.get('waiverdate')),
+                  dob=parse_param_date(request.args.get('dob')),
+                  reindate=parse_param_date(request.args.get('reindate')),
+    )
+    
+    page = int(request.args.get('page') or 1) # default 1
+    page_size = min(int(request.args.get('page_size') or 15), 100) # default 15, max 100
+    params.update(dict(page=page, page_size=page_size, **filter))
+
+    func_name = sys._getframe().f_code.co_name # get name of current function
+    exclusions = [e.fhir() for e in conn.get_exclusions(limit=page_size, page=page, filter=filter, form="dict")]
+    
+    if rowid and len(exclusions) == 1:
+        ret = exclusions[0]
+        ret['link'] = [{"relation": "self", "url": baseurl + url_for(func_name, **params)}]
+    else:
+
+        # Make the paging stuff for the bundle
+        num_pages = math.ceil(conn.count_exclusions() / page_size)
+        ret = {
+            "resourceType": "Bundle",
+            "link": [
+                {"relation": "self", "url": baseurl + url_for(func_name, **params)},
+                {"relation": "first", "url": baseurl + url_for(func_name, **dict(params.items(), page=1))},
+                {"relation": "previous", "url": baseurl + url_for(func_name, **dict(params.items(), page=max([page-1, 1])))},
+                {"relation": "next", "url": baseurl + url_for(func_name, **dict(params.items(), page=min([page+1, num_pages])))},
+                {"relation": "last", "url": baseurl + url_for(func_name, **dict(params.items(), page=num_pages))}
+            ],        
+            "meta":{"tag":[]},
+            "total":len(exclusions),
+            "type":"searchset",
+            "entry":[{"fullUrl":baseurl + url_for(func_name, rowid=e['id']),
+                      "resource":e} for e in exclusions]
+        }
+
+        # If this is a subset, indicate that in the output
+        if num_pages > 1:
+            ret['meta']['tag'].append("SUBSETTED")
+
+    ## Render output as html, json or xml and return it
+    if not request.content_type or 'html' in request.content_type:
+        # We pass here because we want to fall through to the default, which is html
+        pass
+    elif 'json' in request.content_type:
+        return Response(json.dumps(ret), mimetype='application/fhir+json')
+    elif 'xml' in request.content_type:
+        return Response(dicttoxml.dicttoxml(ret), mimetype='application/fhir+xml')
+    return Response(json.dumps(ret), mimetype='text/html') #TODO: put this in an html template
+
+if __name__ == "__main__":
+    os.system('pandoc api.mdwn > api.html')
+    app.run()

--- a/etl/leie/leie/tests/test_etl.py
+++ b/etl/leie/leie/tests/test_etl.py
@@ -86,6 +86,20 @@ def test_exclusion(conn):
     rows = int(subprocess.check_output("wc -l tests/data/UPDATED.csv", shell=True).decode("utf-8").split(' ')[0])
     assert conn.count_exclusions() == rows - 1
 
+def test_get_datadir():
+    """We can't really know what this will return because if it is run on a
+    running system, there might be a /etc file.  All we can really do is see if
+    we have a string or not."""
+
+    assert type(etl.get_datadir()) == type("")
+
+def test_get_dbdir():
+    """We can't really know what this will return because if it is run on a
+    running system, there might be a /etc file.  All we can really do is see if
+    we have a string or not."""
+
+    assert type(etl.get_dbdir()) == type("")
+
 def test_reinstatement(conn):
     print("We just do a complete reinstatement ETL and then see if the results are as expected.")
     rein = etl.Reinstatements(conn)

--- a/etl/leie/leie/tests/test_model.py
+++ b/etl/leie/leie/tests/test_model.py
@@ -35,6 +35,18 @@ def test_goose_write():
     for fname in fnames:
         assert os.path.exists(fname)
 
+def test_log(conn):
+    import random
+    msg = "Test %d" % random.randint(0,9999999999)
+    conn.log("updated", msg)
+    crsr = conn.conn.cursor()
+    cols = crsr.execute("Select * from log where msg=?", [msg]).fetchall()
+    print("Log columns returned: ", cols)
+    assert len(cols) == 1
+    cols = cols[0]
+    assert cols[1] == "updated"
+    assert cols[2] == msg
+
 def test_main():
     """Main just does goose_write, so this is the mostly same test as
     test_goose_write"""

--- a/etl/leie/leie/tests/test_model.py
+++ b/etl/leie/leie/tests/test_model.py
@@ -66,7 +66,7 @@ def test_migrate():
     assert subprocess.check_output("echo .schema | sqlite3 %s" % conn.db_conf['open'], shell=True).decode("utf-8") == ""
     conn.migrate()
     assert subprocess.check_output("echo .schema | sqlite3 %s" % conn.db_conf['open'], shell=True).decode("utf-8") != ""
-    assert conn.get_header("individual_exclusion")[0] == "lastname"
+    assert conn.get_header("exclusion")[0] == "lastname"
     conn.close()
 
     # Check that migrate complains about non-existent directory

--- a/etl/leie/test
+++ b/etl/leie/test
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+cd $(dirname $0)
+
 if [[ "$1" == "dist" ]]; then
 	shift
 	rm -rf dist


### PR DESCRIPTION
This is based on etl-download-reinstatements and etl-refactor.  All patches before "Serve exclusions table over http" are from other branches and can be ignored here.  Review them in the other PR if you must.

This patch introduces a new executable file, serve.py that makes a very simple read-only searchable interface to the exclusions data (but not the reinstatements data).  It tries to comport with FHIR 3 but it is incomplete.  More FHIR 3 will come over time.

Once this is in place, we can start hooking this data into the main code via the API.  Additional interfaces will be needed, but I want to get this one in decent shape so we can pattern the other ones after it.

This stuff needs tests written.  I didn't want to hold up other dev work that needs to connect to the LEIE stuff, so I'm submitting it.  I'll write tests next week.