### PR TITLE
Associate labels with inputs in provider enrollment disclosure question

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
@@ -9,39 +9,87 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 
 <div class="providerPanel">
-    <input type="hidden" name="formNames" value="<%= ViewStatics.INDIVIDUAL_DISCLOSURE_FORM %>">
+    <input
+        type="hidden"
+        name="formNames"
+        value="<%= ViewStatics.INDIVIDUAL_DISCLOSURE_FORM %>">
     <div class="tableHeader">
         <span>Provider Disclosure</span>
     </div>
     <div class="clearFixed"></div>
     <div class="disclosure">
         <div class="row">
-            <label>Have you ever been convicted of a criminal offense related to involvement in any program under Medicare, Medicaid, Title XX, or Title XXI in
-                Minnesota or any other state or jurisdiction since the inception of these programs?<span class="required">*</span></label>
+            <label>Have you ever been convicted of a criminal offense related to
+                involvement in any program under Medicare, Medicaid, Title XX,
+                or Title XXI in Minnesota or any other state or jurisdiction
+                since the inception of these programs?<span
+                    class="required">*</span></label>
             <div>
-                <c:set var="formName" value="_08_criminalConvictionInd"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="radio" value="Y" name="${formName}" ${formValue eq 'Y' ? 'checked' : ''} /><label class="span">Yes</label>
-                <input type="radio" value="N" name="${formName}" ${formValue eq 'N' ? 'checked' : ''} /><label class="span">No</label>
+                <c:set var="formName"
+                    value="_08_criminalConvictionInd"></c:set>
+                <c:set var="formValue"
+                    value="${requestScope[formName]}"></c:set>
+                <input
+                    type="radio"
+                        value="Y"
+                        name="${formName}"
+                        ${formValue eq 'Y' ? 'checked' : ''} /><label
+                            class="span">Yes</label>
+                <input
+                    type="radio"
+                    value="N"
+                    name="${formName}"
+                    ${formValue eq 'N' ? 'checked' : ''} /><label
+                        class="span">No</label>
             </div>
         </div>
         <div class="row">
-            <label>Have you had civil money penalties or assessments imposed under section 1128A of the Social Security Act?<span class="required">*</span></label>
+            <label>Have you had civil money penalties or assessments imposed
+                under section 1128A of the Social Security
+                Act?<span class="required">*</span></label>
             <div>
-                <c:set var="formName" value="_08_civilPenaltyInd"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="radio" value="Y" name="${formName}" ${formValue eq 'Y' ? 'checked' : ''} /><label class="span">Yes</label>
-                <input type="radio" value="N" name="${formName}" ${formValue eq 'N' ? 'checked' : ''} /><label class="span">No</label>
+                <c:set var="formName"
+                    value="_08_civilPenaltyInd"></c:set>
+                <c:set var="formValue"
+                    value="${requestScope[formName]}"></c:set>
+                <input
+                    type="radio"
+                    value="Y"
+                    name="${formName}"
+                    ${formValue eq 'Y' ? 'checked' : ''} /><label
+                        class="span">Yes</label>
+                <input
+                    type="radio"
+                    value="N"
+                    name="${formName}"
+                    ${formValue eq 'N' ? 'checked' : ''} /><label
+                        class="span">No</label>
             </div>
         </div>
         <div class="row">
-            <label>Have you ever been excluded or terminated from participation in Medicare, Medicaid, Children's Health Insurance Program (CHIP),<br />
-                or the Title XXI services program in Minnesota or any other state since the inception of these programs?<span class="required">*</span></label>
+            <label>Have you ever been excluded or terminated from participation
+                in Medicare, Medicaid, Children's Health Insurance Program
+                (CHIP),<br />
+                or the Title XXI services program in Minnesota or any other
+                state since the inception of these
+                programs?<span class="required">*</span></label>
             <div>
-                <c:set var="formName" value="_08_previousExclusionInd"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="radio" value="Y" name="${formName}" ${formValue eq 'Y' ? 'checked' : ''} /><label class="span">Yes</label>
-                <input type="radio" value="N" name="${formName}" ${formValue eq 'N' ? 'checked' : ''} /><label class="span">No</label>
+                <c:set var="formName"
+                    value="_08_previousExclusionInd"></c:set>
+                <c:set var="formValue"
+                    value="${requestScope[formName]}"></c:set>
+                <input
+                    type="radio"
+                    value="Y"
+                    name="${formName}"
+                    ${formValue eq 'Y' ? 'checked' : ''} /><label
+                        class="span">Yes</label>
+                <input
+                    type="radio"
+                    value="N"
+                    name="${formName}"
+                    ${formValue eq 'N' ? 'checked' : ''} /><label
+                        class="span">No</label>
             </div>
         </div>
         <div class="clearFixed"></div>
@@ -54,47 +102,97 @@
         <div class="section">
             <div class="row">
                 <p>
-                    I certify that the information provided on this form is accurate, complete and truthful.
-                    I will notify MHCP Provider Enrollment of any changes to this information. I acknowledge
-                    that any misrepresentations in the information submitted to MHCP, including false claims,
-                    statements, documents, or concealment of a material fact, may be cause for denial or termination
-                    of participation as a Medicaid provider.
+                    I certify that the information provided on this form
+                    is accurate, complete and truthful.
+                    I will notify MHCP Provider Enrollment of any changes to
+                    this information.
+                    I acknowledge that any misrepresentations in the information
+                    submitted to MHCP, including false claims, statements,
+                    documents, or concealment of a material fact, may be cause
+                    for denial or termination of participation as a Medicaid
+                    provider.
                 </p>
             </div>
             <div class="row">
-                <label>Provider Name<span class="required">*</span></label>
+                <label>Provider Name<span
+                    class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                <c:set var="formName" value="_08_name"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
+                <c:set var="formName"
+                    value="_08_name"></c:set>
+                <c:set var="formValue"
+                    value="${requestScope[formName]}"></c:set>
+                <input
+                    type="text"
+                    class="normalInput"
+                    name="${formName}"
+                    value="${formValue}"
+                    maxlength="45"/>
             </div>
             <div class="row titleRow">
-                <label>Provider Title<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
-                <c:set var="formName" value="_08_title"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
+                <label>Provider Title<span
+                    class="required">*</span></label>
+                <span
+                    class="floatL"><b>:</b></span>
+                <c:set var="formName"
+                    value="_08_title"></c:set>
+                <c:set var="formValue"
+                    value="${requestScope[formName]}"></c:set>
+                <input
+                    type="text"
+                    class="normalInput"
+                    name="${formName}"
+                    value="${formValue}"
+                    maxlength="45"/>
             </div>
             
-            <c:set var="formName" value="_08_renewalBlankInit"></c:set>
-            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-            <input type="hidden" name="${formName}" value="${formValue}" />
+            <c:set var="formName"
+                value="_08_renewalBlankInit"></c:set>
+            <c:set var="formValue"
+                value="${requestScope[formName]}"></c:set>
+            <input
+                type="hidden"
+                name="${formName}"
+                value="${formValue}" />
             
-            <c:set var="formName" value="_08_requiredAgreementsSize"></c:set>
-            <c:forEach begin="1" end="${requestScope[formName]}" varStatus="status">
+            <c:set var="formName"
+                value="_08_requiredAgreementsSize"></c:set>
+            <c:forEach
+                begin="1"
+                end="${requestScope[formName]}"
+                varStatus="status">
                 <div class="checkRow">
-                    <c:set var="formName" value="_08_accepted_${status.index - 1}"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <input type="checkbox" value="" class="checkbox" ${formValue eq 'Y' ? 'checked' : ''} name="${formName}"/>
-                    <c:set var="formName" value="_08_documentId_${status.index - 1}"></c:set>
-                    <c:set var="documentId" value="${requestScope[formName]}"></c:set>
-                    <input type="hidden" value="${documentId}" name="${formName}"/>
-                    <c:set var="formName" value="_08_documentName_${status.index - 1}"></c:set>
-                    <c:set var="documentName" value="${requestScope[formName]}"></c:set>
-                    <c:url var="viewDocumentUrl" value="/provider/enrollment/agreement"><c:param name="id" value="${documentId}"></c:param></c:url>
-                    <span>I have read and agree to the terms of the</span><a href="${viewDocumentUrl}" target="_blank">${documentName}</a>
-                    <c:set var="formName" value="_08_updatedVersion_${status.index - 1}"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                    <c:set var="formName"
+                        value="_08_accepted_${status.index - 1}"></c:set>
+                    <c:set var="formValue"
+                        value="${requestScope[formName]}"></c:set>
+                    <input
+                        type="checkbox"
+                        value=""
+                        class="checkbox"
+                        ${formValue eq 'Y' ? 'checked' : ''}
+                        name="${formName}"/>
+                    <c:set var="formName"
+                        value="_08_documentId_${status.index - 1}"></c:set>
+                    <c:set var="documentId"
+                        value="${requestScope[formName]}"></c:set>
+                    <input
+                        type="hidden"
+                        value="${documentId}"
+                        name="${formName}"/>
+                    <c:set var="formName"
+                        value="_08_documentName_${status.index - 1}"></c:set>
+                    <c:set var="documentName"
+                        value="${requestScope[formName]}"></c:set>
+                    <c:url var="viewDocumentUrl"
+                        value="/provider/enrollment/agreement"><c:param
+                            name="id"
+                            value="${documentId}"></c:param></c:url>
+                    <span>I have read and agree to the terms of the</span>
+                    <a href="${viewDocumentUrl}" target="_blank">${documentName}</a>
+                    <c:set var="formName"
+                        value="_08_updatedVersion_${status.index - 1}"></c:set>
+                    <c:set var="formValue"
+                        value="${requestScope[formName]}"></c:set>
                     <c:if test="${formValue eq 'Y'}"><span>(Updated)</span></c:if>
                 </div>
             </c:forEach>
@@ -102,12 +200,19 @@
         </div>
         <div class="bottomSection">
             <div class="row">
-                <label>Date<span class="required">*</span></label>
+                <label>Date<span
+                    class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper">
-                    <c:set var="formName" value="_08_date"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <input class="date" type="text" name="${formName}" value="${formValue}"/>
+                    <c:set var="formName"
+                        value="_08_date"></c:set>
+                    <c:set var="formValue"
+                        value="${requestScope[formName]}"></c:set>
+                    <input
+                        class="date"
+                        type="text"
+                        name="${formName}"
+                        value="${formValue}"/>
                 </span>
             </div>
             <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
@@ -29,18 +29,24 @@
                     value="_08_criminalConvictionInd"></c:set>
                 <c:set var="formValue"
                     value="${requestScope[formName]}"></c:set>
-                <input
-                    type="radio"
-                        value="Y"
-                        name="${formName}"
-                        ${formValue eq 'Y' ? 'checked' : ''} /><label
-                            class="span">Yes</label>
-                <input
-                    type="radio"
-                    value="N"
-                    name="${formName}"
-                    ${formValue eq 'N' ? 'checked' : ''} /><label
-                        class="span">No</label>
+                <label
+                    class="span">
+                        <input
+                            type="radio"
+                            value="Y"
+                            name="${formName}"
+                            ${formValue eq 'Y' ? 'checked' : ''} />
+                    Yes
+                </label>
+                <label
+                    class="span">
+                        <input
+                            type="radio"
+                            value="N"
+                            name="${formName}"
+                            ${formValue eq 'N' ? 'checked' : ''} />
+                    No
+                </label>
             </div>
         </div>
         <div class="row">
@@ -52,18 +58,24 @@
                     value="_08_civilPenaltyInd"></c:set>
                 <c:set var="formValue"
                     value="${requestScope[formName]}"></c:set>
-                <input
-                    type="radio"
-                    value="Y"
-                    name="${formName}"
-                    ${formValue eq 'Y' ? 'checked' : ''} /><label
-                        class="span">Yes</label>
-                <input
-                    type="radio"
-                    value="N"
-                    name="${formName}"
-                    ${formValue eq 'N' ? 'checked' : ''} /><label
-                        class="span">No</label>
+                <label
+                    class="span">
+                        <input
+                            type="radio"
+                            value="Y"
+                            name="${formName}"
+                            ${formValue eq 'Y' ? 'checked' : ''} />
+                    Yes
+                </label>
+                <label
+                    class="span">
+                        <input
+                            type="radio"
+                            value="N"
+                            name="${formName}"
+                            ${formValue eq 'N' ? 'checked' : ''} />
+                    No
+                </label>
             </div>
         </div>
         <div class="row">
@@ -78,18 +90,24 @@
                     value="_08_previousExclusionInd"></c:set>
                 <c:set var="formValue"
                     value="${requestScope[formName]}"></c:set>
-                <input
-                    type="radio"
-                    value="Y"
-                    name="${formName}"
-                    ${formValue eq 'Y' ? 'checked' : ''} /><label
-                        class="span">Yes</label>
-                <input
-                    type="radio"
-                    value="N"
-                    name="${formName}"
-                    ${formValue eq 'N' ? 'checked' : ''} /><label
-                        class="span">No</label>
+                <label
+                    class="span">
+                        <input
+                            type="radio"
+                            value="Y"
+                            name="${formName}"
+                            ${formValue eq 'Y' ? 'checked' : ''} />
+                    Yes
+                </label>
+                <label
+                    class="span">
+                        <input
+                            type="radio"
+                            value="N"
+                            name="${formName}"
+                            ${formValue eq 'N' ? 'checked' : ''} />
+                    No
+                </label>
             </div>
         </div>
         <div class="clearFixed"></div>


### PR DESCRIPTION
I patterned this PR after #264. This PR cleans up some line lengths, then, following the example of 86d1196 , nests the `<input>`s inside the `<label>`s to turn the "Yes"/"No" text into clickable targets. (This should make it a little teensy bit less tedious to make test enrollments.)