### PR TITLE
Remove legacy_seed.sql instruction in refresh script

### DIFF
--- a/scripts/rebuild-and-change-schema-for-testing.sh
+++ b/scripts/rebuild-and-change-schema-for-testing.sh
@@ -25,7 +25,6 @@ else
     cd ..
     echo "Re-seeding database"
     cat scripts/drop-contents-of-db-for-testing.sql \
-	psm-app/db/legacy_seed.sql \
 	psm-app/db/jbpm.sql \
 	psm-app/db/seed.sql | psql -h localhost -U psm psm
     # Once we have a new dev enrollment schema:


### PR DESCRIPTION
Followup to fd9c74edf3eb22eb1d059be337fe3d2ef1d0185b --
since `legacy_seed.sql` no longer exists, the developer
environment refresh script should not invoke it.