### PR TITLE
Allow admin to view license attachments in review

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -67,11 +67,11 @@ import javax.ejb.TransactionManagementType;
 import javax.persistence.EntityGraph;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
+import javax.servlet.http.HttpServletResponse;
 import javax.sql.rowset.serial.SerialBlob;
 import javax.sql.rowset.serial.SerialException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -263,7 +263,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      *
      * @param user         the current user
      * @param attachmentId the attachment id to be streamed.
-     * @param output       the stream to write the contents to
+     * @param response     the response object to write the contents to
      * @throws IOException            for any I/O errors while streaming the
      *                                attachment contents
      * @throws PortalServiceException for any errors encountered
@@ -272,7 +272,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     public void streamContent(
             CMSUser user,
             long attachmentId,
-            OutputStream output
+            HttpServletResponse response
     ) throws IOException, PortalServiceException {
         Document attachment = getEm().find(Document.class, attachmentId);
         if (attachment != null) {
@@ -290,7 +290,12 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             InputStream input = null;
             try {
                 input = content.getContent().getBinaryStream();
-                IOUtils.copy(input, output);
+                response.setContentType(attachment.getType());
+                response.setHeader(
+                        "Content-Disposition",
+                        "attachment; filename=" + attachment.getFilename()
+                );
+                IOUtils.copy(input, response.getOutputStream());
             } catch (SQLException e) {
                 throw new IOException("Cannot read binary content from database.", e);
             } finally {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -201,7 +201,6 @@ public class EnrollmentPageFlowController extends BaseController {
     /**
      * Downloads an attachment.
      *
-     * @param enrollment   the session model
      * @param attachmentId the attachment to download
      * @param response     the response to write to
      * @throws IOException            for read/write errors
@@ -211,21 +210,11 @@ public class EnrollmentPageFlowController extends BaseController {
      */
     @RequestMapping(value = "/attachment", method = RequestMethod.GET)
     public void download(
-            @ModelAttribute("enrollment") EnrollmentType enrollment,
             @RequestParam("id") long attachmentId,
             HttpServletResponse response
     ) throws PortalServiceException, IOException {
-        AttachedDocumentsType attachments = XMLUtility.nsGetAttachments(enrollment.getProviderInformation());
-        List<DocumentType> attachment = attachments.getAttachment();
-        for (DocumentType documentType : attachment) {
-            if (documentType.getObjectId().equals("" + attachmentId)) {
-                response.setContentType(documentType.getMimeType());
-                response.setHeader("Content-Disposition", "attachment; filename=" + documentType.getName());
-                break;
-            }
-        }
         CMSUser user = ControllerHelper.getCurrentUser();
-        enrollmentService.streamContent(user, attachmentId, response.getOutputStream());
+        enrollmentService.streamContent(user, attachmentId, response);
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -31,8 +31,8 @@ import gov.medicaid.entities.SystemId;
 import gov.medicaid.entities.UserRequest;
 import gov.medicaid.entities.Validity;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -122,7 +122,7 @@ public interface ProviderEnrollmentService {
      *
      * @param user         the current user
      * @param attachmentId the attachment id to be streamed.
-     * @param output       the stream to write the contents to
+     * @param response     the response object to write the contents to
      * @throws IOException            for any I/O errors while streaming the
      *                                attachment contents
      * @throws PortalServiceException for any errors encountered
@@ -130,7 +130,7 @@ public interface ProviderEnrollmentService {
     void streamContent(
             CMSUser user,
             long attachmentId,
-            OutputStream output
+            HttpServletResponse response
     ) throws IOException, PortalServiceException;
 
     /**


### PR DESCRIPTION
Previously, trying to view an uploaded license would cause an error:

> org.springframework.web.HttpSessionRequiredException: Session attribute 'enrollment' required - not found in session

While @cecilia-donnelly and I both remember this working at one point, if we are remembering correctly it was from a long time ago: I went back about six weeks trying to figure out what change caused this, and I wasn't able to find a working version.

The exception relates to the way the attachment was being retrieved. For some reason, we were looking for the enrollment model in the session, using that to get its MIME type and filename, and then looking it up in the database. The database has the MIME type and filename, and the existing method checks that the user has permission to view the attachment, so stop looking for information in the session and use the values from the database.

I was able to test this by creating an enrollment as a provider (an individual provider, not a group provider - see #261), uploading an image on the license screen, and submitting the enrollment; as the admin, I could then review the enrollment and click the license link to open the image.