### PR TITLE
Make LEIE API base URL configurable

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -129,6 +129,8 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
     @PostConstruct
     public void init() {
         super.init();
+        CMSConfigurator config = new CMSConfigurator();
+
         handlers.put("PreProcess", new PreProcessHandler());
         handlers.put("Validate", new ValidationHandler());
         handlers.put("Data Transformation", new SystemOutWorkItemHandler());
@@ -139,7 +141,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
         handlers.put("Verify License or Certification", new VerifyLicenseHandler());
         handlers.put(
                 "Check Excluded Provider List in OIG",
-                new ExcludedProvidersScreeningHandler("http://localhost:5000/")
+                new ExcludedProvidersScreeningHandler(config.getLeieApiBaseUrl())
         );
         handlers.put("Check Excluded Provider List in SAM", new SAMExcludedProvidersScreeningHandler());
         handlers.put("Auto Disqualification", new DisqualificationHandler());
@@ -149,7 +151,6 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
         handlers.put("SIRS", new SystemOutWorkItemHandler());
         handlers.put("Accept Application", new AcceptedHandler());
 
-        CMSConfigurator config = new CMSConfigurator();
         if (providerService == null) {
             providerService = config.getEnrollmentService();
         }

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -339,6 +339,13 @@ public class CMSConfigurator {
         }
     }
 
+    public String getLeieApiBaseUrl() {
+        return globalSettings.getProperty(
+                "external-sources.leie",
+                "http://localhost:5000/"
+        );
+    }
+
     /**
      * Retrieves the flag setting for using external or embedded rules
      * @return the flag setting for rules

--- a/psm-app/services/src/main/resources/cms.properties
+++ b/psm-app/services/src/main/resources/cms.properties
@@ -240,6 +240,7 @@ display.notifications.max=5
 # external sources integration
 extsources.TEST.base=http://test.example.com
 extsources.PROD.base=http://prod.example.com
+#external-sources.leie=http://localhost:5000/
 
 # use guvnor or embedded rules (no spaces please) Y/N
 rules.embedded=Y


### PR DESCRIPTION
Add a new, configurable property to specify the base URL of the LEIE API. It defaults to running on the same machine on port 5000.

This addresses an issue raised by @cecilia-donnelly during code review of PR #345.

Issue #289 Use LEIE API to automatically screen providers