### PR TITLE
Remove commons-logging runtime dependency

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -50,7 +50,6 @@ ext.libs = [
 // are required.  We know for sure that SOME of them are loaded during runtime, but
 // need to spend some time investigating one by one.
 List runtime_libs = [
-    'commons-logging:commons-logging:1.1.1',
     'net.sourceforge.jexcelapi:jxl:2.6.10',
     'org.codehaus.jackson:jackson-mapper-asl:1.9.13',
     'org.codehaus.janino:janino:2.5.15',


### PR DESCRIPTION
We do not use [the Apache Commons Logging component](https://commons.apache.org/proper/commons-logging/) directly. Spring uses it, and depends on it, so we still get it transitively. The only direct reference to it in our repository, in a Java file that is bundled as part of a JavaScript library, and that Java file isn't included in our build.

I tested this change by building, deploying, logging in, and viewing a PDF export of a previously-submitted enrollment.

Issue #16 Manage sets of dependencies via Gradle or another tool