### PR TITLE
Show number of records matched in screening log

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
@@ -39,11 +39,25 @@
                                             <span>SUCCESS</span>
                                         </div>
 
-                                        <c:set var="recordsMatched" value="${false}"></c:set>
+                                        <c:set var="recordsMatched"
+                                         value="${fn:length(output.searchResultItem)}"/>
+                                        <div class="row">
+                                            <c:choose>
+                                                <c:when test="${recordsMatched == 0}">
+                                                    No records were matched.
+                                                </c:when>
+                                                <c:when test="${recordsMatched == 1}">
+                                                    1 record matched.
+                                                </c:when>
+                                                <c:otherwise>
+                                                    ${recordsMatched} records matched.
+                                                </c:otherwise>
+                                            </c:choose>
+                                        </div>
+
                                         <c:forEach var="record" items="${output.searchResultItem}">
                                             <hr />
                                             <c:forEach var="coldata" items="${record.columnData.nameValuePair}">
-                                                <c:set var="recordsMatched" value="${true}"></c:set>
                                                 <div class="row">
                                                     <label>${coldata.name}</label>
                                                     <span class="floatL"><b>:</b></span>
@@ -51,12 +65,6 @@
                                                 </div>
                                             </c:forEach>
                                         </c:forEach>
-
-                                        <c:if test="${not recordsMatched}">
-                                        <div class="row">
-                                            No records were matched.
-                                        </div>
-                                        </c:if>
                                     </c:if>
                                 </div>
                             </div>


### PR DESCRIPTION
With no records:
![screenshot 2017-08-11 17 51 33](https://user-images.githubusercontent.com/1494855/29233301-38b86aec-7ebe-11e7-8dd8-0b3bb49a46bc.png)

With one record:
![screenshot 2017-08-11 17 51 52](https://user-images.githubusercontent.com/1494855/29233300-38b69a1e-7ebe-11e7-88d4-590be6a18e04.png)

With more than one record:
![screenshot 2017-08-11 17 50 55](https://user-images.githubusercontent.com/1494855/29233302-38b8bede-7ebe-11e7-8234-35479a3ada11.png)




Issue #355 Improve UI and add more explicit phrasing in screening log