### PR TITLE
Drools microservice script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,3 +7,6 @@ administrators or our build systems.
   documentation using Javadoc and push it to the `gh-pages` branch,
   which updates our GitHub Pages site,
   https://opentechstrategies.github.io/psm/javadoc/ .
+* `drools-microservice.sh` sets up a copy of jbpm and Guvnor on a
+  standalone server, which the core application can then be configured
+  to communicate with.

--- a/scripts/drools-microservice.sh
+++ b/scripts/drools-microservice.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+function download_and_sha1 {
+	base=$(basename $1)
+	[ -e $base ] || curl -OL $1
+	echo "$2 $base" | sha1sum --quiet -c - || (printf "$base has an unexpected sha1sum: $(sha1sum $base | awk '{print $1}')\n" && exit)
+}
+
+# Set up java
+sudo yum -y update
+sudo yum -y install unzip java-1.6.0-openjdk.x86_64 ant
+sudo alternatives --set java /usr/lib/jvm/jre-1.6.0-openjdk.x86_64/bin/java
+
+# Download the jbpm installer
+download_and_sha1 "https://downloads.sourceforge.net/project/jbpm/jBPM%205/jbpm-5.4.0.Final/jbpm-5.4.0.Final-installer-full.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fjbpm%2Ffiles%2FjBPM%25205%2Fjbpm-5.4.0.Final%2F&ts=1503270090&use_mirror=svwh" f96ed9ee2e574325693c8ce5a0ffea76fb0de319
+mv "jbpm-5.4.0.Final-installer-full.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fjbpm%2Ffiles%2FjBPM%25205%2Fjbpm-5.4.0.Final%2F&ts=1503270090&use_mirror=svwh" jbpm-installer.zip
+unzip jbpm-installer.zip
+rm jbpm-installer.zip
+
+# Run the jbpm installer
+cd jbpm-installer
+ant install.demo.noeclipse
+
+# Edit config
+local_ip_for_public='inet-address value="${jboss\.bind\.address:127.0.0.1}"'
+any_ip='any\-ipv4\-address'
+sed -i "s/$local_ip_for_public/$any_ip/g" jboss-as-7.1.1.Final/standalone/configuration/standalone.xml
+
+# Start jbpm
+ant start.demo.noeclipse

--- a/scripts/drools-microservice.sh
+++ b/scripts/drools-microservice.sh
@@ -13,8 +13,8 @@ sudo yum -y install unzip java-1.6.0-openjdk.x86_64 ant
 sudo alternatives --set java /usr/lib/jvm/jre-1.6.0-openjdk.x86_64/bin/java
 
 # Download the jbpm installer
-download_and_sha1 "https://downloads.sourceforge.net/project/jbpm/jBPM%205/jbpm-5.4.0.Final/jbpm-5.4.0.Final-installer-full.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fjbpm%2Ffiles%2FjBPM%25205%2Fjbpm-5.4.0.Final%2F&ts=1503270090&use_mirror=svwh" f96ed9ee2e574325693c8ce5a0ffea76fb0de319
-mv "jbpm-5.4.0.Final-installer-full.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fjbpm%2Ffiles%2FjBPM%25205%2Fjbpm-5.4.0.Final%2F&ts=1503270090&use_mirror=svwh" jbpm-installer.zip
+download_and_sha1 "https://downloads.sourceforge.net/project/jbpm/jBPM%205/jbpm-5.4.0.Final/jbpm-5.4.0.Final-installer-full.zip" f96ed9ee2e574325693c8ce5a0ffea76fb0de319
+mv jbpm-5.4.0.Final-installer-full.zip jbpm-installer.zip
 unzip jbpm-installer.zip
 rm jbpm-installer.zip
 


### PR DESCRIPTION
This script will download, install, and set up a copy of a service that allows
editing of drools rulesets.  It is using an older version of the stack because
that is what is compatable with the rest of the psm code base.