### PR TITLE
Remove unneeded direct dependency on spring-asm

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -56,7 +56,6 @@ List runtime_libs = [
     'org.codehaus.janino:janino:2.5.15',
     'org.slf4j:slf4j-api:1.6.4',
     'org.slf4j:slf4j-log4j12:1.6.4',
-    'org.springframework:spring-asm:3.0.5.RELEASE',
 ]
 
 allprojects {


### PR DESCRIPTION
We do not directly refer to anything in the `spring-asm` jar, so we do not need to depend on it directly. It is still part of the project because other spring dependencies transitively depend on it, including `spring-context` and `spring-webmvc`.

Aside from a conceptually simpler build, this should also ease upgrading Spring, as it means one fewer thing to explicitly upgrade and test.

I was able to test this by building, deploying, submitting an enrollment as a provider, and approving it as an admin.

Issue #16 Manage sets of dependencies via Gradle
Issue #157 Review libraries for needed updates
Issue #219 Upgrade Spring to 3.2.18