### PR TITLE
Add UI integration tests - 332 Rewrite, Part 1

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -18,7 +18,6 @@ public class EnrollmentStepDefinitions {
     private EnrollmentPage enrollmentPage;
     private OwnershipInfoPage ownershipInfoPage;
 
-
     @Given("^I am entering ownership information$")
     public void i_am_entering_ownership_information() {
         enrollmentSteps.selectOrganizationalProviderType();
@@ -72,4 +71,13 @@ public class EnrollmentStepDefinitions {
         assertThat(enrollmentPage.getTitle()).isEqualTo("Summary Information");
     }
 
+    @When("^I enter valid personal information$")
+    public void enter_valid_personal_information() {
+        enrollmentSteps.enterIndividualPersonalInfo();
+    }
+
+    @Then("^I can move on from the personal info page with no errors$")
+    public void i_will_move_on_from_the_personal_info_page_with_no_errors() {
+        enrollmentSteps.advanceFromIndividualPersonalInfoToLicenseInfo();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -2,6 +2,7 @@ package gov.medicaid.features.enrollment.steps;
 
 import gov.medicaid.features.enrollment.ui.IndividualInfoPage;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
+import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
 import gov.medicaid.features.enrollment.ui.SelectProviderTypePage;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.LoginPage;
@@ -19,6 +20,7 @@ public class EnrollmentSteps {
     private SelectProviderTypePage selectProviderTypePage;
     private OrganizationInfoPage organizationInfoPage;
     private IndividualInfoPage individualInfoPage;
+    private PersonalInfoPage personalInfoPage;
 
     private SimpleDateFormat formFieldDateFormat = new SimpleDateFormat("MMddyyyy");
 
@@ -80,5 +82,10 @@ public class EnrollmentSteps {
         individualInfoPage.setIndividualOwnerSoSec("123456789");
         individualInfoPage.setIndividualOwnerDOB("01011970");
         individualInfoPage.setIndividualHireDate("01012000");
+    }
+
+    @Step
+    public void checkForTooYoungError() throws Exception {
+        personalInfoPage.checkForTooYoungError();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -9,9 +9,12 @@ import gov.medicaid.features.general.ui.LoginPage;
 import net.thucydides.core.annotations.Step;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unused")
 public class EnrollmentSteps {
@@ -44,6 +47,26 @@ public class EnrollmentSteps {
     public void selectIndividualProviderType() {
         selectProviderTypePage.selectProviderType("Podiatrist");
         selectProviderTypePage.clickNext();
+    }
+
+    @Step
+    void enterIndividualPersonalInfo() {
+        personalInfoPage.enterFirstName("FirstName");
+        personalInfoPage.enterMiddleName("MiddleName");
+        personalInfoPage.enterLastName("LastName");
+        personalInfoPage.enterNPI("0000000006");
+        personalInfoPage.enterSSN("000-00-0000");
+        personalInfoPage.enterDOB(
+                LocalDate.of(1970, 1, 1)
+        );
+        personalInfoPage.enterEmail("p1@example.com");
+        personalInfoPage.checkSameAsAbove();
+    }
+
+    @Step
+    void advanceFromIndividualPersonalInfoToLicenseInfo() {
+        personalInfoPage.clickNext();
+        assertThat(personalInfoPage.getTitle()).contains("License Information");
     }
 
     public void enterOrganizationInfo() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
@@ -4,8 +4,11 @@ import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
+import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
 import net.thucydides.core.annotations.Steps;
 import org.apache.commons.lang3.StringUtils;
+
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +19,7 @@ public class ValidationStepDefinitions {
     EnrollmentSteps enrollmentSteps;
 
     private OrganizationInfoPage organizationInfoPage;
+    private PersonalInfoPage personalInfoPage;
 
     @Given("^I have started an enrollment$")
     public void i_have_started_an_enrollment() {
@@ -28,15 +32,40 @@ public class ValidationStepDefinitions {
         enrollmentSteps.selectOrganizationalProviderType();
     }
 
+    @Given("^I am on the personal info page$")
+    public void i_am_on_the_personal_info_page() {
+        i_have_started_an_enrollment();
+        enrollmentSteps.selectIndividualProviderType();
+    }
+
     @When("^when I enter an (\\d+) digit FEIN$")
     public void when_I_enter_an_digit_FEIN(int numDigits) {
         String generatedFEIN = StringUtils.repeat("0", numDigits);
         organizationInfoPage.setFEIN(generatedFEIN);
     }
 
+    @When("^I enter a date of birth less than eighteen years ago")
+    public void fill_form_with_under_age_date_of_birth() {
+        LocalDate eighteenthBirthdayEve = LocalDate
+                .now()
+                .minusYears(18)
+                .plusDays(1);
+        personalInfoPage.enterDOB(eighteenthBirthdayEve);
+    }
+
+    @When("^I click 'next' on the personal info page$")
+    public void click_next_on_personal_info_page() {
+        personalInfoPage.clickNext();
+    }
+
     @Then("^It should be rejected$")
     public void it_should_be_rejected() {
         String feinValue = organizationInfoPage.getFEINValue();
         assertThat(feinValue.length()).isEqualTo(0);
+    }
+
+    @Then("^I should get a provider too young error$")
+    public void i_should_get_a_provider_too_young_error() throws Exception {
+        enrollmentSteps.checkForTooYoungError();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -1,0 +1,34 @@
+package gov.medicaid.features.enrollment.ui;
+
+import net.thucydides.core.pages.PageObject;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * PageObject to interact with the "Personal Info" step of an individual
+ * provider enrollment. This page is reached by logging in, creating an
+ * enrollment, and selecting an individual provider type.
+ */
+public class PersonalInfoPage extends PageObject {
+    private static final String PROVIDER_TOO_YOUNG_ERROR_MESSAGE =
+            "Provider age should be 18 or above during enrollment.";
+
+    public void enterDOB(LocalDate dateOfBirth) {
+        String dob = dateOfBirth.format(
+                DateTimeFormatter.ofPattern("MM/dd/yyyy")
+        );
+        $("[name=_02_dob]").type(dob);
+    }
+
+    public void clickNext() {
+        $("#nextBtn").click();
+    }
+
+    public void checkForTooYoungError() throws Exception {
+        assertThat($(".errorInfo > ._02_dob").getText())
+                .contains(PROVIDER_TOO_YOUNG_ERROR_MESSAGE);
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -23,6 +23,35 @@ public class PersonalInfoPage extends PageObject {
         $("[name=_02_dob]").type(dob);
     }
 
+    public void enterFirstName(String firstName) {
+        $("#firstName").type(firstName);
+    }
+
+    public void enterMiddleName(String middleName) {
+        $("#middleName").type(middleName);
+    }
+
+    public void enterLastName(String lastName) {
+        $("[name=_02_lastName]").type(lastName);
+    }
+
+    public void enterNPI(String NPI) {
+        $("[name=_02_npi]").type(NPI);
+    }
+
+    public void enterSSN(String SSN) {
+        $("[name=_02_ssn]").type(SSN);
+    }
+
+
+    public void enterEmail(String email) {
+        $("#emailAddress").type(email);
+    }
+
+    public void checkSameAsAbove() {
+        $("#sameAsAbove").click();
+    }
+
     public void clickNext() {
         $("#nextBtn").click();
     }

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -35,4 +35,8 @@ Feature: Data Coverage Checks
     When I click 'next' on the Ownership Info Page
     Then the city should be accepted
 
-
+  @psm-FR-2.6
+  Scenario: Accepts valid individual provider personal information
+    Given I am on the personal info page
+    When I enter valid personal information
+    Then I can move on from the personal info page with no errors

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
@@ -9,3 +9,9 @@ Feature: Form and Field Validations
     And I am on the organization page
     When when I enter an 8 digit FEIN
     Then It should be rejected
+
+  Scenario: Validate minimum age
+    Given I am on the personal info page
+    When I enter a date of birth less than eighteen years ago
+    And I click 'next' on the personal info page
+    Then I should get a provider too young error


### PR DESCRIPTION
@kevinwan1996 wrote some great integration tests before he finished his internship, but didn't have a chance to respond to our change suggestions in #332. I split two of those tests off, put them in their own commits, and rewrote them to use the step libraries @BenGalewsky created.

I'm putting up this PR now, which doesn't include all the tests in #332, both because it's ready now (and has been for a week) and because some of the next tests require more substantial changes to our application (see #390 for one such change).

After deploying, you can run the tests with `./gradlew integration-tests:test integration-tests:aggregate`. See also [the integration test documentation](https://github.com/OpenTechStrategies/psm/blob/8f8da39a668934ee8660eefc6a8a1b000cb3db1a/psm-app/integration-tests/README.md).