### PR TITLE
Serenity Tests to Validate App Accepts Name and Contact Fields

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/EnrollmentSteps.java
@@ -27,4 +27,9 @@ public class EnrollmentSteps {
         enrollmentPage.selectProviderType("Dental Clinic");
         enrollmentPage.clickNext();
     }
+
+    public void selectIndividualProviderType() {
+        enrollmentPage.selectProviderType("Podiatrist");
+        enrollmentPage.clickNext();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DataCoverageStepDefinitions.java
@@ -1,0 +1,52 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import gov.medicaid.features.enrollment.EnrollmentSteps;
+import gov.medicaid.features.general.ui.EnrollmentPage;
+import net.thucydides.core.annotations.Steps;
+
+
+@SuppressWarnings("unused")
+public class DataCoverageStepDefinitions {
+    @Steps
+    EnrollmentSteps enrollmentSteps;
+
+    private EnrollmentPage enrollmentPage;
+
+    @When("^I move to the organization page$")
+    public void i_move_to_the_organization_page() {
+        enrollmentSteps.selectOrganizationalProviderType();
+    }
+
+    @Then("^I should be asked to enter Applicant Name, Contact Person, Contact phone$")
+    public void i_should_be_asked_to_enter_Applicant_Name_Contact_Person_Contact_phone() {
+        enrollmentPage.verifyApplicantNameAccepted();
+        enrollmentPage.verifyContactNameAccepted();
+        enrollmentPage.verifyContactPhoneAccepted();
+    }
+
+    @Then("^I should be asked to enter Medicaid number$")
+    public void i_should_be_asked_to_enter_Medicaid() {
+        enrollmentPage.verifyMedicaidNumberAccepted();
+    }
+
+    @When("^I move to the personal info page$")
+    public void i_move_to_the_personal_info_page() {
+        enrollmentSteps.selectIndividualProviderType();
+    }
+
+    @Then("^I should be asked to enter Applicant Name, Contact Person$")
+    public void i_should_be_asked_to_enter_Applicant_Name_Contact_Person() {
+        enrollmentPage.verifyApplicantNameAccepted();
+        enrollmentPage.verifyContactNameAccepted();
+    }
+
+    @Then("^I should be asked to enter Contact phone, Medicaid number$")
+    public void i_should_be_asked_to_enter_Contact_phone_Medicaid_number() {
+        enrollmentPage.verifyContactPhoneAccepted();
+        enrollmentPage.verifyMedicaidNumberAccepted();
+    }
+
+
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/EnrollmentPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/EnrollmentPage.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.general.ui;
 
 
+import cucumber.api.PendingException;
 import net.thucydides.core.pages.PageObject;
 
 
@@ -20,5 +21,42 @@ public class EnrollmentPage extends PageObject {
 
     public String getFEINValue() {
         return $("#fein").getValue();
+    }
+
+    public void verifyApplicantNameAccepted() {
+        if (isOrganizaionalEnrollment()) {
+            $("#legalName").sendKeys("verify_name");
+        } else {
+            $("#firstName").sendKeys("first_name");
+            $("#middleName").sendKeys("MI");
+            $("[name='_02_lastName']").sendKeys("last_name");
+        }
+    }
+
+    public void verifyContactNameAccepted() {
+        $("#contactName").sendKeys("contact_name");
+    }
+
+    public void verifyContactPhoneAccepted() {
+        if (isOrganizaionalEnrollment()) {
+            $("[name='_15_contactPhone1']").sendKeys("217");
+            $("[name='_15_contactPhone2']").sendKeys("217");
+            $("[name='_15_contactPhone3']").sendKeys("217");
+        } else {
+            throw new PendingException("Issue #346 - Capture contact phone # for individual provider enrollments");
+        }
+    }
+
+    public void verifyMedicaidNumberAccepted() {
+        throw new PendingException("Issue #347 - Capture Medicaid Number for new Enrollments");
+    }
+
+
+    public boolean isPersonalEnrollment() {
+        return this.getTitle().equals("Personal Information");
+    }
+
+    public boolean isOrganizaionalEnrollment() {
+        return this.getTitle().equals("Organization Information");
     }
 }

--- a/psm-app/integration-tests/src/test/resources/features/general/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/data_coverage.feature
@@ -1,0 +1,28 @@
+Feature: Data Coverage Checks
+  To ensure that the app accepts data that is required by the agencies to perform
+  their jobs.
+
+  @psm-2.9
+  Scenario: Captures Contact Info for Organization
+    Given I have started an enrollment
+    When  I move to the organization page
+    Then I should be asked to enter Applicant Name, Contact Person, Contact phone
+
+  @psm-2.9
+  Scenario: Captures Medicaid number for Organization's contact
+    Given I have started an enrollment
+    When  I move to the organization page
+    Then I should be asked to enter Medicaid number
+
+  @psm-2.9
+  Scenario: Captures Contact Info for Individual
+    Given I have started an enrollment
+    When  I move to the personal info page
+    Then I should be asked to enter Applicant Name, Contact Person
+
+  @psm-2.9
+  Scenario: Captures Phone number and Medicaid number for Individual
+    Given I have started an enrollment
+    When  I move to the personal info page
+    Then I should be asked to enter Contact phone, Medicaid number
+


### PR DESCRIPTION
This PR introduces serenity tests to validate requirement ID psm-2.9

The requirement states 
```
The PSM shall accept the following fields: Applicant Name, Contact Person, 
Contact phone, Medicaid number
```

Created a new feature file to document data coverage validations and introduced some new steps as well as some new enrollment page methods to verify that the requested fields exist and accept data.

There are some fields that are missing from the application and so marked these tests as pending at the point where enhancements are required before we can say that we meet the requirement.

Created two issues to add these missing fields. See #346 and #347 

# Progress on
This PR brings is partial fulfillment of issue #291 
