### PR TITLE
Remove unused dependency on asm

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -50,7 +50,6 @@ ext.libs = [
 // are required.  We know for sure that SOME of them are loaded during runtime, but
 // need to spend some time investigating one by one.
 List runtime_libs = [
-    'asm:asm:3.3',
     'commons-logging:commons-logging:1.1.1',
     'net.sourceforge.jexcelapi:jxl:2.6.10',
     'org.codehaus.jackson:jackson-mapper-asl:1.9.13',


### PR DESCRIPTION
One of the libraries that was originally vendored was [asm](https://en.wikipedia.org/wiki/ObjectWeb_ASM). We intentionally moved it over to gradle without examining its use or purpose so that we could use gradle instead of ant, with the intention of looking more closely at it later.

We have no direct dependency on any of the classes included in the asm jar. They are all in a subpackage of `org.objectweb`, which we never import. The vendored libraries we have from TopCoder do not depend on it, either, according to [Tattletale](http://tattletale.jboss.org/). Finally, it turns out that WildFly 10.1.0.Final bundles a newer version of asm, so even if we did need it, it's provided at runtime.

Issue #16 Manage sets of dependencies via Gradle or another tool