### PR TITLE
Add contextual help about NPIs to provider enrollment screen

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
@@ -13,25 +13,25 @@
 <div id="new-modal">
     <!-- /#deleteUserAccountModal-->
     <div id="deleteUserAccountModal" class="outLay">
-        <div class="inner"> 
+        <div class="inner">
             <!-- title -->
             <div class="modal-title">
                 <div class="right">
                     <div class="middle">
-                        <a href="javascript:;" class="closeModal"></a> 
+                        <a href="javascript:;" class="closeModal"></a>
                         <h2>Delete User Account</h2>
-                        
+
                     </div>
                 </div>
             </div>
-            <!-- End .modal-title --> 
-    
+            <!-- End .modal-title -->
+
             <!-- content -->
             <div class="modal-content">
                 <div class="right">
                     <div class="middle">
                         <p>Are you sure you want to delete <span class="deleteAccountSpan">this user account</span>?</p>
-                        <div class="buttonArea"> 
+                        <div class="buttonArea">
                             <a href="javascript:;" class="purpleBtn closeModal okBtn linkRight" id="deleteBtn"><span class="btR"><span class="btM">Yes, delete</span></span></a>
                             <a href="javascript:;" class="greyBtn closeModal"><span class="btR"><span class="btM">No, retain <span class="deleteAccountSpan">this user account</span> and cancel deletion</span></span></a>
                         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/includes/userhelp/npi.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/includes/userhelp/npi.jsp
@@ -1,0 +1,4 @@
+An NPI is a National Provider Identifier number.
+
+You can search NPIs or register for an NPI at NPPES (the National Plan
+&amp; Provider Enumeration System).

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -40,8 +40,12 @@
             </div>
             <div class="row requireField">
                 <%-- BUGR-9673 (optional NPI for some provider types) --%>
-                <label>NPI<span class="required">${requireNPI ? '*' : ''}
-                    </span></label>
+                <label
+                    title="<%@ include
+                        file="/WEB-INF/pages/includes/userhelp/npi.jsp" %>">NPI
+                        <span class="required">${requireNPI ? '*' : ''}
+                        </span>
+                </label>
                 <span class="floatL"><b>:</b></span>
 
                 <c:set var="formName" value="_02_npi"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -11,98 +11,99 @@
 <c:set var="requireNPI" value="${viewModel.tabModels[viewModel.currentTab].formSettings['Personal Information Form'].settings['requireNPI']}"></c:set>
 
 <div class="newEnrollmentPanel">
-	<div class="section">
-	    <input type="hidden" name="formNames" value="<%= ViewStatics.PERSONAL_INFO_FORM %>">
-	    <div class="wholeCol">
+    <div class="section">
+        <input type="hidden" name="formNames" value="<%= ViewStatics.PERSONAL_INFO_FORM %>">
+        <div class="wholeCol">
             <div class="row requireField">
                 <label>First Name<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_02_firstName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="normalInput" id="firstName" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row">
-	            <label>Middle Name</label>
-	            <span class="floatL"><b>:</b></span>
-	            
-	            <c:set var="formName" value="_02_middleName"></c:set>
-	            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <input type="text" class="normalInput" id="middleName" name="${formName}" value="${formValue}" maxlength="45"/>
-	        </div>
-	        <div class="row requireField">
-	            <label>Last Name<span class="required">*</span></label>
-	            <span class="floatL"><b>:</b></span>
-	
-		        <c:set var="formName" value="_02_lastName"></c:set>
-		        <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <input type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
-	        </div>
-	        <div class="row requireField">
-	        	<%-- BUGR-9673 (optional NPI for some provider types) --%>
-	            <label>NPI<span class="required">${requireNPI ? '*' : ''}</span></label>
-	            <span class="floatL"><b>:</b></span>
-	            
-	            <c:set var="formName" value="_02_npi"></c:set>
-	            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <input type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
-	        </div>
-	        <div class="row requireField">
-	            <label>Social Security Number<span class="required">*</span></label>
-	            <span class="floatL"><b>:</b></span>
-	
-	            <c:set var="formName" value="_02_ssn"></c:set>
-	            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <input type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
-	        </div>
-	        <div class="row requireField">
-	            <label>Date of Birth<span class="required">*</span></label>
-	            <span class="floatL"><b>:</b></span>
-	            <span class="dateWrapper floatL">
-	
-		            <c:set var="formName" value="_02_dob"></c:set>
-		            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	                <input class="date" type="text" name="${formName}" value="${formValue}" maxlength="10"/>
-	            </span>
-	        </div>
-	        <div class="row">
-	            <label>Email Address</label>
-	            <span class="floatL"><b>:</b></span>
-	
-	            <c:set var="formName" value="_02_email"></c:set>
-	            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <input type="text" class="normalInput" id="emailAddress" name="${formName}" value="${formValue}" maxlength="50"/>
-	        </div>
-	        <div class="clearFixed"></div>
-	    </div>
-	    <div class="tableHeader"><span>Contact Info</span></div>
-	    <div class="clearFixed"></div>
-	    <div class="wholeCol">
-	        <div class="row">
-	            <c:set var="formName" value="_02_useProviderAsContact"></c:set>
-	            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <c:set var="disableContact" value="${formValue eq 'Y' ? 'disabled' : ''}"></c:set>
-	            <input type="checkbox" class="checkbox" id="sameAsAbove" ${formValue eq 'Y' ? 'checked' : ''} name="${formName}" />Same as Above
-	        </div>
-	        <div class="row requireField">
-	            <label>Contact Name<span class="required">*</span></label>
-	            <span class="floatL"><b>:</b></span>
-	            <c:set var="formName" value="_02_contactName"></c:set>
-	            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <input ${disableContact} type="text" class="${disableContact} normalInput" id="contactName" name="${formName}" value="${formValue}" maxlength="100"/>
-	        </div>
-	        <div class="row">
-	            <label>Contact Email Address</label>
-	            <span class="floatL"><b>:</b></span>
-	            
-	            <c:set var="formName" value="_02_contactEmail"></c:set>
-	            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-	            <input ${disableContact} type="text" class="${disableContact} normalInput" id="contactEmail" name="${formName}" value="${formValue}" maxlength="50"/>
-	        </div>
-	        <div class="clearFixed"></div>
-	    </div>
-	</div>
-	<!-- /.section -->
+                <label>Middle Name</label>
+                <span class="floatL"><b>:</b></span>
+
+                <c:set var="formName" value="_02_middleName"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input type="text" class="normalInput" id="middleName" name="${formName}" value="${formValue}" maxlength="45"/>
+            </div>
+            <div class="row requireField">
+                <label>Last Name<span class="required">*</span></label>
+                <span class="floatL"><b>:</b></span>
+
+                <c:set var="formName" value="_02_lastName"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
+            </div>
+            <div class="row requireField">
+                <%-- BUGR-9673 (optional NPI for some provider types) --%>
+                <label>NPI<span class="required">${requireNPI ? '*' : ''}
+                    </span></label>
+                <span class="floatL"><b>:</b></span>
+
+                <c:set var="formName" value="_02_npi"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
+            </div>
+            <div class="row requireField">
+                <label>Social Security Number<span class="required">*</span></label>
+                <span class="floatL"><b>:</b></span>
+
+                <c:set var="formName" value="_02_ssn"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
+            </div>
+            <div class="row requireField">
+                <label>Date of Birth<span class="required">*</span></label>
+                <span class="floatL"><b>:</b></span>
+                <span class="dateWrapper floatL">
+
+                    <c:set var="formName" value="_02_dob"></c:set>
+                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                    <input class="date" type="text" name="${formName}" value="${formValue}" maxlength="10"/>
+                </span>
+            </div>
+            <div class="row">
+                <label>Email Address</label>
+                <span class="floatL"><b>:</b></span>
+
+                <c:set var="formName" value="_02_email"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input type="text" class="normalInput" id="emailAddress" name="${formName}" value="${formValue}" maxlength="50"/>
+            </div>
+            <div class="clearFixed"></div>
+        </div>
+        <div class="tableHeader"><span>Contact Info</span></div>
+        <div class="clearFixed"></div>
+        <div class="wholeCol">
+            <div class="row">
+                <c:set var="formName" value="_02_useProviderAsContact"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <c:set var="disableContact" value="${formValue eq 'Y' ? 'disabled' : ''}"></c:set>
+                <input type="checkbox" class="checkbox" id="sameAsAbove" ${formValue eq 'Y' ? 'checked' : ''} name="${formName}" />Same as Above
+            </div>
+            <div class="row requireField">
+                <label>Contact Name<span class="required">*</span></label>
+                <span class="floatL"><b>:</b></span>
+                <c:set var="formName" value="_02_contactName"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input ${disableContact} type="text" class="${disableContact} normalInput" id="contactName" name="${formName}" value="${formValue}" maxlength="100"/>
+            </div>
+            <div class="row">
+                <label>Contact Email Address</label>
+                <span class="floatL"><b>:</b></span>
+
+                <c:set var="formName" value="_02_contactEmail"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input ${disableContact} type="text" class="${disableContact} normalInput" id="contactEmail" name="${formName}" value="${formValue}" maxlength="50"/>
+            </div>
+            <div class="clearFixed"></div>
+        </div>
+    </div>
+    <!-- /.section -->
 
     <div class="tl"></div>
     <div class="tr"></div>


### PR DESCRIPTION
This is a first step towards #265. If the user hovers their mouse pointer over the abbreviation "NPI" during the Personal Info step of the enrollment process, they'll see a short informational message (see screenshot). We need to polish the presentation (and our approach may partly depend on #238 and other frontend technology choices), but this first step is useful in itself as well as serving as a proof of concept, so I'm making a PR.

![npi-label-hover-working](https://user-images.githubusercontent.com/842790/28483300-8f26ed66-6e3a-11e7-81ec-2a5b1783bf44.png)

This PR covers the first two steps from [this plan](https://github.com/OpenTechStrategies/psm/issues/265#issuecomment-317087085); the next PR for #265 will cover steps 3, 4, and 5.

Also in this PR: a small whitespace fix to another template that I ran across in the process.