### PR TITLE
Indicate if auto screen run on enrollment review

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -47,7 +47,16 @@
                                 <tr>
                                     <td>NPI LOOKUP</td>
                                     <td>${model.enrollment.providerInformation.NPI}</td>
-                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI LOOKUP&id=${id}" target="_blank">View</a></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI LOOKUP&id=${id}" target="_blank">
+                                        <c:choose>
+                                            <c:when test="${empty verification.NPILookup}">
+                                                Not performed
+                                            </c:when>
+                                            <c:otherwise>
+                                                View results
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </a></td>
                                     <td>
                                         <input
                                             type="checkbox"
@@ -60,7 +69,16 @@
                                 <tr>
                                     <td>SSN DMF VERIFICATION</td>
                                     <td>${model.enrollment.providerInformation.applicantInformation.personalInformation.socialSecurityNumber}</td>
-                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SSN DMF VERIFICATION&id=${id}" target="_blank">View</a></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SSN DMF VERIFICATION&id=${id}" target="_blank">
+                                        <c:choose>
+                                            <c:when test="${empty verification.socialSecurityNumber}">
+                                                Not performed
+                                            </c:when>
+                                            <c:otherwise>
+                                                View results
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </a></td>
                                     <td>
                                         <input
                                             type="checkbox"
@@ -73,7 +91,16 @@
                                 <tr>
                                     <td>NPI PECOS VERIFICATION</td>
                                     <td>${model.enrollment.providerInformation.NPI}</td>
-                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI PECOS VERIFICATION&id=${id}" target="_blank">View</a></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI PECOS VERIFICATION&id=${id}" target="_blank">
+                                        <c:choose>
+                                            <c:when test="${empty verification.NPI}">
+                                                Not performed
+                                            </c:when>
+                                            <c:otherwise>
+                                                View results
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </a></td>
                                     <td>
                                         <input
                                             type="checkbox"
@@ -87,7 +114,16 @@
                                     <tr>
                                         <td>NET STUDY ID VERIFICATION</td>
                                         <td>${model.enrollment.providerInformation.agencyInformation.backgroundStudyId}</td>
-                                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NET STUDY ID VERIFICATION&id=${id}" target="_blank">View Log</a></td>
+                                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NET STUDY ID VERIFICATION&id=${id}" target="_blank">
+                                            <c:choose>
+                                                <c:when test="${empty verification.netStudy}">
+                                                    Not performed
+                                                </c:when>
+                                                <c:otherwise>
+                                                    View results
+                                                </c:otherwise>
+                                            </c:choose>
+                                        </a></td>
                                         <td>
                                             <input
                                                 type="checkbox"
@@ -101,7 +137,16 @@
                                 <tr>
                                     <td>EXCLUDED PROVIDER VERIFICATION IN OIG (checked means not in exclusion list)</td>
                                     <td></td>
-                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=EXCLUDED PROVIDERS&id=${id}" target="_blank">
+                                        <c:choose>
+                                            <c:when test="${empty verification.nonExclusion}">
+                                                Not performed
+                                            </c:when>
+                                            <c:otherwise>
+                                                View results
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </a></td>
                                     <td>
                                         <input
                                             type="checkbox"
@@ -114,7 +159,16 @@
                                 <tr>
                                     <td>EXCLUDED PROVIDER VERIFICATION IN SAM (checked means not in exclusion list)</td>
                                     <td></td>
-                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SAM EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SAM EXCLUDED PROVIDERS&id=${id}" target="_blank">
+                                        <c:choose>
+                                            <c:when test="${empty verification.SAMNonExclusion}">
+                                                Not performed
+                                            </c:when>
+                                            <c:otherwise>
+                                                View results
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </a></td>
                                     <td>
                                         <input
                                             type="checkbox"
@@ -150,7 +204,16 @@
                                     <a href="${downloadLink}">View</a>
 
                                     </td>
-                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}" target="_blank">View Log</a></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}" target="_blank">
+                                        <c:choose>
+                                            <c:when test="${empty license.verified}">
+                                                Not performed
+                                            </c:when>
+                                            <c:otherwise>
+                                                View results
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </a></td>
                                     <td>
                                         <input
                                             type="checkbox"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -1,4 +1,4 @@
- <%--
+<%--
   - Author: TCSASSEMBLER
   - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
@@ -28,102 +28,102 @@
                     <div class="tabSection" id="enrollmentSection">
                         <%@include file="/WEB-INF/pages/provider/enrollment/steps/screening_errors.jsp" %>
                         <form action="${ctx}/agent/enrollment/approve" method="post" id="approvalForm">
-                        
-						<div class="newEnrollmentPanel practicePanel">
+
+                        <div class="newEnrollmentPanel practicePanel">
                             <div class="tableHeader topHeader"><span>Provider Information</span></div>
-						    <div class="clearFixed"></div>
-						    <div class="section">
-	                        <input type="hidden" name="id" value="${id}" />
+                            <div class="clearFixed"></div>
+                            <div class="section">
+                            <input type="hidden" name="id" value="${id}" />
                             <table  class="generalTable">
                             <thead>
-	                            <tr>
-	                               <th>Field<span class="sep"></span></th>
-	                               <th>Value<span class="sep"></span></th>
-                                   <th>Auto Screening<span class="sep"></span></th>
-	                               <th>Verified</th>
-	                            </tr>
+                                <tr>
+                                    <th>Field<span class="sep"></span></th>
+                                    <th>Value<span class="sep"></span></th>
+                                    <th>Auto Screening<span class="sep"></span></th>
+                                    <th>Verified</th>
+                                </tr>
                             </thead>
                             <tbody>
-                            	<tr>
-                                   <td>NPI LOOKUP</td>
-                                   <td>${model.enrollment.providerInformation.NPI}</td>
-                                   <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI LOOKUP&id=${id}" target="_blank">View</a></td>
-                                   <td><input type="checkbox" name="npiLookupVerified" value="Y" ${verification.NPILookup eq 'Y' ? 'checked' : ''} /></td>
+                                <tr>
+                                    <td>NPI LOOKUP</td>
+                                    <td>${model.enrollment.providerInformation.NPI}</td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI LOOKUP&id=${id}" target="_blank">View</a></td>
+                                    <td><input type="checkbox" name="npiLookupVerified" value="Y" ${verification.NPILookup eq 'Y' ? 'checked' : ''} /></td>
                                 </tr>
                                 <tr>
-                                   <td>SSN DMF VERIFICATION</td>
-                                   <td>${model.enrollment.providerInformation.applicantInformation.personalInformation.socialSecurityNumber}</td>
-                                   <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SSN DMF VERIFICATION&id=${id}" target="_blank">View</a></td>
-                                   <td><input type="checkbox" name="ssnVerified" value="Y" ${verification.socialSecurityNumber eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>SSN DMF VERIFICATION</td>
+                                    <td>${model.enrollment.providerInformation.applicantInformation.personalInformation.socialSecurityNumber}</td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SSN DMF VERIFICATION&id=${id}" target="_blank">View</a></td>
+                                    <td><input type="checkbox" name="ssnVerified" value="Y" ${verification.socialSecurityNumber eq 'Y' ? 'checked' : ''} /></td>
                                 </tr>
                                 <tr>
-                                   <td>NPI PECOS VERIFICATION</td>
-                                   <td>${model.enrollment.providerInformation.NPI}</td>
-                                   <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI PECOS VERIFICATION&id=${id}" target="_blank">View</a></td>
-                                   <td><input type="checkbox" name="npiVerified" value="Y" ${verification.NPI eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>NPI PECOS VERIFICATION</td>
+                                    <td>${model.enrollment.providerInformation.NPI}</td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI PECOS VERIFICATION&id=${id}" target="_blank">View</a></td>
+                                    <td><input type="checkbox" name="npiVerified" value="Y" ${verification.NPI eq 'Y' ? 'checked' : ''} /></td>
                                 </tr>
                                 <c:if test="${not empty model.enrollment.providerInformation.agencyInformation.backgroundStudyId}">
-	                                <tr>
-	                                   <td>NET STUDY ID VERIFICATION</td>
-	                                   <td>${model.enrollment.providerInformation.agencyInformation.backgroundStudyId}</td>
-                                       <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NET STUDY ID VERIFICATION&id=${id}" target="_blank">View Log</a></td>
-                                       <td><input type="checkbox" name="bgsVerified" value="Y" ${verification.netStudy eq 'Y' ? 'checked' : ''} /></td>
-	                                </tr>
+                                    <tr>
+                                        <td>NET STUDY ID VERIFICATION</td>
+                                        <td>${model.enrollment.providerInformation.agencyInformation.backgroundStudyId}</td>
+                                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NET STUDY ID VERIFICATION&id=${id}" target="_blank">View Log</a></td>
+                                        <td><input type="checkbox" name="bgsVerified" value="Y" ${verification.netStudy eq 'Y' ? 'checked' : ''} /></td>
+                                    </tr>
                                 </c:if>
                                 <tr>
-                                   <td>EXCLUDED PROVIDER VERIFICATION IN OIG (checked means not in exclusion list)</td>
-                                   <td></td>
-                                   <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
-                                   <td><input type="checkbox" name="nonExclusionVerified" value="Y" ${verification.nonExclusion eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>EXCLUDED PROVIDER VERIFICATION IN OIG (checked means not in exclusion list)</td>
+                                    <td></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
+                                    <td><input type="checkbox" name="nonExclusionVerified" value="Y" ${verification.nonExclusion eq 'Y' ? 'checked' : ''} /></td>
                                 </tr>
                                 <tr>
-                                   <td>EXCLUDED PROVIDER VERIFICATION IN SAM (checked means not in exclusion list)</td>
-                                   <td></td>
-                                   <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SAM EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
-                                   <td><input type="checkbox" name="nonSAMExclusionVerified" value="Y" ${verification.SAMNonExclusion eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>EXCLUDED PROVIDER VERIFICATION IN SAM (checked means not in exclusion list)</td>
+                                    <td></td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SAM EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
+                                    <td><input type="checkbox" name="nonSAMExclusionVerified" value="Y" ${verification.SAMNonExclusion eq 'Y' ? 'checked' : ''} /></td>
                                 </tr>
                             </tbody>
                             </table>
-                            
+
                             <div class="tableHeader"><span>License Information</span></div>
                             <div class="clearFixed"></div>
                             <table class="generalTable">
                             <thead>
                                 <tr>
-                                   <th>Type<span class="sep"></span></th>
-                                   <th>Number<span class="sep"></span></th>
-                                   <th>Auto Screening<span class="sep"></span></th>
-                                   <th>Verified</th>
+                                    <th>Type<span class="sep"></span></th>
+                                    <th>Number<span class="sep"></span></th>
+                                    <th>Auto Screening<span class="sep"></span></th>
+                                    <th>Verified</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <c:forEach var="license" items="${model.enrollment.providerInformation.licenseInformation.license}">
                                 <tr>
-                                   <td>${license.licenseType}${license.specialtyType}</td>
-                                   <td>${license.licenseNumber}
-                                    
+                                    <td>${license.licenseType}${license.specialtyType}</td>
+                                    <td>${license.licenseNumber}
+
                                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                                         <c:param name="id" value="${license.attachmentObjectId}"></c:param>
                                     </c:url>
                                     <a href="${downloadLink}">View</a>
-                                   
-                                   </td>
-                                   <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}" target="_blank">View Log</a></td>
-                                   <td><input type="checkbox" name="verifiedLicenses" value="${license.attachmentObjectId}" ${license.verified eq 'Y' ? 'checked' : ''} /></td>
+
+                                    </td>
+                                    <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}" target="_blank">View Log</a></td>
+                                    <td><input type="checkbox" name="verifiedLicenses" value="${license.attachmentObjectId}" ${license.verified eq 'Y' ? 'checked' : ''} /></td>
                                 </tr>
                                 </c:forEach>
                             </tbody>
                             </table>
-	                        <div class="row"></div>
+                            <div class="row"></div>
                         </div>
-                        
+
                         <div class="clear"></div>
-                        
-					    <div class="tl"></div>
-					    <div class="tr"></div>
-					    <div class="bl"></div>
-					    <div class="br"></div>
-                        
+
+                        <div class="tl"></div>
+                        <div class="tr"></div>
+                        <div class="bl"></div>
+                        <div class="br"></div>
+
                         </div>
                         <div class="buttonBox">
                             <a href="${ctx}/provider/search/pending?statuses=Pending&showFilterPanel=true" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Cancel</span></span></span></a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -48,39 +48,81 @@
                                     <td>NPI LOOKUP</td>
                                     <td>${model.enrollment.providerInformation.NPI}</td>
                                     <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI LOOKUP&id=${id}" target="_blank">View</a></td>
-                                    <td><input type="checkbox" name="npiLookupVerified" value="Y" ${verification.NPILookup eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            name="npiLookupVerified"
+                                            value="Y"
+                                            ${verification.NPILookup eq 'Y' ? 'checked' : ''}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>SSN DMF VERIFICATION</td>
                                     <td>${model.enrollment.providerInformation.applicantInformation.personalInformation.socialSecurityNumber}</td>
                                     <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SSN DMF VERIFICATION&id=${id}" target="_blank">View</a></td>
-                                    <td><input type="checkbox" name="ssnVerified" value="Y" ${verification.socialSecurityNumber eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            name="ssnVerified"
+                                            value="Y"
+                                            ${verification.socialSecurityNumber eq 'Y' ? 'checked' : ''}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>NPI PECOS VERIFICATION</td>
                                     <td>${model.enrollment.providerInformation.NPI}</td>
                                     <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI PECOS VERIFICATION&id=${id}" target="_blank">View</a></td>
-                                    <td><input type="checkbox" name="npiVerified" value="Y" ${verification.NPI eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            name="npiVerified"
+                                            value="Y"
+                                            ${verification.NPI eq 'Y' ? 'checked' : ''}
+                                        />
+                                    </td>
                                 </tr>
                                 <c:if test="${not empty model.enrollment.providerInformation.agencyInformation.backgroundStudyId}">
                                     <tr>
                                         <td>NET STUDY ID VERIFICATION</td>
                                         <td>${model.enrollment.providerInformation.agencyInformation.backgroundStudyId}</td>
                                         <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NET STUDY ID VERIFICATION&id=${id}" target="_blank">View Log</a></td>
-                                        <td><input type="checkbox" name="bgsVerified" value="Y" ${verification.netStudy eq 'Y' ? 'checked' : ''} /></td>
+                                        <td>
+                                            <input
+                                                type="checkbox"
+                                                name="bgsVerified"
+                                                value="Y"
+                                                ${verification.netStudy eq 'Y' ? 'checked' : ''}
+                                            />
+                                        </td>
                                     </tr>
                                 </c:if>
                                 <tr>
                                     <td>EXCLUDED PROVIDER VERIFICATION IN OIG (checked means not in exclusion list)</td>
                                     <td></td>
                                     <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
-                                    <td><input type="checkbox" name="nonExclusionVerified" value="Y" ${verification.nonExclusion eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            name="nonExclusionVerified"
+                                            value="Y"
+                                            ${verification.nonExclusion eq 'Y' ? 'checked' : ''}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>EXCLUDED PROVIDER VERIFICATION IN SAM (checked means not in exclusion list)</td>
                                     <td></td>
                                     <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SAM EXCLUDED PROVIDERS&id=${id}" target="_blank">View</a></td>
-                                    <td><input type="checkbox" name="nonSAMExclusionVerified" value="Y" ${verification.SAMNonExclusion eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            name="nonSAMExclusionVerified"
+                                            value="Y"
+                                            ${verification.SAMNonExclusion eq 'Y' ? 'checked' : ''}
+                                        />
+                                    </td>
                                 </tr>
                             </tbody>
                             </table>
@@ -109,7 +151,14 @@
 
                                     </td>
                                     <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}" target="_blank">View Log</a></td>
-                                    <td><input type="checkbox" name="verifiedLicenses" value="${license.attachmentObjectId}" ${license.verified eq 'Y' ? 'checked' : ''} /></td>
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            name="verifiedLicenses"
+                                            value="${license.attachmentObjectId}"
+                                            ${license.verified eq 'Y' ? 'checked' : ''}
+                                        />
+                                    </td>
                                 </tr>
                                 </c:forEach>
                             </tbody>


### PR DESCRIPTION
Change the link text for the automatic screening results to be either "View results" if the automatic screening was run, or "Not performed" if it was not. Hopefully this will somewhat clarify the difference between "not performed" and "performed with a negative result", both of which were previously indicated by an unchecked box in the "Verified" column.

![screening-results-failed](https://user-images.githubusercontent.com/1494855/29285087-3285664a-80fb-11e7-8174-14859fa00c44.png)
![screening-results-passed](https://user-images.githubusercontent.com/1494855/29285086-3283f8d2-80fb-11e7-992a-37416ddcfa9c.png)


Issue #354 Redesign Enrollment Review page