### PR TITLE
Show practice/billing addresses in h-adr microformat

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
@@ -1,4 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 
 <div class="row">
     <label>Primary Practice Name</label>
@@ -18,12 +19,13 @@
 <div class="row">
     <label>Practice Address</label>
     <span class="floatL"><b>:</b></span>
-    <span>
-        <c:if test="${not empty requestScope['_06_addressLine1']}"><c:out value="${requestScope['_06_addressLine1']}" /><br /></c:if>
-        <c:out value="${requestScope['_06_addressLine2']}" /><br />
-        ${requestScope['_06_city']}, ${requestScope['_06_state']} ${requestScope['_06_zip']}
-        <c:set var="county" value="${requestScope['_06_county']}" /><c:if test="${not empty county}">,</c:if>${county} 
-    </span>
+    <h:address name="practice"
+        streetAddress="${requestScope['_06_addressLine1']}"
+        extendedAddress="${requestScope['_06_addressLine2']}"
+        city="${requestScope['_06_city']}"
+        state="${requestScope['_06_state']}"
+        postalCode="${requestScope['_06_zip']}"
+        county="${requestScope['_06_county']}" />
 </div>
 <div class="row">
     <label>Practice Phone Number</label>
@@ -48,10 +50,11 @@
         <span>Same As Above</span>
     </c:if>
     <c:if test="${requestScope['_06_reimbursementSameAsPrimary'] ne 'Y'}">
-        <span>
-            <c:if test="${not empty requestScope['_06_reimbursementAddressLine1']}"><c:out value="${requestScope['_06_reimbursementAddressLine1']}" /><br /></c:if>
-            <c:out value="${requestScope['_06_reimbursementAddressLine2']}" /><br />
-            ${requestScope['_06_reimbursementCity']}, ${requestScope['_06_reimbursementState']} ${requestScope['_06_reimbursementZip']}
-        </span>
+        <h:address name="billing"
+            streetAddress="${requestScope['_06_reimbursementAddressLine1']}"
+            extendedAddress="${requestScope['_06_reimbursementAddressLine2']}"
+            city="${requestScope['_06_reimbursementCity']}"
+            state="${requestScope['_06_reimbursementState']}"
+            postalCode="${requestScope['_06_reimbursementZip']}" />
     </c:if>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -1,4 +1,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <div class="row">
     <label>Private Practice Name</label>
     <span class="floatL"><b>:</b></span>
@@ -17,12 +19,13 @@
 <div class="row">
     <label>Practice Address</label>
     <span class="floatL"><b>:</b></span>
-    <span>
-        <c:if test="${not empty requestScope['_05_addressLine1']}"><c:out value="${requestScope['_05_addressLine1']}" /><br /></c:if>
-        <c:out value="${requestScope['_05_addressLine2']}" /><br />
-        ${requestScope['_05_city']}, ${requestScope['_05_state']} ${requestScope['_05_zip']}
-        <c:set var="county" value="${requestScope['_05_county']}" /><c:if test="${not empty county}">,</c:if>${county}
-    </span>
+    <h:address name="practice"
+        streetAddress="${requestScope['_05_addressLine1']}"
+        extendedAddress="${requestScope['_05_addressLine2']}"
+        city="${requestScope['_05_city']}"
+        state="${requestScope['_05_state']}"
+        postalCode="${requestScope['_05_zip']}"
+        county="${requestScope['_05_county']}" />
 </div>
 <div class="row">
     <label>Practice Phone Number</label>
@@ -43,17 +46,17 @@
 <div class="row">
     <label>Billing Address</label>
     <span class="floatL"><b>:</b></span>
-    
     <c:if test="${requestScope['_05_billingSameAsPrimary'] eq 'Y'}">
         <span>Same As Above</span>
     </c:if>
     <c:if test="${requestScope['_05_billingSameAsPrimary'] ne 'Y'}">
-        <span>
-            <c:if test="${not empty requestScope['_05_addressLine1']}"><c:out value="${requestScope['_05_billingAddressLine1']}" /><br /></c:if>
-            <c:out value="${requestScope['_05_billingAddressLine2']}" /><br />
-            ${requestScope['_05_billingCity']}, ${requestScope['_05_billingState']} ${requestScope['_05_billingZip']}
-            <c:set var="county" value="${requestScope['_05_billingCounty']}" /><c:if test="${not empty county}">,</c:if>${county}
-        </span>
+        <h:address name="billing"
+            streetAddress="${requestScope['_05_billingAddressLine1']}"
+            extendedAddress="${requestScope['_05_billingAddressLine2']}"
+            city="${requestScope['_05_billingCity']}"
+            state="${requestScope['_05_billingState']}"
+            postalCode="${requestScope['_05_billingZip']}"
+            county="${requestScope['_05_billingCounty']}" />
     </c:if>
 </div>
 <div class="row">

--- a/psm-app/cms-web/WebContent/WEB-INF/tags/address.tag
+++ b/psm-app/cms-web/WebContent/WEB-INF/tags/address.tag
@@ -1,0 +1,17 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ attribute name="name" required="true" %>
+<%@ attribute name="streetAddress" required="true" %>
+<%@ attribute name="extendedAddress" required="false" %>
+<%@ attribute name="city" required="true" %>
+<%@ attribute name="state" required="true" %>
+<%@ attribute name="postalCode" required="true" %>
+<%@ attribute name="county" required="false" %>
+<span class="h-adr ${name}">
+    <div class="p-street-address"><c:out value="${streetAddress}" /></div>
+    <div class="p-extended-address"><c:out value="${extendedAddress}" /></div>
+    <span class="p-locality"><c:out value="${city}" /></span>,
+    <span class="p-region state"><c:out value="${state}" /></span>
+    <span class="p-postal-code"><c:out value="${postalCode}" /></span><
+        c:if test="${not empty county}">,</c:if>
+    <span class="p-region county"><c:out value="${county}" /></span>
+</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/tags/input.tag
+++ b/psm-app/cms-web/WebContent/WEB-INF/tags/input.tag
@@ -1,8 +1,0 @@
-<%@ tag import="java.util.Date" 
-  import="java.text.DateFormat"%>
-<% 
-  DateFormat dateFormat = 
-    DateFormat.getDateInstance(DateFormat.LONG);
-  Date now = new Date(System.currentTimeMillis());
-  out.println(dateFormat.format(now));
-%>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4857,6 +4857,15 @@ p.confirm {
     word-wrap: break-word;
 }
 
+div.row > .h-adr > .p-street-address,
+div.row > .h-adr > .p-extended-address,
+div.row > .h-adr > .p-locality,
+div.row > .h-adr > .p-region,
+div.row > .h-adr > .p-postal-code {
+    float: none;
+    width: auto;
+}
+
 .summaryPageWrapper .row , #printModal .row {
 	margin-top: 12px;
 	line-height: 18px;


### PR DESCRIPTION
As I'm working on updating Kevin's tests from #332, I found I needed to add more structure to the summary page. This seemed like a good, separable piece that can be reviewed independently.

---

Enable testability in Selenium by splitting the private and primary address fields for practice and billing in the summary page into separate fields following the [h-adr microformat](http://microformats.org/wiki/h-adr
). While we probably won't have any particular use for this format, the new elements needed class names, this format seemed to fit well, and we might as well use something standard.

While so doing, fix a misplaced comma between the zip code and county.

Also fix a few potential [cross-site-scripting issue caused by not using `<c:out>` tags](https://stackoverflow.com/a/291047/25637) to display user-entered data.

---

Testing: built and deployed, logged in as a provider with several previously-filled-out individual provider type enrollments, and examined the practice info tag on a private practice enrollment and on a primary practice enrollment.

---

Issue #159 Practice address displays punctuated improperly
See also #322 Fix comma placement in confirmation screen, where I incorrectly suggested removing the `<c:out>` tags.