### PR TITLE
Provider and service agent help documentation

### DIFF
--- a/docs/userhelp/source/account-help.rst
+++ b/docs/userhelp/source/account-help.rst
@@ -1,0 +1,69 @@
+Making and changing your account on this site
+=============================================
+
+How do I register for an account on this site?
+----------------------------------------------
+
+This depends on whether you are a healthcare provider or not.
+
+If you're a healthcare provider:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Go to the main page and click the "Register New Account" link.
+
+A new account needs a username, first and last name, a user role, and an
+email address. The site will create a random password and email it to
+you, and will assume that the account is for a provider.
+
+Your account can also have a middle name (this is optional).
+
+This site does not enforce any limits on the number or type of
+characters in the user's first name, last name, username or password.
+
+You will need to have JavaScript turned on in your browser.
+
+If you are not a healthcare provider:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You probably want to create an account to be a "service agent" (someone
+who helps get providers enrolled) or a "service admin" (a state employee
+who approves and rejects enrollments). Please speak with the state
+Medicaid office for an account.
+
+How do I log in?
+----------------
+
+Go to the main page of the website and enter your user name and
+password, and click the "Login" button.
+
+I forgot my password. Can I retrieve or reset it?
+-------------------------------------------------
+
+On the main page, click the "Forgot Password?" link and enter your
+username and email address. Click the "Reset Password" button. The
+website will email you a new password to use to log in.
+
+I registered using an old email address I don't have access to anymore, and I've forgotten my password. How can I log in?
+-------------------------------------------------------------------------------------------------------------------------
+
+You will need to contact your state Medicaid office directly to get your
+account information changed and to get a new password.
+
+Someone stole my identity and created an account or took over my existing account. How do I get control of my account back?
+---------------------------------------------------------------------------------------------------------------------------
+
+To get your account back after identity theft, you will need to contact
+your state Medicaid office directly.
+
+Can I change my username or password?
+-------------------------------------
+
+You can't change your username after you register it.
+
+You can change your password using the Change Password page. Go to "My
+Profile" and click the "Change Password" link.
+
+Can I delete my account?
+------------------------
+
+No, you cannot. A future version of the PSM may let you do so.

--- a/docs/userhelp/source/enrollment.rst
+++ b/docs/userhelp/source/enrollment.rst
@@ -1,0 +1,243 @@
+Enrollment
+==========
+
+This help section explains what an enrollment is, tells you what you
+need to do to create one and submit it, and answers common questions
+about confusing terms.
+
+What information do I need to create an enrollment?
+---------------------------------------------------
+
+First, you'll need to register for an account (see "how do I register
+for an account on this site?"). Then you'll need to click the button to
+create a new enrollment.
+
+An enrollment includes:
+
+-  provider/organization information, such as provider type, name, NPI,
+   and contact information
+
+-  license and certification information, including a scan of the
+   license or certification itself
+
+-  contact and billing/reimbursement addresses for the practice
+
+-  answers to questions about the provider's past exclusions, penalties,
+   terminations, and convictions, if any
+
+-  information about ownership and potential conflicts (e.g. ownership
+   over other entities billing Medicaid)
+
+-  an electronic signature and date attesting to the accuracy of the
+   enrollment information
+
+What are the steps in the enrollment process?
+---------------------------------------------
+
+-  A provider, service agent, or service admin creates and submits a new
+   enrollment for a particular provider. (A user can save a draft
+   enrollment and come back later to finish and submit it.)
+
+-  A service admin reviews the enrollment, using links provided by the
+   PSM to verify enrollment details, and decides whether to approve or
+   reject the submission.
+
+-  After an enrollment has been approved, a service admin can select and
+   renew it.
+
+Who can view enrollments?
+-------------------------
+
+A provider can view their own enrollments (including draft, rejected,
+approved, and pending enrollments).
+
+A service agent or service admin can view all enrollments (including
+draft, rejected, approved, and pending enrollments).
+
+A system admin should not be able to view any enrollments. `The PSM
+currently allows a system admin to view enrollments, but will remove
+that capability in a future
+version. <https://github.com/OpenTechStrategies/psm/issues/10>`__
+
+Which enrollment information can a provider, service agent, or service admin modify or delete?
+----------------------------------------------------------------------------------------------
+
+A provider can modify a draft enrollment, but can't delete it. A
+provider also cannot delete or modify an enrollment after submitting it
+(once it is "pending", "approved", or "denied").
+
+A service agent or service admin can modify a draft or pending
+enrollment, but cannot delete any enrollments.
+
+What will a provider see or receive when enrollment is pending, modified, approved, or rejected?
+------------------------------------------------------------------------------------------------
+
+When you log into the PSM, you'll see any enrollments you've submitted
+or started drafting via your PSM user account. You'll be able to see the
+status of each enrollment.
+
+Right now, a provider does not receive any email notifications about
+their enrollment. (A future version of the PSM will send email
+notifications to providers when the status of your enrollment changes.)
+
+Can I create an enrollment for someone else?
+--------------------------------------------
+
+A service agent or a service admin can create an enrollment for someone
+else.
+
+Can I start an enrollment now and finish it later, or do I have to start and submit it all in one session?
+----------------------------------------------------------------------------------------------------------
+
+This site lets you save a "draft" at any point while you are creating a
+new enrollment. Click the "Save as draft" button. Even if you log out
+and then log back in, that draft enrollment will still be available for
+you to work on -- you will see it in your Dashboard and in the Draft tab
+under Enrollments.
+
+Can I start a draft enrollment and then have someone else finish it for me?
+---------------------------------------------------------------------------
+
+Service agents and service admins can do this, but providers cannot.
+
+How do we renew an enrollment or update an enrollment?
+------------------------------------------------------
+
+Right now that's not something the PSM can do, but it'll be possible in
+a future version.
+
+I've already submitted an enrollment and it's pending, but I need to change something; what can I do?
+-----------------------------------------------------------------------------------------------------
+
+You'll need to directly contact the state Medicaid office; once you've
+submitted an enrollment, you can't update it in the PSM.
+
+How will I find out when my enrollment is accepted or rejected?
+---------------------------------------------------------------
+
+Right now, this site does not notify you via email or paper mail when
+the state accepts or rejects an enrollment you have submitted. This will
+change in a future version of the Provider Screening Module.
+
+When you log into the PSM, you'll see any enrollments you've submitted
+or started drafting via your PSM user account. You'll be able to see the
+status of each enrollment. We recommend you log in and check regularly
+for status updates.
+
+It is your responsibility to check this regularly.
+
+What can I do to reduce the risk of delay or rejection for an enrollment?
+-------------------------------------------------------------------------
+
+You should: \* Include clear, accurate scans of your
+licenses/certifications \* Make sure your NPI number, address, and other
+details in the application are correct \* Check the `NPPES (National
+Plan and Provider Enumeration System)
+website <https://nppes.cms.hhs.gov/>`__ to ensure your NPI status is
+active \* Check the state Medicaid provider guidelines
+
+What is the difference between a private practice and a group practice?
+-----------------------------------------------------------------------
+
+On the "Practice Info" page of the enrollment process for individual
+providers, the site asks you:
+
+    Do you maintain your own private practice?
+
+If you have an Entity Type 1 (Individual) NPI number, say "yes". `The
+Center for Medicare and Medicaid Services website has more guidance on
+your NPI
+number. <https://questions.cms.gov/faq.php?id=5005&rtopic=1851&rsubtopic=8605>`__
+
+    Are you employed and/or independently contracted by a group
+    practice?
+
+If you are employed and/or independently contracted by an organization
+health care provider that has an Entity Type 2 (Organization) NPI
+number, say "yes". `The CMS website has more information on Type 2 NPI
+numbers and what kinds of business structures should have
+them <https://questions.cms.gov/faq.php?id=5005&faqId=1965>`__.
+
+Can I create multiple enrollments for one person (e.g., if a person is licensed as two or more kinds of provider)?
+------------------------------------------------------------------------------------------------------------------
+
+Yes.
+
+Why would a provider have multiple enrollments?
+-----------------------------------------------
+
+An individual person might be licensed as two or more kinds of provider.
+
+How do I input an enrollment for an individual provider who is affiliated with multiple organizations (e.g., a psychologist who works for two clinics)?
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+
+You can choose to "Add Another Practice Location" on the "Practice Info"
+screen of the enrollment application. This is a way to indicate that a
+provider works with multiple group practices.
+
+How do I input an enrollment for an organization with several individual providers (e.g., a clinic employing several physicians)?
+---------------------------------------------------------------------------------------------------------------------------------
+
+Choose the correct organizational provider type during the first step of
+enrollment. On the member entry screen, click the link to add an
+additional member. Repeat as necessary to add all the individuals who
+will provide services under the umbrella of the organization.
+
+When an organizational provider owns a number of separately located facilities in the state, does each facility need to enroll separately?
+------------------------------------------------------------------------------------------------------------------------------------------
+
+If the organizational provider (often a corporation) owns multiple
+locations, each one must be enrolled separately.
+
+What do I do if none of the provider types seem to describe what I do (what this provider does)?
+------------------------------------------------------------------------------------------------
+
+Contact your state Medicaid office directly.
+
+How can I update an existing organizational enrollment to add a new provider (e.g., if a clinic hires a new physician)?
+-----------------------------------------------------------------------------------------------------------------------
+
+If an enrollment is a draft (you haven't submitted it yet), then yes,
+you can click on the draft enrollment and edit the member list.
+
+If you have already submitted the enrollment, then you should have the
+individual, or a service agent, create a new enrollment for an
+individual provider. On the "Practice Info" screen, the user should say
+"Yes" to the question "Are you employed and/or independently contracted
+by a group practice?" and enter the organization's information.
+
+How can I update an existing organizational enrollment to remove a provider (e.g., if a physician retires from a clinic)?
+-------------------------------------------------------------------------------------------------------------------------
+
+If an enrollment is a draft (you haven't submitted it yet), then yes,
+you can click on the draft enrollment and edit the member list. If you
+have already submitted the enrollment, then it is not possible to remove
+an individual member via the PSM, and you will need to directly contact
+your state Medicaid office.
+
+How do I view license/certification files?
+------------------------------------------
+
+When viewing a pending enrollment, on the "Review Enrollment" screen,
+look under the "License Information" heading. Next to a license or
+certification number (issued by the licensure or certification
+authority), you'll see a "View" link. Click that to access the scanned
+image of the provider's license or certification. Your PC will probably
+automatically open a program to view the file, such as:
+
+-  PDF files: Adobe Acrobat
+-  PNG, JPEG, BMP, GIF and TIF files: built-in image viewer
+-  DOC and DOCX files: Microsoft Word
+-  PPT and PPTX files: Microsoft PowerPoint
+
+What if I know from past experience that someone else with the same name, address, or NPI has previously been excluded from Medicaid and that automatic checks are likely to flag this enrollment as a result?
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Contact your state Medicaid office directly.
+
+How do I end (terminate) my own active enrollment?
+--------------------------------------------------
+
+Currently the PSM does not give you a way to terminate an approved
+enrollment, but a future version of the PSM will. Please contact the
+state Medicaid office directly to terminate an enrollment.

--- a/docs/userhelp/source/index.rst
+++ b/docs/userhelp/source/index.rst
@@ -10,8 +10,13 @@ Welcome to Provider Screening Module's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-   system-admin-help
+   process-purpose
+   account-help
+   provider-help
+   enrollment
+   service-agent-help
    service-admin-help
+   system-admin-help
 
 Indices and tables
 ==================

--- a/docs/userhelp/source/index.rst
+++ b/docs/userhelp/source/index.rst
@@ -6,6 +6,17 @@
 Welcome to Provider Screening Module's documentation!
 =====================================================
 
+This code is a work-in-progress and is not yet ready for production
+deployment. Please see `our installation documentation
+<https://github.com/OpenTechStrategies/psm/blob/master/INSTALL.md>`__
+for details, and check our current status.
+
+If you have suggestions for improving this user help guide, please add
+them `as comments on this issue
+<https://github.com/OpenTechStrategies/psm/issues/338>`__ or `as
+emails to this mailing list
+<https://groups.google.com/forum/#!forum/psm-dev>`__. Thank you!
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/userhelp/source/process-purpose.rst
+++ b/docs/userhelp/source/process-purpose.rst
@@ -1,0 +1,15 @@
+Why do we have this enrollment process?
+=======================================
+
+Under Medicaid and similar programs, federal and state governments pay
+doctors, pharmacists, and other medical service providers for treating
+patients. State and federal regulations require providers to meet
+eligibility standards. The enrollment process is where we verify that
+eligibility. The Provider Screening Module helps states manage the
+enrollment process so that eligible providers can serve Medicaid
+clients.
+
+The goal of the PSM is to make it as painless as possible for providers
+to enroll (encouraging enrollment and thus improving service to Medicaid
+patients), and as painless as possible for administrators to manage
+enrollments.

--- a/docs/userhelp/source/provider-help.rst
+++ b/docs/userhelp/source/provider-help.rst
@@ -1,0 +1,44 @@
+Provider help documentation
+===========================
+
+This is documentation for health care providers using the Provider
+Screening Module.
+
+Do I count as a provider?
+-------------------------
+
+Providers are people and organizations who render health care services,
+group practices that furnish health care supplies to patients, and in
+some cases, other people or organizations who are eligible to be
+reimbursed through Medicaid for providing certain services.
+
+Providers can be sole proprietorships or incorporated practices.
+
+How do I change my name in this system? Can I update it in one place for all my enrollments?
+--------------------------------------------------------------------------------------------
+
+If an enrollment is a draft (you haven't submitted it yet), then yes,
+you can click on the draft enrollment and edit your name. If you have
+already submitted the enrollment, then it is not possible to edit your
+name as associated with that enrollment; you'll need to contact the
+state Medicaid office directly.
+
+Currently it is not possible for you to change your name for your
+account; you will need to contact a system administrator at your state
+Medicaid office to do this.
+
+How do I update my contact information for an approved enrollment? Can I update it in one place for all my enrollments?
+-----------------------------------------------------------------------------------------------------------------------
+
+Once an enrollment has been approved, you cannot change the contact
+information in it via this system (although a future version of the PSM
+will allow you to do this); please contact the state Medicaid office
+directly.
+
+How do I update my license/certification information for an approved enrollment (e.g., if I have renewed my license)?
+---------------------------------------------------------------------------------------------------------------------
+
+Once an enrollment has been approved, you cannot change the license and
+certification information in it via this system (although a future
+version of the PSM will allow you to do this); please contact the state
+Medicaid office directly.

--- a/docs/userhelp/source/service-admin-help.rst
+++ b/docs/userhelp/source/service-admin-help.rst
@@ -4,55 +4,6 @@ Service administrator help documentation
 This is documentation for service administrators for the Provider
 Screening Module.
 
-Why do we have this enrollment process?
----------------------------------------
-
-Under Medicaid and similar programs, federal and state governments pay
-doctors, pharmacists, and other medical service providers for treating
-patients. State and federal regulations require providers to meet
-eligibility standards. The enrollment process is where we verify that
-eligibility. The Provider Screening Module helps states manage the
-enrollment process so that eligible providers can serve Medicaid
-clients.
-
-The goal of the PSM is to make it as painless as possible for providers
-to enroll (encouraging enrollment and thus improving service to Medicaid
-patients), and as painless as possible for administrators to manage
-enrollments.
-
-What information do I need to create an enrollment?
----------------------------------------------------
-
-An enrollment includes:
-
--  provider/organization information, such as provider type, name, NPI,
-   and contact information
-
--  license and certification information, including a scan of the
-   license or certification itself
-
--  contact and billing/reimbursement information about the practice
-
--  answers to questions about the provider's past exclusions, penalties,
-   terminations, and convictions, if any
-
--  an electronic signature and date attesting to the accuracy of the
-   enrollment information
-
-What are the steps in the enrollment process?
----------------------------------------------
-
--  A provider, service agent, or service admin creates and submits a new
-   enrollment for a particular provider. (A user can save a draft
-   enrollment and come back later to finish and submit it.)
-
--  A service admin reviews the enrollment, using links provided by the
-   PSM to verify enrollment details, and decides whether to approve or
-   reject the submission.
-
--  After an enrollment has been approved, a service admin can select and
-   renew it.
-
 How do I use the enrollment verification process?
 -------------------------------------------------
 
@@ -108,45 +59,6 @@ appropriate.
 
 Future verification processes will be increasingly automated.
 
-How do I view license/certification files?
-------------------------------------------
-
-When viewing a pending enrollment, on the "Review Enrollment" screen,
-look under the "License Information" heading. Next to a license or
-certification number (issued by the licensure or certification
-authority), you'll see a "View" link. Click that to access the scanned
-image of the provider's license or certification. Your PC will probably
-automatically open a program to view the file, such as:
-
--  PDF files: Adobe Acrobat
--  PNG, JPEG, BMP, GIF and TIF files: built-in image viewer
--  DOC and DOCX files: Microsoft Word
--  PPT and PPTX files: Microsoft PowerPoint
-
-Who can view enrollments?
--------------------------
-
-A provider can view their own enrollments (including draft, rejected,
-approved, and pending enrollments).
-
-A service agent or service admin can view all enrollments (including
-draft, rejected, approved, and pending enrollments).
-
-A system admin should not be able to view any enrollments. `The PSM
-currently allows a system admin to view enrollments, but will remove
-that capability in a future
-version. <https://github.com/OpenTechStrategies/psm/issues/10>`__
-
-Which enrollment information can a provider, service agent, or service admin modify or delete?
-----------------------------------------------------------------------------------------------
-
-A provider can modify a draft enrollment, but can't delete it. A
-provider also cannot delete or modify an enrollment after submitting it
-(once it is "pending").
-
-A service agent or service admin can modify a draft or pending
-enrollment, but cannot delete it.
-
 How do I look at and change the risk assessment rules?
 ------------------------------------------------------
 
@@ -156,23 +68,6 @@ IT team. You can also refer to the Centers for Medicare and Medicaid
 Services' rules, and to the
 `regulations <https://www.law.cornell.edu/cfr/text/42/424.518>`__ they
 implement.
-
-What will the provider see or receive when enrollment is pending, modified, approved, or rejected?
---------------------------------------------------------------------------------------------------
-
-When a provider logs into the PSM, they'll see any enrollments they've
-submitted or started drafting via their PSM user account. They'll be
-able to see the status of each enrollment.
-
-Right now, the provider does not receive any email notifications about
-their enrollment. (A future version of the PSM will send email
-notifications to providers when the status of their enrollment changes.)
-
-How do we renew an enrollment or update an enrollment?
-------------------------------------------------------
-
-Right now that's not something the PSM can do, but it'll be possible in
-a future version.
 
 What's the difference between an agreement and an addendum?
 -----------------------------------------------------------

--- a/docs/userhelp/source/service-agent-help.rst
+++ b/docs/userhelp/source/service-agent-help.rst
@@ -1,0 +1,71 @@
+Service agent help documentation
+================================
+
+This is documentation for service agents using the Provider Screening
+Module.
+
+Who is allowed to be a service agent?
+-------------------------------------
+
+The state Medicaid office decides on criteria for service agents.
+
+Is it acceptable for me to fill out and sign the Provider Statement on the provider's behalf?
+---------------------------------------------------------------------------------------------
+
+Please confer with the state Medicaid office.
+
+When the state accepts or rejects an enrollment I've submitted, how do I find out? Is it my responsibility to notify the provider?
+----------------------------------------------------------------------------------------------------------------------------------
+
+Right now, this site does not notify you via email or paper mail when
+the state accepts or rejects an enrollment you have submitted. This will
+change in a future version of the Provider Screening Module.
+
+When you log into the PSM, you'll see any enrollments you've submitted
+or started drafting via your PSM user account. You'll be able to see the
+status of each enrollment. We recommend you log in and check regularly
+for status updates.
+
+It is your responsibility to check this and notify providers whose
+enrollments you have submitted to tell them the status of their
+enrollments.
+
+Can I submit a batch submission to renew several providers' enrollments?
+------------------------------------------------------------------------
+
+No. Currently the PSM does not support this.
+
+How do I change a provider's name in this system? Can I update it in one place for all their enrollments?
+---------------------------------------------------------------------------------------------------------
+
+If an enrollment is a draft (you haven't submitted it yet), then yes,
+you can click on the draft enrollment and edit the provider's name. If
+you have already submitted the enrollment, then it is not possible to
+edit the provider's name.
+
+Currently you cannot update multiple draft enrollments at once.
+
+How do I update the contact information for an approved enrollment? Can I update it in one place for all their enrollments?
+---------------------------------------------------------------------------------------------------------------------------
+
+If an enrollment is a draft (you haven't submitted it yet), then yes,
+you can click on the draft enrollment and edit the provider's contact
+information. If you have already submitted the enrollment, then it is
+not possible to edit the provider's contact information. However, a
+future version of the PSM will let you do this.
+
+Currently you cannot update multiple draft enrollments at once.
+
+How do I update the license/certification information for an approved enrollment (e.g., if the provider has renewed their license)?
+-----------------------------------------------------------------------------------------------------------------------------------
+
+Currently, the PSM does not allow you to update information for an
+approved enrollment. You'll need to contact the state Medicaid office
+directly.
+
+How do I terminate an enrollment (e.g., if a provider retires or dies)?
+-----------------------------------------------------------------------
+
+Currently the PSM does not give you a way to terminate an approved
+enrollment (but a future version will let you do this). Please contact
+the state Medicaid office directly to terminate an enrollment.


### PR DESCRIPTION
Refactor and deduplicate some documentation (pulling enrollment, process, and account FAQs into their own documents), and add a first draft of provider and service agent user help documents.

Currently ready for a first read; Monday I'll finish the not-yet-finished (`TK`) bits and remove the "WIP" from the PR title and ask for a review.