### PR TITLE
Use 'username' consistently in user messaging

### DIFF
--- a/docs/userhelp/source/account-help.rst
+++ b/docs/userhelp/source/account-help.rst
@@ -33,8 +33,8 @@ Medicaid office for an account.
 How do I log in?
 ----------------
 
-Go to the main page of the website and enter your user name and
-password, and click the "Login" button.
+Go to the main page of the website and enter your username and password,
+and click the "Login" button.
 
 I forgot my password. Can I retrieve or reset it?
 -------------------------------------------------

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -153,7 +153,7 @@ public class RegistrationServiceBean extends BaseService implements Registration
     }
 
     /**
-     * Retrieves the user with the given user name.
+     * Retrieves the user with the given username.
      *
      * @param username the username to search for
      * @return the matching user, null if not found

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -41,7 +41,7 @@
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
                                     <div class="row">
-                                        <label>User Name<span class="required">*</span></label>
+                                        <label>Username<span class="required">*</span></label>
                                         <span class="floatL"><b>:</b></span>
                                         
                                         <c:set var="errorCls" value="" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/advanced-search-section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/advanced-search-section.jsp
@@ -22,7 +22,7 @@
             <div class="section">
                 <div class="leftCol">
                     <div class="row">
-                        <label>User Name</label>
+                        <label>Username</label>
                         <span class="floatL"><b>:</b></span>
                         <form:input cssClass="normalInput" path="username"/>
                     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
@@ -15,7 +15,7 @@
     <div class="floatW">
         <div class="leftCol">
             <div class="row">
-                <label>User Name</label>
+                <label>Username</label>
                 <span class="floatL"><b>:</b></span>
                 <form:input cssClass="normalInput" path="username" />
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sortable-table-headers.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sortable-table-headers.jsp
@@ -11,7 +11,10 @@
 <th>
     <c:choose>
         <c:when test="${criteria.sortColumn == 'username'}">
-            <a class="sortable_column" rel="username" href="javascript:;"><span>User Name</span>
+            <a
+                class="sortable_column"
+                rel="username"
+                href="javascript:;"><span>Username</span>
                 <c:choose>
                     <c:when test="${criteria.ascending}">
                         <span class="sort-up"></span>
@@ -23,7 +26,10 @@
             </a>
         </c:when>
         <c:otherwise>
-            <a class="sortable_column" rel="username" href="javascript:;"><span>User Name</span></a>
+            <a
+                class="sortable_column"
+                rel="username"
+                href="javascript:;"><span>Username</span></a>
         </c:otherwise>
     </c:choose>
     <span class="sep"></span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_user_profile.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_user_profile.jsp
@@ -36,7 +36,7 @@
                                 <div class="section" id="updateProfile">
                                     <div class="wholeCol">
                                         <div class="row">
-                                            <label>User Name</label>
+                                            <label>Username</label>
                                             <span class="floatL"><b>:</b></span>
                                             <form:hidden path="username" />
                                             <span><c:out value="${user.username}"/></span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_user_profile.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_user_profile.jsp
@@ -34,7 +34,7 @@
 							<div class="section">
 								<div class="wholeCol">
                                     <div class="row">
-                                        <label>User Name</label>
+                                        <label>Username</label>
                                         <span class="floatL"><b>:</b></span>
                                         <span><c:out value="${user.username}"/></span>
                                     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -27,7 +27,7 @@
         <div class="section">
             <div class="wholeCol">
                 <div class="row">
-                    <label>User Name</label>
+                    <label>Username</label>
                     <span class="floatL"><b>:</b></span>
                     <span>${user.username}</span>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -61,7 +61,7 @@
             <form:hidden path="userId"/>
             <div class="wholeCol">
                 <div class="row">
-                    <label>User Name</label>
+                    <label>Username</label>
                     <span class="floatL"><b>:</b></span>
                     <form:input cssClass="normalInput" path="username" />
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -43,7 +43,7 @@
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
                                     <div class="row">
-                                        <label>User Name<span class="required">*</span></label>
+                                        <label>Username<span class="required">*</span></label>
                                         <span class="floatL"><b>:</b></span>
                                         
                                         <c:set var="errorCls" value="" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
@@ -22,7 +22,7 @@
             <div class="section">
                 <div class="leftCol">
                     <div class="row">
-                        <label>User Name</label>
+                        <label>Username</label>
                         <span class="floatL"><b>:</b></span>
                         <input type="text" class="normalInput" name="username"/>
                     </div>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseServiceAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseServiceAdminController.java
@@ -64,7 +64,7 @@ public abstract class BaseServiceAdminController {
     }
 
     /**
-     * Get user name from the session.
+     * Get username from the session.
      * @param request the http request
      * @return the username
      */

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
@@ -115,7 +115,7 @@ public class UserValidator extends BaseValidator implements Validator {
         // perform format validations
         rejectIfEmpty(errors, "firstName", "field.required", "First Name");
         rejectIfEmpty(errors, "lastName", "field.required", "Last Name");
-        rejectIfEmpty(errors, "username", "field.required", "User Name");
+        rejectIfEmpty(errors, "username", "field.required", "Username");
         rejectIfEmpty(errors, "email", "field.required", "Email");
         rejectIfEmpty(errors, "role.description", "field.required", "Role");
 
@@ -137,7 +137,7 @@ public class UserValidator extends BaseValidator implements Validator {
         }
 
         if (user.getUsername() != null && user.getUsername().length() > USERNAME_MAX_LENGTH) {
-            rejectValue(errors, "username", "length.exceeded", "User Name", USERNAME_MAX_LENGTH);
+            rejectValue(errors, "username", "length.exceeded", "Username", USERNAME_MAX_LENGTH);
         }
 
         // perform logical validations

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
@@ -50,7 +50,7 @@ public class ForgotPasswordFormValidator extends BaseValidator {
      * @param errors the binding results
      */
     public void validate(Object target, Errors errors) {
-        rejectIfEmpty(errors, "username", "field.required", "User Name");
+        rejectIfEmpty(errors, "username", "field.required", "Username");
         rejectIfEmpty(errors, "email", "field.required", "Email");
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
@@ -80,7 +80,7 @@ public class RegistrationFormValidator extends BaseValidator {
      */
     public void validate(Object target, Errors errors) {
         // perform format validations
-        rejectIfEmpty(errors, "username", "field.required", "User Name");
+        rejectIfEmpty(errors, "username", "field.required", "Username");
         rejectIfEmpty(errors, "firstName", "field.required", "First Name");
         rejectIfEmpty(errors, "lastName", "field.required", "Last Name");
         rejectIfEmpty(errors, "email", "field.required", "Email");
@@ -88,7 +88,7 @@ public class RegistrationFormValidator extends BaseValidator {
         RegistrationForm user = (RegistrationForm) target;
 
         if (user.getUsername() != null && user.getUsername().length() > USERNAME_MAX_LENGTH) {
-            rejectValue(errors, "username", "length.exceeded", "User Name", USERNAME_MAX_LENGTH);
+            rejectValue(errors, "username", "length.exceeded", "Username", USERNAME_MAX_LENGTH);
         }
         if (user.getFirstName() != null && user.getFirstName().length() > NAME_MAX_LENGTH) {
             rejectValue(errors, "firstName", "length.exceeded", "First Name", NAME_MAX_LENGTH);

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
@@ -131,7 +131,7 @@ public class CMSLDAPUserDetailsMapper extends LdapUserDetailsMapper {
      * Wraps the user details to contain tracking information.
      *
      * @param context the directory context
-     * @param username the user name
+     * @param username the username
      * @param authority the granted authorities
      * @return the user details
      */

--- a/psm-app/cms-web/src/main/resources/messages.properties
+++ b/psm-app/cms-web/src/main/resources/messages.properties
@@ -2,7 +2,7 @@ field.required={0} is required.
 length.exceeded={0} cannot exceed {1} characters.
 email.invalid=Please enter a valid email address.
 
-duplicate.username=Requested user name is already registered.
+duplicate.username=Requested username is already registered.
 password.mismatch=Passwords do not match.
 
 invalid.credentials=Invalid credentials.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
@@ -41,7 +41,7 @@ public class AuditRecord {
     private long id;
 
     /**
-     * User name.
+     * Username.
      */
     private String username;
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class UserSearchCriteria extends SearchCriteria {
 
     /**
-     * The user name.
+     * The username.
      */
     private String username;
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
@@ -40,7 +40,7 @@ public interface RegistrationService {
     CMSUser findByExternalUsername(SystemId systemName, String username) throws PortalServiceException;
 
     /**
-     * Retrieves the user with the given user name.
+     * Retrieves the user with the given username.
      *
      * @param username the username to search for
      * @return the matching user, null if not found


### PR DESCRIPTION
We had "username" in some places and "user name" in others. This commit fixes that inconsistency.

@jasonaowen do you want me to wrap the lines in these files as long as I am touching them?