### PR TITLE
Added test for FEIN validation

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/EnrollmentSteps.java
@@ -1,0 +1,30 @@
+package gov.medicaid.features.enrollment;
+
+import gov.medicaid.features.general.ui.DashboardPage;
+import gov.medicaid.features.general.ui.EnrollmentPage;
+import gov.medicaid.features.general.ui.LoginPage;
+import net.thucydides.core.annotations.Step;
+
+@SuppressWarnings("unused")
+public class EnrollmentSteps {
+    private LoginPage loginPage;
+    private DashboardPage dashboardPage;
+    private EnrollmentPage enrollmentPage;
+
+    @Step
+    public void loginAsProvider(){
+        loginPage.open();
+        loginPage.enterProviderCredentials();
+        loginPage.login();
+        loginPage.checkUserLoggedIn("p1");
+    }
+
+    public void createEnrollment() {
+        dashboardPage.clickOnNewEnrollment();
+    }
+
+    public void selectOrganizationalProviderType() {
+        enrollmentPage.selectProviderType("Dental Clinic");
+        enrollmentPage.clickNext();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ValidationStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ValidationStepDefinitions.java
@@ -1,0 +1,43 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import gov.medicaid.features.enrollment.EnrollmentSteps;
+import gov.medicaid.features.general.ui.EnrollmentPage;
+import net.thucydides.core.annotations.Steps;
+import org.apache.commons.lang3.StringUtils;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SuppressWarnings("unused")
+public class ValidationStepDefinitions {
+    @Steps
+    EnrollmentSteps enrollmentSteps;
+
+    private EnrollmentPage enrollmentPage;
+
+    @Given("^I have started an enrollment$")
+    public void i_have_started_an_enrollment() {
+        enrollmentSteps.loginAsProvider();
+        enrollmentSteps.createEnrollment();
+    }
+
+    @Given("^I am on the organization page$")
+    public void i_am_on_the_organization_page() {
+        enrollmentSteps.selectOrganizationalProviderType();
+    }
+
+    @When("^when I enter an (\\d+) digit FEIN$")
+    public void when_I_enter_an_digit_FEIN(int numDigits) {
+        String generatedFEIN = StringUtils.repeat("0", numDigits);
+        enrollmentPage.setFEIN(generatedFEIN);
+    }
+
+    @Then("^It should be rejected$")
+    public void it_should_be_rejected() {
+        String feinValue = enrollmentPage.getFEINValue();
+        assertThat(feinValue.length()).isEqualTo(0);
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -1,0 +1,22 @@
+package gov.medicaid.features.general.ui;
+
+
+import net.thucydides.core.pages.PageObject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DashboardPage extends PageObject {
+    public void clickOnNewEnrollment() {
+        $("#mainContent > div > div.tabContent.contentT > div.tableHeader.tableHeader2 > a").click();
+        assertThat(getTitle().equals("Provider Type Page"));
+    }
+
+    public void selectProviderType(String aProviderType) {
+        $("[name=_01_providerType]").selectByVisibleText(aProviderType);
+    }
+
+    public void clickNext() {
+        $("#nextBtn").click();
+    }
+
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/EnrollmentPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/EnrollmentPage.java
@@ -1,0 +1,24 @@
+package gov.medicaid.features.general.ui;
+
+
+import net.thucydides.core.pages.PageObject;
+
+
+public class EnrollmentPage extends PageObject {
+    public void selectProviderType(String aProviderType) {
+        $("[name=_01_providerType]").selectByVisibleText(aProviderType);
+    }
+
+    public void clickNext() {
+        $("#nextBtn").click();
+    }
+
+    public void setFEIN(String feinValue) {
+        $("#fein").typeAndTab(feinValue);
+    }
+
+
+    public String getFEINValue() {
+        return $("#fein").getValue();
+    }
+}

--- a/psm-app/integration-tests/src/test/resources/features/general/validation.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/validation.feature
@@ -1,0 +1,10 @@
+Feature: Form and Field Validations
+  To ensure the quality of entered data, the forms should validate field values
+  against data quality rules.
+
+  @issue_291
+  Scenario: Validate Tax ID Number
+    Given I have started an enrollment
+    And I am on the organization page
+    When when I enter an 8 digit FEIN
+    Then It should be rejected


### PR DESCRIPTION
As part of Issue #291 we are developing Serenity tests to demonstrate basic form and field
validations. This is the first PR for this issue and in addition to adding some new infrastructure
for testing, exercises validation of the Federal Tax ID field.

# How to Run
In order to run the tests you should carefully follow the setup instructions in the integration-test [README](https://github.com/OpenTechStrategies/psm/blob/master/psm-app/integration-tests/README.md).

The feature file created in this PR is tagged with the Git Issue Number, so you can force gradle to just run these tests with the command

`gradlew -Dcucumber.options="--tags @issue_291"" clean test aggregate`

You can leave off the cucumber.options to run the full suite of serenity tests.

# General Approach
I created a new feature file called `validation.feature`. There will eventually be several scenarios in this feature file, one for each validation case. For now,  we are just validating the FEIN field on the
Organization page.

Validation for this field in the app is limited to setting the field to blank if the field loses focus and there are fewer than nine characters. Undoubtedly feedback on this validation error will be improved and the test will also need improvement at that time.

The cucumber steps from this feature file match with methods in `ValidationStepDefinitions` class. This class makes use of a Step library found in `EnrollmentSteps`. The steps in this library should make it easier to generate future tests that exercise the enrollment process.

In this PR we also introduced Selenium `Page` objects to back the Dashboard, and Enrollment pages. 

The "Create New Enrollment" button on the dashboard is hard to reliably find with JQuery. I've created an issue to fix this (See #333)
