### PR TITLE
Let UI tests start without existing enrollment

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
@@ -67,7 +68,8 @@
                                             mollit anim id est laborum.
                                         </p>
                                         <div class="">
-                                            <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
+                                            <h:create-enrollment-button
+                                               cssClass="purpleBtn" />
                                         </div>
 
                                     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -18,10 +18,10 @@
                         <%@include file="/WEB-INF/pages/includes/logo.jsp" %>
                         <%@include file="/WEB-INF/pages/includes/nav.jsp" %>
                     </div>
-					<div class="breadCrumb"></div>
-					<h1>Account Setup</h1>
+                    <div class="breadCrumb"></div>
+                    <h1>Account Setup</h1>
                     <div class="tabSection">
-                    	<!-- 
+                        <!--
                         <div class="detailPanel">
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
@@ -49,27 +49,27 @@
                             <div class="bl"></div>
                             <div class="br"></div>
                         </div>
-                    	-->
+                        -->
                         <div class="detailPanel">
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
                                     <div class="row">
-				                        <h3>Additional Enrollments</h3>
-				                        <p>
-				                            You also have the option to create new enrollments. <br />
-											Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-											do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-											Ut enim ad minim veniam, quis nostrud exercitation ullamco
-											laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-											irure dolor in reprehenderit in voluptate velit esse cillum
-											dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-											cupidatat non proident, sunt in culpa qui officia deserunt
-											mollit anim id est laborum.
-										</p>
-				                        <div class="">
-				                            <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
-				                        </div>
-				                        
+                                        <h3>Additional Enrollments</h3>
+                                        <p>
+                                            You also have the option to create new enrollments. <br />
+                                            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
+                                            do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                                            Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                                            laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+                                            irure dolor in reprehenderit in voluptate velit esse cillum
+                                            dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                                            cupidatat non proident, sunt in culpa qui officia deserunt
+                                            mollit anim id est laborum.
+                                        </p>
+                                        <div class="">
+                                            <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
+                                        </div>
+
                                     </div>
                                 </div>
                             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -16,23 +16,22 @@
                 <div class="contentWidth">
                     <div class="mainNav">
                         <%@include file="/WEB-INF/pages/includes/logo.jsp" %>
-                        <%@include file="/WEB-INF/pages/includes/nav.jsp" %>                        
+                        <%@include file="/WEB-INF/pages/includes/nav.jsp" %>
                     </div>
-					<div class="breadCrumb"></div>
-					<h1>Account Setup</h1>
+                    <div class="breadCrumb"></div>
+                    <h1>Account Setup</h1>
                     <div class="tabSection">
                         <div class="detailPanel">
                             <div class="section" id="updateProfile">
                                 <div class="wholeCol">
                                     <div class="row">
-				                        <h3>New Enrollments</h3>
-				                        <p>
-				                            You can now begin the enrollment process.
-				                        </p>
-				                        <div class="">
-				                            <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
-				                        </div>
-				                        
+                                        <h3>New Enrollments</h3>
+                                        <p>
+                                            You can now begin the enrollment process.
+                                        </p>
+                                        <div class="">
+                                            <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -45,7 +44,7 @@
 
 <!-- Commented out the "Linked Profiles" section below because that
      functionality isn't enabled right now.  See commit f5d70d7bb93
-     and any followup commits that refer to it. 
+     and any followup commits that refer to it.
 
      The commenting-out actually uses two separate comment blocks
      below, in order to avoid a comment nesting situation with the

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
@@ -30,7 +31,8 @@
                                             You can now begin the enrollment process.
                                         </p>
                                         <div class="">
-                                            <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
+                                            <h:create-enrollment-button
+                                               cssClass="purpleBtn" />
                                         </div>
                                     </div>
                                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -28,7 +29,8 @@
                     <div class="tabContent contentT">
                             <c:set var="paginatedResults" value="${results}" />
                             <div class="tableHeader tableHeader2">
-                                <a class="purpleBtn purpleBtnR" href="<c:url value="/provider/enrollment/start" />"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
+                                            <h:create-enrollment-button
+                                               cssClass="purpleBtn purpleBtnR" />
                                 <span>Latest Activities</span>
                             </div>
                             <div class="tl"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -44,15 +44,15 @@
                                 </div>
                             </div>
                             <!-- /.pagination -->
-                            
-                            <%@include file="dashboard_filter.jsp" %>                            
+
+                            <%@include file="dashboard_filter.jsp" %>
                             <!-- /.filterPanel -->
-                            
+
                             <div class="tableContainer">
                                 <%@include file="dashboard_table.jsp" %>
                             </div>
                             <!-- /.tableContainer -->
-                            
+
                             <div class="tabFoot">
                                 <div class="tabR">
                                     <div class="tabM">
@@ -88,7 +88,7 @@
                              And why isn't the code here doing
                              <%@ include file="/WEB-INF/pages/admin/includes/high_risk_level_means.jsp" %>
                              the way various other places in the
-                             PSM tree do? 
+                             PSM tree do?
                         --%>
                         <!--
                         <div class="row infoRow">
@@ -114,7 +114,7 @@
         <div id="new-modal">
 
         <%@include file="/WEB-INF/pages/provider/enrollment/steps/modal/print_modal.jsp" %>
-        
+
         </div>
     </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -25,7 +25,7 @@
                         Enrollment
                     </div>
                     <h1>Dashboard</h1>
-                    
+
                     <div class="tabSection">
                         <c:set var="paginatedResults" value="${results}" />
                         <div class="tabHead">
@@ -42,7 +42,7 @@
                         <!-- /.tabHead -->
                         <div class="tabContent" id="tabDraft">
                             <c:url var="exportResultsURL" value="/provider/dashboard/export" />
-                        
+
                             <div class="pagination">
                                 <div class="left">
                                     <%@include file="/WEB-INF/pages/includes/pagination_details.jsp" %>
@@ -59,12 +59,12 @@
                             <div class="filterPanel" style="display: ${param.filterViewState eq 'visible' ? 'block' : 'none'};">
                                 <div class="floatW">
                                     <input type="hidden" id="filterViewStateId" name="filterViewState" value="${param.filterViewState eq 'visible' ? 'visible' : 'hidden'}" />
-							        <form:hidden path="pageSize" />
-							        <form:hidden path="pageNumber" />
-							        <form:hidden path="sortColumn" />
-							        <form:hidden path="ascending" />
+                                    <form:hidden path="pageSize" />
+                                    <form:hidden path="pageNumber" />
+                                    <form:hidden path="sortColumn" />
+                                    <form:hidden path="ascending" />
                                     <input type="hidden" name="status" value="${statusFilter}" />
-                                    
+
                                     <div class="leftCol">
                                         <div class="row">
                                             <label>NPI/UMPI</label>
@@ -124,7 +124,7 @@
                                     <div class="tabM">
                                         <div class="pagination">
                                             <div class="left">
-                                                <%@include file="/WEB-INF/pages/includes/pagination_details.jsp" %>                                                
+                                                <%@include file="/WEB-INF/pages/includes/pagination_details.jsp" %>
                                             </div>
                                             <div class="right">
                                                 <%@include file="/WEB-INF/pages/includes/pagination_links.jsp" %>
@@ -138,7 +138,7 @@
                         </div>
                         <!-- /#tabDraft -->
                     </div>
-                    <!-- /.tabSection -->                    
+                    <!-- /.tabSection -->
                 </div>
             </div>
             <!-- /#mainContent -->
@@ -151,25 +151,24 @@
         <!-- /#modalBackground-->
         <div id="modalBackground"></div>
         <div id="new-modal">
-        
+
         <div id="printModal" class="outLay">
-            <div class="inner"> 
+            <div class="inner">
                 <!-- title -->
                 <div class="modal-title">
-                    <a href="javascript:;" class="greyBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-x.png" />" alt="" />Close</span></span></a> 
+                    <a href="javascript:;" class="greyBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-x.png" />" alt="" />Close</span></span></a>
                     <a href="javascript:;" class="purpleBtn printBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-print2.png" />" alt="" />Print</span></span></a>
                     <h3>Print Preview</h3>
                 </div>
-                <!-- End .modal-title --> 
+                <!-- End .modal-title -->
                 <!-- content -->
                 <div class="modal-content">
-                    
+
                 </div>
                 <!-- End .content -->
             </div>
         </div>
         <!-- /#printModal-->
-        
         </div>
     </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -35,7 +36,8 @@
                                     <a class="tab ${statusFilter eq 'Pending' ? 'active' : ''}" href="<c:url value="/provider/dashboard/pending" />"><span class="aR"><span class="aM">Pending</span></span></a>
                                     <a class="tab ${statusFilter eq 'Approved' ? 'active' : ''}" href="<c:url value="/provider/dashboard/approved" />"><span class="aR"><span class="aM">Approved</span></span></a>
                                     <a class="tab ${statusFilter eq 'Rejected' ? 'active' : ''}" href="<c:url value="/provider/dashboard/rejected" />"><span class="aR"><span class="aM">Denied</span></span></a>
-                                    <a class="purpleBtn" href="<c:url value="/provider/enrollment/start" />"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
+                                    <h:create-enrollment-button
+                                       cssClass="purpleBtn" />
                                 </div>
                             </div>
                         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
@@ -109,7 +110,8 @@
                                 <a href="javascript:submitFormById('importProfilesForm');" class="purpleBtn"><span class="btR"><span class="btM">Import Selected</span></span></a>
                             </c:if>
                             <c:if test="${empty profiles}">
-                                <a href="<c:url value="/provider/enrollment/start" />" class="purpleBtn"><span class="btR"><span class="btM">Create New Enrollment</span></span></a>
+                                <h:create-enrollment-button
+                                   cssClass="purpleBtn" />
                             </c:if>
                         </div>
                         <!-- /.tableDataButtons -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -27,12 +27,12 @@
                         <h1>Import Profiles</h1>
                     </div>
                     <div class="clearFixed"></div>
-                    
+
                     <%@include file="/WEB-INF/pages/includes/flash.jsp" %>
-                    
+
                     <div class="dashboardPanel">
                         <div class="tableData">
-	                        <form id="importProfilesForm" action="<c:url value="/provider/onboarding/list" />" method="post">
+                            <form id="importProfilesForm" action="<c:url value="/provider/onboarding/list" />" method="post">
                             <div class="tableTitle">
                                 <h2>Profiles</h2>
                             </div>
@@ -73,7 +73,7 @@
                             <div class="clearFixed"></div>
                             <div class="tl"></div>
                             <div class="tr"></div>
-	                        </form>
+                            </form>
                         </div>
                         <!-- /.tableData -->
                         <div class="sideBar">
@@ -83,18 +83,18 @@
                                 </div>
                                 <div class="panelSection">
                                     <ul>
-	                                    <li>
-		                                    <p>
-			                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-			                                    do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-			                                    Ut enim ad minim veniam, quis nostrud exercitation ullamco
-			                                    laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-			                                    irure dolor in reprehenderit in voluptate velit esse cillum
-			                                    dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-			                                    cupidatat non proident, sunt in culpa qui officia deserunt
-			                                    mollit anim id est laborum.
-		                                    </p>
-	                                    </li>
+                                        <li>
+                                            <p>
+                                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
+                                                do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                                                Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                                                laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+                                                irure dolor in reprehenderit in voluptate velit esse cillum
+                                                dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                                                cupidatat non proident, sunt in culpa qui officia deserunt
+                                                mollit anim id est laborum.
+                                            </p>
+                                        </li>
                                     </ul>
                                 </div>
                                 <div class="tl"></div>
@@ -102,7 +102,7 @@
                             </div>
                         </div>
                         <!-- /.sideBar -->
-                        
+
                         <div class="tableDataButtons buttonBox">
                             <a href="<c:url value="/provider/dashboard/setup" />" class="greyBtn"><span class="btR"><span class="btM">Cancel</span></span></a>
                             <c:if test="${not empty profiles}">

--- a/psm-app/cms-web/WebContent/WEB-INF/tags/create-enrollment-button.tag
+++ b/psm-app/cms-web/WebContent/WEB-INF/tags/create-enrollment-button.tag
@@ -1,0 +1,8 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ attribute name="cssClass" required="true" %>
+<a
+    href="<c:url value="/provider/enrollment/start" />"
+    class="${cssClass}"
+    >
+  <span class="btR"><span class="btM">Create New Enrollment</span></span>
+</a>

--- a/psm-app/cms-web/WebContent/WEB-INF/tags/create-enrollment-button.tag
+++ b/psm-app/cms-web/WebContent/WEB-INF/tags/create-enrollment-button.tag
@@ -3,6 +3,7 @@
 <a
     href="<c:url value="/provider/enrollment/start" />"
     class="${cssClass}"
+    id="createNewEnrollment"
     >
   <span class="btR"><span class="btM">Create New Enrollment</span></span>
 </a>

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DashboardPage extends PageObject {
     public void clickOnNewEnrollment() {
-        $("#mainContent > div > div.tabContent.contentT > div.tableHeader.tableHeader2 > a").click();
+        $("#createNewEnrollment").click();
         assertThat(getTitle().equals("Provider Type Page"));
     }
 


### PR DESCRIPTION
@brainwane found that the integration tests would fail when the user `p1` had no existing enrollments or drafts - as would be the case with a fresh database. We had also already realized that there was a risk, at least to readability, in the way we were selecting the "Create New Enrollment" button.

My solution to both is to extract the repeated HTML into a new custom tag, then give it an HTML ID and refer to that ID in the tests.

---

I tested this by building, deploying, and running the integration tests with [the credentials](https://github.com/OpenTechStrategies/psm/blob/2ac4487fa92f15c6f6177846c7c524e618a3435b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java#L12-L13) swapped to a new user.

Resolves #333 Make the "Create New Enrollment" Button Testable