### PR TITLE
Fix comma placement in confirmation screen

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
@@ -21,9 +21,7 @@
     <span>
         <c:if test="${not empty requestScope['_06_addressLine1']}"><c:out value="${requestScope['_06_addressLine1']}" /><br /></c:if>
         <c:out value="${requestScope['_06_addressLine2']}" /><br />
-        <c:set var="city" value="${requestScope['_06_city']}" /><c:out value="${city}" /> 
-        <c:set var="state" value="${requestScope['_06_state']}" /><c:if test="${not empty state}">,</c:if>${state}
-        <c:set var="zip" value="${requestScope['_06_zip']}" /><c:if test="${not empty zip}">,</c:if>${zip} 
+        ${requestScope['_06_city']}, ${requestScope['_06_state']} ${requestScope['_06_zip']}
         <c:set var="county" value="${requestScope['_06_county']}" /><c:if test="${not empty county}">,</c:if>${county} 
     </span>
 </div>
@@ -53,9 +51,7 @@
         <span>
             <c:if test="${not empty requestScope['_06_reimbursementAddressLine1']}"><c:out value="${requestScope['_06_reimbursementAddressLine1']}" /><br /></c:if>
             <c:out value="${requestScope['_06_reimbursementAddressLine2']}" /><br />
-            <c:set var="city" value="${requestScope['_06_reimbursementCity']}" /><c:out value="${city}" />
-            <c:set var="state" value="${requestScope['_06_reimbursementState']}" /><c:if test="${not empty state}">,</c:if>${state}
-            <c:set var="zip" value="${requestScope['_06_reimbursementZip']}" /><c:if test="${not empty zip}">,</c:if>${zip}
+            ${requestScope['_06_reimbursementCity']}, ${requestScope['_06_reimbursementState']} ${requestScope['_06_reimbursementZip']}
         </span>
     </c:if>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -20,9 +20,7 @@
     <span>
         <c:if test="${not empty requestScope['_05_addressLine1']}"><c:out value="${requestScope['_05_addressLine1']}" /><br /></c:if>
         <c:out value="${requestScope['_05_addressLine2']}" /><br />
-        <c:set var="city" value="${requestScope['_05_city']}" /><c:out value="${city}" />
-        <c:set var="state" value="${requestScope['_05_state']}" /><c:if test="${not empty state}">,</c:if>${state}
-        <c:set var="zip" value="${requestScope['_05_zip']}" /><c:if test="${not empty zip}">,</c:if>${zip}
+        ${requestScope['_05_city']}, ${requestScope['_05_state']} ${requestScope['_05_zip']}
         <c:set var="county" value="${requestScope['_05_county']}" /><c:if test="${not empty county}">,</c:if>${county}
     </span>
 </div>
@@ -53,9 +51,7 @@
         <span>
             <c:if test="${not empty requestScope['_05_addressLine1']}"><c:out value="${requestScope['_05_billingAddressLine1']}" /><br /></c:if>
             <c:out value="${requestScope['_05_billingAddressLine2']}" /><br />
-            <c:set var="city" value="${requestScope['_05_billingCity']}" /><c:out value="${city}" />
-            <c:set var="state" value="${requestScope['_05_billingState']}" /><c:if test="${not empty state}">,</c:if>${state}
-            <c:set var="zip" value="${requestScope['_05_billingZip']}" /><c:if test="${not empty zip}">,</c:if>${zip}
+            ${requestScope['_05_billingCity']}, ${requestScope['_05_billingState']} ${requestScope['_05_billingZip']}
             <c:set var="county" value="${requestScope['_05_billingCounty']}" /><c:if test="${not empty county}">,</c:if>${county}
         </span>
     </c:if>


### PR DESCRIPTION
During provider enrollment, on the Step 4 ("Summary") screen, in the
"practice information" confirmation display, the final line of the
practice address should have a comma and then a space between the city
name and the state, and no comma between the state and the ZIP code.

The old behavior would omit a comma if the state field were empty.
Jason and I decided that, in the unlikely event that a user somehow
got to the end of the process without specifying a state, then having
an address with a trailing comma after the city was a reasonable
trade-off.

Fixes #159.