### PR TITLE
Use requirements.txt for LEIE dependencies

### DIFF
--- a/etl/leie/README.mdwn
+++ b/etl/leie/README.mdwn
@@ -187,13 +187,7 @@ known-good combination of versions but there is no reason to think
 newer versions will break anything.  If you change versions, use the
 test suite.
 
-    $ pip install \
-        dicttoxml \
-        flask \
-        petl==1.1.1 \
-        python-dateutil==2.6.0
-        pyyaml=3.12 \
-        requests=2.17.3
+    $ pip install -r requirements.txt
 
 If you want sqlite3, don't get it from pypi (you can't).  Use your
 distro's packaged version:

--- a/etl/leie/requirements.txt
+++ b/etl/leie/requirements.txt
@@ -1,7 +1,16 @@
+dicttoxml==1.7.4
+Flask==0.12.2
+itsdangerous==0.24
+Jinja2==2.9.6
+MarkupSafe==1.0
 petl==1.1.1
+py==1.4.34
 pytest==3.1.1
 pytest-cov==2.5.1
 python-dateutil==2.6.0
 PyYAML==3.12
-pytest
 requests==2.17.3
+simplejson==3.11.1
+six==1.10.0
+urllib3==1.21.1
+Werkzeug==0.12.2


### PR DESCRIPTION
Simplify initial setup by moving dependencies specified in the README to requirements.txt, and document how to use it in the README.