### PR TITLE
Add scripts to help refresh developer environment

### DIFF
--- a/scripts/drop-contents-of-db-for-testing.sql
+++ b/scripts/drop-contents-of-db-for-testing.sql
@@ -1,0 +1,3 @@
+/* For use in rebuild-and-change-schema-for-testing.sh */
+
+DROP OWNED BY current_user;

--- a/scripts/rebuild-and-change-schema-for-testing.sh
+++ b/scripts/rebuild-and-change-schema-for-testing.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# A script to build a fresh EAR, blow away the old database
+# contents and build a new schema, and deploy the EAR.
+# For use in development when testing a pull request.
+
+# If you don't want to have to type in the psm user's
+# PostgreSQL password midway through, create a .pgpass file
+# in your home directory:
+# https://www.postgresql.org/docs/current/static/libpq-pgpass.html
+
+RESPONSE=$(../../wildfly-10.1.0.Final/bin/jboss-cli.sh --connect --command=":read-attribute(name=server-state)")
+# Check whether WildFly is running.
+# TODO: use something like
+# http://www.mastertheboss.com/jboss-server/jboss-monitoring/monitor-wildfly-with-your-bash-skills
+# to check whether WildFly is about to run out of memory.
+if echo $RESPONSE | grep "Failed"
+then
+    echo "Please start WildFly in another terminal first:"
+    echo "wildfly-10.1.0.Final/bin/standalone.sh -c standalone-full.xml"
+else
+    set -e
+    cd ../psm-app
+    ./gradlew cms-portal-services:build
+    cd ..
+    echo "Re-seeding database"
+    cat scripts/drop-contents-of-db-for-testing.sql \
+	psm-app/db/legacy_seed.sql \
+	psm-app/db/jbpm.sql \
+	psm-app/db/seed.sql | psql -h localhost -U psm psm
+    # Once we have a new dev enrollment schema:
+    # psql -h localhost -U psm psm < psm-app/db/dev_enrollment.sql
+    echo "Deploying new EAR"
+    ../wildfly-10.1.0.Final/bin/jboss-cli.sh --connect \
+       --command="deploy --force
+       psm-app/cms-portal-services/build/libs/cms-portal-services.ear"
+    echo "Ready to test at http://localhost:8080/cms/ ."
+    echo "To stop WildFly server:  wildfly-10.1.0.Final/bin/jboss-cli.sh --connect --command=:shutdown "
+fi


### PR DESCRIPTION
When testing a pull request, we often need to refresh our developer
environments. This bash script restarts WildFly, builds a fresh EAR,
blows away the old database contents (thus the new one-line SQL file),
builds a new schema, and deploys the EAR. It's based on a script by
Cecilia and help from Jason, per
https://groups.google.com/forum/#!topic/psm-dev/INETwkaFZ9g .

I've tested this locally and it works for me, usually running in under a minute.