### PR TITLE
Document new build command,  post-#306

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -313,7 +313,7 @@ repository, update its location in your local properties:
 
    ```ShellSession
    $ cd ../{psm}/psm-app
-   $ ./gradlew build
+   $ ./gradlew cms-portal-services:build
    ...[cut]...
    BUILD SUCCESSFUL
    ```

--- a/scripts/rhel-install.sh
+++ b/scripts/rhel-install.sh
@@ -111,7 +111,7 @@ EOF
 ## Build and deploy the psm app
 cp psm/psm-app/build.properties.template psm/psm-app/build.properties
 cd psm/psm-app
-./gradlew build
+./gradlew cms-portal-services:build
 cd ../../
 ./wildfly-10.1.0.Final/bin/jboss-cli.sh --connect \
 		--command="deploy psm/psm-app/cms-portal-services/build/libs/cms-portal-services.ear"


### PR DESCRIPTION
`./gradlew build` currently fails with `:integration-tests:checkOutcomes FAILED`, after PR #306.  This will be fixed in #304, I believe.  See [this paste](https://hastebin.com/seperahami.vbs) for the exact error.