### PR TITLE
Fix calls to `assertThat` to test what we expect

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DashboardPage extends PageObject {
     public void clickOnNewEnrollment() {
         $("#createNewEnrollment").click();
-        assertThat(getTitle().equals("Provider Type Page"));
+        assertThat(getTitle()).isEqualTo("Provider Type Page");
     }
 
     public void selectProviderType(String aProviderType) {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -19,6 +19,6 @@ public class LoginPage extends PageObject {
 
     public void checkUserLoggedIn(String username) {
         String welcomeText = $("#header > div > div.userSection").getText();
-        assertThat(welcomeText.contains("Welcome, " + username));
+        assertThat(welcomeText).contains("Welcome, " + username);
     }
 }


### PR DESCRIPTION
[AssertJ](https://joel-costigliola.github.io/assertj/) provides a fluent API for assertions and more-useful error messages than the built-in Java `assert()` call, but some of its fluent API methods overlap with methods on `String`s, which has led to some mistaken calls. `assertThat(...)` returns an object; if no methods on that object are called, nothing is asserted.

Move the method calls that we expect to assert outside of the `assertThat()`.

---

I tested this by running the integration tests and verifying they still passed.