### PR TITLE
Test license upload and entry

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
@@ -4,6 +4,9 @@ import cucumber.api.CucumberOptions;
 import net.serenitybdd.cucumber.CucumberWithSerenity;
 import org.junit.runner.RunWith;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 
 /**
  * Integration test glue for serenity
@@ -13,4 +16,9 @@ import org.junit.runner.RunWith;
 @RunWith(CucumberWithSerenity.class)
 @CucumberOptions(features = "src/test/resources/features")
 public class IntegrationTests {
+    public static String format(LocalDate date) {
+        return date.format(
+                DateTimeFormatter.ofPattern("MM/dd/yyyy")
+        );
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -1,10 +1,12 @@
 package gov.medicaid.features.enrollment.steps;
 
+import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
 import net.thucydides.core.annotations.Steps;
 
+import java.io.IOException;
 
 @SuppressWarnings("unused")
 public class DataCoverageStepDefinitions {
@@ -12,6 +14,26 @@ public class DataCoverageStepDefinitions {
     EnrollmentSteps enrollmentSteps;
 
     private OrganizationInfoPage organizationInfoPage;
+
+    @Given("I am on the individual provider license info page")
+    public void enter_individual_provider_license_info_page() {
+        enrollmentSteps.loginAsProvider();
+        enrollmentSteps.createEnrollment();
+        enrollmentSteps.selectIndividualProviderType();
+        enrollmentSteps.enterIndividualPersonalInfo();
+        enrollmentSteps.advanceFromIndividualPersonalInfoToLicenseInfo();
+    }
+
+    @When("^I enter valid license information$")
+    public void enter_valid_license_information() {
+        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
+        enrollmentSteps.enterIndividualLicenseInfo();
+    }
+
+    @When("^I upload a valid license$")
+    public void upload_valid_license() throws IOException {
+        enrollmentSteps.uploadLicense();
+    }
 
     @When("^I move to the organization page$")
     public void i_move_to_the_organization_page() {
@@ -45,5 +67,10 @@ public class DataCoverageStepDefinitions {
     public void i_should_be_asked_to_enter_Contact_phone_Medicaid_number() {
         organizationInfoPage.verifyContactPhoneAccepted();
         organizationInfoPage.verifyMedicaidNumberAccepted();
+    }
+
+    @Then("^the license is accepted$")
+    public void license_is_accepted() {
+        enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.enrollment.steps;
 
 import gov.medicaid.features.enrollment.ui.IndividualInfoPage;
+import gov.medicaid.features.enrollment.ui.LicenseInfoPage;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
 import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
 import gov.medicaid.features.enrollment.ui.SelectProviderTypePage;
@@ -8,6 +9,7 @@ import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import net.thucydides.core.annotations.Step;
 
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Calendar;
@@ -24,6 +26,7 @@ public class EnrollmentSteps {
     private OrganizationInfoPage organizationInfoPage;
     private IndividualInfoPage individualInfoPage;
     private PersonalInfoPage personalInfoPage;
+    private LicenseInfoPage licenseInfoPage;
 
     private SimpleDateFormat formFieldDateFormat = new SimpleDateFormat("MMddyyyy");
 
@@ -45,7 +48,7 @@ public class EnrollmentSteps {
     }
 
     public void selectIndividualProviderType() {
-        selectProviderTypePage.selectProviderType("Podiatrist");
+        selectProviderTypePage.selectProviderType("Speech Language Pathologist");
         selectProviderTypePage.clickNext();
     }
 
@@ -110,5 +113,31 @@ public class EnrollmentSteps {
     @Step
     public void checkForTooYoungError() throws Exception {
         personalInfoPage.checkForTooYoungError();
+    }
+
+    @Step
+    public void enterNotAProviderAtPublicHealthServiceIndianHospital() {
+        licenseInfoPage.clickNo();
+    }
+
+    @Step
+    public void enterIndividualLicenseInfo() {
+        licenseInfoPage.addLicense();
+        licenseInfoPage.addLicenseType("Speech Language Pathologist");
+        licenseInfoPage.enterLicenseNumber("1");
+        licenseInfoPage.enterIssueDate(LocalDate.of(2002, 2, 2));
+        licenseInfoPage.enterRenewalDate(LocalDate.of(2020, 2, 2));
+        licenseInfoPage.enterIssueState("Alaska");
+    }
+
+    @Step
+    public void uploadLicense() throws IOException {
+        licenseInfoPage.uploadSampleFile();
+    }
+
+    @Step
+    public void advanceFromIndividualLicenseInfoToPracticeInfo() {
+        licenseInfoPage.clickNext();
+        assertThat(licenseInfoPage.getTitle()).contains("Practice Information");
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
@@ -1,0 +1,65 @@
+package gov.medicaid.features.enrollment.ui;
+
+import net.thucydides.core.pages.PageObject;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.LocalDate;
+
+import static gov.medicaid.features.IntegrationTests.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LicenseInfoPage extends PageObject {
+    public void clickNo() {
+        $("input[value='N'").click();
+    }
+
+    public void addLicense() {
+        $("#addLicense").click();
+    }
+
+    public void addLicenseType(String licenseType) {
+        $("[name=_03_licenseType_0]").selectByVisibleText(licenseType);
+    }
+
+    public void uploadSampleFile() throws IOException {
+        File temporaryFile = File.createTempFile("License.", ".txt");
+        try (PrintWriter writer = new PrintWriter(
+                new FileOutputStream(temporaryFile))) {
+            writer.println("License");
+        }
+        uploadFile(temporaryFile.getAbsolutePath());
+        temporaryFile.deleteOnExit();
+    }
+
+    public void uploadFile(String filepath) {
+        $("[name=_03_attachment_0]").sendKeys(filepath);
+    }
+
+    public void enterLicenseNumber(String licenseNumber) {
+        $("[name=_03_licenseNumber_0]").type(licenseNumber);
+    }
+
+    public void enterIssueDate(LocalDate issueDate) {
+        $("[name=_03_originalIssueDate_0]").type(
+                format(issueDate)
+        );
+    }
+
+    public void enterRenewalDate(LocalDate renewalDate) {
+        $("[name=_03_renewalDate_0]").type(
+                format(renewalDate)
+        );
+    }
+
+    public void enterIssueState(String issueState) {
+        $("[name=_03_issuingState_0]").selectByVisibleText(issueState);
+    }
+
+    public void clickNext() {
+        $("#nextBtn").click();
+        assertThat(getTitle()).contains("Practice Information");
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -3,8 +3,8 @@ package gov.medicaid.features.enrollment.ui;
 import net.thucydides.core.pages.PageObject;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 
+import static gov.medicaid.features.IntegrationTests.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -17,10 +17,7 @@ public class PersonalInfoPage extends PageObject {
             "Provider age should be 18 or above during enrollment.";
 
     public void enterDOB(LocalDate dateOfBirth) {
-        String dob = dateOfBirth.format(
-                DateTimeFormatter.ofPattern("MM/dd/yyyy")
-        );
-        $("[name=_02_dob]").type(dob);
+        $("[name=_02_dob]").type(format(dateOfBirth));
     }
 
     public void enterFirstName(String firstName) {

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -40,3 +40,10 @@ Feature: Data Coverage Checks
     Given I am on the personal info page
     When I enter valid personal information
     Then I can move on from the personal info page with no errors
+
+  @psm-FR-2.4
+  Scenario: Accepts license
+    Given I am on the individual provider license info page
+    When I enter valid license information
+    And I upload a valid license
+    Then the license is accepted


### PR DESCRIPTION
Add a Serenity test that tries to upload a brief text license for an individual provider and verifies that the license and license info is accepted.

Mostly authored by Kevin in PR #332, split up and updated by Jason.