### PR TITLE
Upgrade Apache Commons FileUpload library to 1.3.3

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -15,7 +15,7 @@ def jbpm_version = '5.4.0.Final'
 // or on immediate deployment
 ext.libs = [
     commons_codec: 'commons-codec:commons-codec:1.6',
-    commons_fileupload: 'commons-fileupload:commons-fileupload:1.2.2',
+    commons_fileupload: 'commons-fileupload:commons-fileupload:1.3.3',
     commons_io: 'commons-io:commons-io:2.0.1',
     commons_lang: 'commons-lang:commons-lang:2.4',
     itext: 'com.lowagie:itext:2.1.7',


### PR DESCRIPTION
Fix several security vulnerabilities present in the old version we were using by upgrading to the latest version.

We seem to use FileUpload purely by including it in our classpath - no code refers to it, and no XML configuration mentions it, but omitting it prevents our application from deploying due to a missing dependency.

I tested this by deploying it, creating an enrollment with a license attachment as a provider, and viewing that attachment as an admin.

See also: [Apache Commons FileUpload Security Vulnerabilities](https://commons.apache.org/proper/commons-fileupload/security-reports.html)

Issue #157 Review libraries for needed updates