### PR TITLE
Add UI test to enter and verify practice data

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
@@ -1,11 +1,11 @@
 <div class="row">
     <label>Contact Name</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_02_contactName']}</span>
+    <span id="contactName">${requestScope['_02_contactName']}</span>
 </div>
 
 <div class="row">
     <label>Contact Email Address</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_02_contactEmail']}</span>
+    <span id="contactEmail">${requestScope['_02_contactEmail']}</span>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/license_information.jsp
@@ -1,5 +1,10 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table
+        cellpadding="0"
+        cellspacing="0"
+        class="generalTable noInput"
+        id="licenseTable"
+>
     <colgroup>
         <col width="28"/>
         <col width="184"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp
@@ -2,32 +2,32 @@
         <div class="row">
             <label>First Name</label>
             <span class="floatL"><b>:</b></span>
-            <span>${requestScope['_02_firstName']}</span>
+            <span id="firstName">${requestScope['_02_firstName']}</span>
         </div>
         <div class="row">
             <label>Middle Name</label>
             <span class="floatL"><b>:</b></span>
-            <span>${requestScope['_02_middleName']}</span>
+            <span id="middleName">${requestScope['_02_middleName']}</span>
         </div>
         <div class="row">
             <label>Last Name</label>
             <span class="floatL"><b>:</b></span>
-            <span>${requestScope['_02_lastName']}</span>
+            <span id="lastName">${requestScope['_02_lastName']}</span>
         </div>
         <div class="row">
             <label>NPI</label>
             <span class="floatL"><b>:</b></span>
-            <span>${requestScope['_02_npi']}</span>
+            <span id="npi">${requestScope['_02_npi']}</span>
         </div>
         <div class="row">
             <label>Social Security Number</label>
             <span class="floatL"><b>:</b></span>
-            <span>${requestScope['_02_ssn']}</span>
+            <span id="ssn">${requestScope['_02_ssn']}</span>
         </div>
         <div class="row">
             <label>Date of Birth</label>
             <span class="floatL"><b>:</b></span>
-            <span>${requestScope['_02_dob']}</span>
+            <span id="dob">${requestScope['_02_dob']}</span>
         </div>
     </div>
     <!-- /.leftCol -->
@@ -35,6 +35,6 @@
         <div class="row">
             <label>Email Address</label>
             <span class="floatL"><b>:</b></span>
-            <span>${requestScope['_02_email']}</span>
+            <span id="email">${requestScope['_02_email']}</span>
         </div>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/practice_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/practice_type.jsp
@@ -2,17 +2,16 @@
 <div class="row">
     <label>Do you maintain your own private practice?</label>
     <span class="floatL"><b>:</b></span>
-    <span><c:choose>
+    <span id="maintainsOwnPrivatePractice"><c:choose>
         <c:when test="${requestScope['_04_maintainsOwnPrivatePractice'] eq 'Y'}">Yes</c:when>
         <c:when test="${requestScope['_04_maintainsOwnPrivatePractice'] eq 'N'}">No</c:when>
-    </c:choose></span>            
-    
+    </c:choose></span>
 </div>
 <div class="row">
     <label>Are you employed and/or independently contracted by a group practice?</label>
     <span class="floatL"><b>:</b></span>
-    <span><c:choose>
+    <span id="employedOrContractedByGroup"><c:choose>
         <c:when test="${requestScope['_04_employedOrContractedByGroup'] eq 'Y'}">Yes</c:when>
         <c:when test="${requestScope['_04_employedOrContractedByGroup'] eq 'N'}">No</c:when>
-    </c:choose></span>            
+    </c:choose></span>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
@@ -4,12 +4,12 @@
 <div class="row">
     <label>Primary Practice Name</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_06_name']}</span>
+    <span id="primaryPracticeName">${requestScope['_06_name']}</span>
 </div>
 <div class="row">
     <label>Group NPI/UMPI</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_06_npi']}</span>
+    <span id="groupNPI">${requestScope['_06_npi']}</span>
 </div>
 <div class="row">
     <label>State Medicaid ID</label>
@@ -19,7 +19,7 @@
 <div class="row">
     <label>Effective Date</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_06_effectiveDate']}</span>
+    <span id="effectiveDate">${requestScope['_06_effectiveDate']}</span>
 </div>
 <div class="row">
     <label>Practice Address</label>
@@ -35,7 +35,7 @@
 <div class="row">
     <label>Practice Phone Number</label>
     <span class="floatL"><b>:</b></span>
-    <span>
+    <span id="practicePhoneNumber">
     ${requestScope['_06_phone1']}<c:if test="${requestScope['_06_phone2'] ne ''}"> - </c:if>${requestScope['_06_phone2']}<c:if test="${requestScope['_06_phone3'] ne ''}"> - </c:if>${requestScope['_06_phone3']}<c:if test="${requestScope['_06_phone4'] ne ''}"> ext. </c:if>${requestScope['_06_phone4']}
     </span>
 </div>
@@ -44,7 +44,7 @@
     <span class="floatL"><b>:</b></span>
     <c:set var="formName" value="_06_faxNumber"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-    <span>
+    <span id="practiceFaxNumber">
     ${requestScope['_06_fax1']}<c:if test="${requestScope['_06_fax2'] ne ''}"> - </c:if>${requestScope['_06_fax2']}<c:if test="${requestScope['_06_fax3'] ne ''}"> - </c:if>${requestScope['_06_fax3']}
     </span>
 </div>
@@ -52,7 +52,7 @@
     <label>Reimbursement Address</label>
     <span class="floatL"><b>:</b></span>
     <c:if test="${requestScope['_06_reimbursementSameAsPrimary'] eq 'Y'}">
-        <span>Same As Above</span>
+        <span id="billingSameAsPrimary">Same As Above</span>
     </c:if>
     <c:if test="${requestScope['_06_reimbursementSameAsPrimary'] ne 'Y'}">
         <h:address name="billing"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -4,17 +4,17 @@
 <div class="row">
     <label>Private Practice Name</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_05_name']}</span>
+    <span id="privatePracticeName">${requestScope['_05_name']}</span>
 </div>
 <div class="row">
     <label>Effective Date</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_05_effectiveDate']}</span>
+    <span id="effectiveDate">${requestScope['_05_effectiveDate']}</span>
 </div>
 <div class="row">
     <label>Group NPI/UMPI</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_05_npi']}</span>
+    <span id="groupNPI">${requestScope['_05_npi']}</span>
 </div>
 <div class="row">
     <label>Practice Address</label>
@@ -30,7 +30,7 @@
 <div class="row">
     <label>Practice Phone Number</label>
     <span class="floatL"><b>:</b></span>
-    <span>
+    <span id="practicePhoneNumber">
     ${requestScope['_05_phone1']}<c:if test="${requestScope['_05_phone2'] ne ''}"> - </c:if>${requestScope['_05_phone2']}<c:if test="${requestScope['_05_phone3'] ne ''}"> - </c:if>${requestScope['_05_phone3']}<c:if test="${requestScope['_05_phone4'] ne ''}"> ext. </c:if>${requestScope['_05_phone4']}
     </span>
 </div>
@@ -39,7 +39,7 @@
     <span class="floatL"><b>:</b></span>
     <c:set var="formName" value="_05_faxNumber"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-    <span>
+    <span id="practiceFaxNumber">
     ${requestScope['_05_fax1']}<c:if test="${requestScope['_05_fax2'] ne ''}"> - </c:if>${requestScope['_05_fax2']}<c:if test="${requestScope['_05_fax3'] ne ''}"> - </c:if>${requestScope['_05_fax3']}
     </span>
 </div>
@@ -47,7 +47,7 @@
     <label>Billing Address</label>
     <span class="floatL"><b>:</b></span>
     <c:if test="${requestScope['_05_billingSameAsPrimary'] eq 'Y'}">
-        <span>Same As Above</span>
+        <span id="billingSameAsPrimary">Same As Above</span>
     </c:if>
     <c:if test="${requestScope['_05_billingSameAsPrimary'] ne 'Y'}">
         <h:address name="billing"
@@ -62,27 +62,31 @@
 <div class="row">
     <label>FEIN</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_05_fein']}</span>
+    <span id="fein">${requestScope['_05_fein']}</span>
 </div>
 <div class="row">
     <label>MN Tax ID</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_05_stateTaxId']}</span>
+    <span id="stateTaxId">${requestScope['_05_stateTaxId']}</span>
 </div>
 <div class="row">
     <label>Fiscal Year End</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_05_fye1']}<c:if test="${requestScope['_05_fye2'] ne ''}">/</c:if>${requestScope['_05_fye2']}</span>
+    <span id="fiscalYearEnd">
+        ${requestScope['_05_fye1']}
+        <c:if test="${requestScope['_05_fye2'] ne ''}">/</c:if>
+        ${requestScope['_05_fye2']}
+    </span>
 </div>
 <div class="row">
     <label>EFT Vendor Number</label>
     <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_05_eftVendorNo']}</span>
+    <span id="eftVendorNumber">${requestScope['_05_eftVendorNo']}</span>
 </div>
 <div class="row">
     <label>Remittance Sequence</label>
     <span class="floatL"><b>:</b></span>
-    <span><c:choose>
+    <span id="remittanceSequence"><c:choose>
         <c:when test="${requestScope['_05_remittanceSequence'] eq 'PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'}">
             Patient Account or Own Reference Number Order
         </c:when>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -82,15 +82,15 @@
 <div class="row">
     <label>Remittance Sequence</label>
     <span class="floatL"><b>:</b></span>
-    <c:choose>
+    <span><c:choose>
         <c:when test="${requestScope['_05_remittanceSequence'] eq 'PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'}">
-      <span>Patient Account or Own Reference Number Order</span>
+            Patient Account or Own Reference Number Order
         </c:when>
         <c:when test="${requestScope['_05_remittanceSequence'] eq 'DHS_TRANSACTION_CONTROL_ORDER'}">
-      <span>DHS Transaction Control Number Order</span>
+            DHS Transaction Control Number Order
         </c:when>
         <c:when test="${requestScope['_05_remittanceSequence'] eq 'RECIPIENT_MHCP_ID_NUMBER_ORDER'}">
-      <span>Recipient MHCP ID Number Order</span>
+            Recipient MHCP ID Number Order
         </c:when>
-    </c:choose>
+    </c:choose></span>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
@@ -6,7 +6,7 @@
         <div class="row">
             <label>Is applicant a provider at a Public Health Service (PHS) Indian Hospital?</label>
             <span class="floatL"><b>:</b></span>
-            <span><c:choose>
+            <span id="worksOnReservation"><c:choose>
                 <c:when test="${requestScope['_13_worksOnReservation'] eq 'Y'}">Yes</c:when>
                 <c:when test="${requestScope['_13_worksOnReservation'] eq 'N'}">No</c:when>
             </c:choose></span>

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
@@ -16,9 +16,10 @@ import java.time.format.DateTimeFormatter;
 @RunWith(CucumberWithSerenity.class)
 @CucumberOptions(features = "src/test/resources/features")
 public class IntegrationTests {
+    public static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("MM/dd/yyyy");
+
     public static String format(LocalDate date) {
-        return date.format(
-                DateTimeFormatter.ofPattern("MM/dd/yyyy")
-        );
+        return date.format(DATE_FORMATTER);
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -17,11 +17,24 @@ public class DataCoverageStepDefinitions {
 
     @Given("I am on the individual provider license info page")
     public void enter_individual_provider_license_info_page() {
+        navigateToLicensePage();
+    }
+
+    private void navigateToLicensePage() {
         enrollmentSteps.loginAsProvider();
         enrollmentSteps.createEnrollment();
         enrollmentSteps.selectIndividualProviderType();
         enrollmentSteps.enterIndividualPersonalInfo();
         enrollmentSteps.advanceFromIndividualPersonalInfoToLicenseInfo();
+    }
+
+    @Given("^I am on the individual provider practice info page$")
+    public void enter_individual_provider_practice_info_page() throws IOException {
+        navigateToLicensePage();
+        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
+        enrollmentSteps.enterIndividualLicenseInfo();
+        enrollmentSteps.uploadLicense();
+        enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
     }
 
     @When("^I enter valid license information$")
@@ -38,6 +51,11 @@ public class DataCoverageStepDefinitions {
     @When("^I move to the organization page$")
     public void i_move_to_the_organization_page() {
         enrollmentSteps.selectOrganizationalProviderType();
+    }
+
+    @When("^I enter a valid private practice$")
+    public void enter_valid_private_practice_information() {
+        enrollmentSteps.enterIndividualPrivatePracticeInfo();
     }
 
     @Then("^I should be asked to enter Applicant Name, Contact Person, Contact phone$")
@@ -72,5 +90,17 @@ public class DataCoverageStepDefinitions {
     @Then("^the license is accepted$")
     public void license_is_accepted() {
         enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
+    }
+
+    @Then("^the practice information is accepted$")
+    public void practice_information_is_accepted() {
+        enrollmentSteps.advanceFromIndividualPracticeInfoToSummaryPage();
+    }
+
+    @Then("^the summary page shows expected information$")
+    public void summary_information_is_correct() {
+        enrollmentSteps.validatePersonalSummaryInformation();
+        enrollmentSteps.validateLicenseSummaryInfo();
+        enrollmentSteps.validatePracticeSummaryInformation();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -1,9 +1,11 @@
 package gov.medicaid.features.enrollment.steps;
 
 import gov.medicaid.features.enrollment.ui.IndividualInfoPage;
+import gov.medicaid.features.enrollment.ui.IndividualSummaryPage;
 import gov.medicaid.features.enrollment.ui.LicenseInfoPage;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
 import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
+import gov.medicaid.features.enrollment.ui.PracticeInfoPage;
 import gov.medicaid.features.enrollment.ui.SelectProviderTypePage;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.LoginPage;
@@ -20,6 +22,40 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unused")
 public class EnrollmentSteps {
+    private static final String FIRST_NAME = "FirstName";
+    private static final String MIDDLE_NAME = "MiddleName";
+    private static final String LAST_NAME = "LastName";
+    private static final String NPI = "0000000006";
+    private static final String SSN = "000-00-0000";
+    private static final LocalDate DATE_OF_BIRTH =
+            LocalDate.of(1970, 1, 1);
+    private static final String EMAIL = "p1@example.com";
+
+    private static final String LICENSE_TYPE = "Speech Language Pathologist";
+    private static final String LICENSE_NUMBER = "1";
+    private static final LocalDate LICENSE_ISSUE_DATE =
+            LocalDate.of(2002, 2, 2);
+    private static final LocalDate LICENSE_RENEWAL_DATE =
+            LocalDate.of(2020, 2, 2);
+    private static final String LICENSE_ISSUING_STATE_FULL = "Alaska";
+    private static final String LICENSE_ISSUING_STATE_ABBR = "AK";
+
+    private static final String PRIVATE_PRACTICE_NAME = "My Private Practice";
+    private static final String PRACTICE_GROUP_NPI = "1111111112";
+    private static final LocalDate PRACTICE_EFFECTIVE_DATE =
+            LocalDate.of(2000, 1, 1);
+    private static final String PRACTICE_ADDRESS_1 = "1234 Main St";
+    private static final String PRACTICE_ADDRESS_2 = "Suite 56";
+    private static final String PRACTICE_CITY = "Springfield";
+    private static final String PRACTICE_STATE_FULL = "Illinois";
+    private static final String PRACTICE_STATE_ABBR = "IL";
+    private static final String PRACTICE_ZIP = "12345-6789";
+    private static final String PRACTICE_PHONE = "444-555-6666";
+    private static final String PRACTICE_FEIN = "12-3456789";
+    private static final String PRACTICE_STATE_TAX_ID = "1234567";
+    private static final String PRACTICE_YEAR_END = "12/31";
+    private static final String PRACTICE_EFT_VENDOR_NUMBER = "1234567890-123";
+
     private LoginPage loginPage;
     private DashboardPage dashboardPage;
     private SelectProviderTypePage selectProviderTypePage;
@@ -27,6 +63,8 @@ public class EnrollmentSteps {
     private IndividualInfoPage individualInfoPage;
     private PersonalInfoPage personalInfoPage;
     private LicenseInfoPage licenseInfoPage;
+    private PracticeInfoPage practiceInfoPage;
+    private IndividualSummaryPage individualSummaryPage;
 
     private SimpleDateFormat formFieldDateFormat = new SimpleDateFormat("MMddyyyy");
 
@@ -54,15 +92,13 @@ public class EnrollmentSteps {
 
     @Step
     void enterIndividualPersonalInfo() {
-        personalInfoPage.enterFirstName("FirstName");
-        personalInfoPage.enterMiddleName("MiddleName");
-        personalInfoPage.enterLastName("LastName");
-        personalInfoPage.enterNPI("0000000006");
-        personalInfoPage.enterSSN("000-00-0000");
-        personalInfoPage.enterDOB(
-                LocalDate.of(1970, 1, 1)
-        );
-        personalInfoPage.enterEmail("p1@example.com");
+        personalInfoPage.enterFirstName(FIRST_NAME);
+        personalInfoPage.enterMiddleName(MIDDLE_NAME);
+        personalInfoPage.enterLastName(LAST_NAME);
+        personalInfoPage.enterNPI(NPI);
+        personalInfoPage.enterSSN(SSN);
+        personalInfoPage.enterDOB(DATE_OF_BIRTH);
+        personalInfoPage.enterEmail(EMAIL);
         personalInfoPage.checkSameAsAbove();
     }
 
@@ -123,11 +159,11 @@ public class EnrollmentSteps {
     @Step
     public void enterIndividualLicenseInfo() {
         licenseInfoPage.addLicense();
-        licenseInfoPage.addLicenseType("Speech Language Pathologist");
-        licenseInfoPage.enterLicenseNumber("1");
-        licenseInfoPage.enterIssueDate(LocalDate.of(2002, 2, 2));
-        licenseInfoPage.enterRenewalDate(LocalDate.of(2020, 2, 2));
-        licenseInfoPage.enterIssueState("Alaska");
+        licenseInfoPage.addLicenseType(LICENSE_TYPE);
+        licenseInfoPage.enterLicenseNumber(LICENSE_NUMBER);
+        licenseInfoPage.enterIssueDate(LICENSE_ISSUE_DATE);
+        licenseInfoPage.enterRenewalDate(LICENSE_RENEWAL_DATE);
+        licenseInfoPage.enterIssueState(LICENSE_ISSUING_STATE_FULL);
     }
 
     @Step
@@ -139,5 +175,102 @@ public class EnrollmentSteps {
     public void advanceFromIndividualLicenseInfoToPracticeInfo() {
         licenseInfoPage.clickNext();
         assertThat(licenseInfoPage.getTitle()).contains("Practice Information");
+    }
+
+    @Step
+    void enterIndividualPrivatePracticeInfo() {
+        practiceInfoPage.checkYesPrivatePractice();
+        practiceInfoPage.checkNoGroupPractice();
+        practiceInfoPage.enterPracticeName(PRIVATE_PRACTICE_NAME);
+        practiceInfoPage.enterGroupNPI(PRACTICE_GROUP_NPI);
+        practiceInfoPage.enterEffectiveDate(PRACTICE_EFFECTIVE_DATE);
+        practiceInfoPage.enterPracticeAddress1(PRACTICE_ADDRESS_1);
+        practiceInfoPage.enterPracticeAddress2(PRACTICE_ADDRESS_2);
+        practiceInfoPage.enterCity(PRACTICE_CITY);
+        practiceInfoPage.enterState(PRACTICE_STATE_FULL);
+        practiceInfoPage.enterZipCode(PRACTICE_ZIP);
+        practiceInfoPage.enterPhoneNumber(PRACTICE_PHONE);
+        practiceInfoPage.clickSameAsAbove();
+        practiceInfoPage.enterFein(PRACTICE_FEIN);
+        practiceInfoPage.enterStateTaxId(PRACTICE_STATE_TAX_ID);
+        practiceInfoPage.enterFiscalYearEnd(PRACTICE_YEAR_END);
+        practiceInfoPage.enterEftVendorNumber(PRACTICE_EFT_VENDOR_NUMBER);
+        practiceInfoPage.checkFirstRemittanceSequence();
+    }
+
+    @Step
+    void advanceFromIndividualPracticeInfoToSummaryPage() {
+        practiceInfoPage.clickNext();
+        assertThat(individualSummaryPage.getTitle()).contains("Summary Information");
+    }
+
+    @Step
+    void validatePersonalSummaryInformation() {
+        assertThat(individualSummaryPage.getFirstName())
+                .isEqualToIgnoringWhitespace(FIRST_NAME);
+        assertThat(individualSummaryPage.getMiddleName())
+                .isEqualToIgnoringWhitespace(MIDDLE_NAME);
+        assertThat(individualSummaryPage.getLastName())
+                .isEqualToIgnoringWhitespace(LAST_NAME);
+        assertThat(individualSummaryPage.getNPI())
+                .isEqualToIgnoringWhitespace(NPI);
+        assertThat(individualSummaryPage.getSSN())
+                .isEqualToIgnoringWhitespace(SSN);
+        assertThat(individualSummaryPage.getDOB())
+                .isEqualTo(DATE_OF_BIRTH);
+        assertThat(individualSummaryPage.getEmail())
+                .isEqualToIgnoringWhitespace(EMAIL);
+    }
+
+    @Step
+    void validateLicenseSummaryInfo() {
+        assertThat(individualSummaryPage.isProviderAtPublicHealthServiceIndianHospital())
+                .isFalse();
+        assertThat(individualSummaryPage.getFirstLicenseType())
+                .isEqualToIgnoringWhitespace(LICENSE_TYPE);
+        assertThat(individualSummaryPage.getFirstLicenseNumber())
+                .isEqualToIgnoringWhitespace(LICENSE_NUMBER);
+        assertThat(individualSummaryPage.getFirstLicenseOriginalIssueDate())
+                .isEqualTo(LICENSE_ISSUE_DATE);
+        assertThat(individualSummaryPage.getFirstLicenseRenewalEndDate())
+                .isEqualTo(LICENSE_RENEWAL_DATE);
+        assertThat(individualSummaryPage.getFirstLicenseIssuingState())
+                .isEqualToIgnoringWhitespace(LICENSE_ISSUING_STATE_ABBR);
+    }
+
+    @Step
+    void validatePracticeSummaryInformation() {
+        assertThat(individualSummaryPage.isPrivatePractice()).isTrue();
+        assertThat(individualSummaryPage.isPartOfGroupPractice()).isFalse();
+        assertThat(individualSummaryPage.getPrivatePracticeName())
+                .isEqualToIgnoringWhitespace(PRIVATE_PRACTICE_NAME);
+        assertThat(individualSummaryPage.getGroupNPI())
+                .isEqualToIgnoringWhitespace(PRACTICE_GROUP_NPI);
+        assertThat(individualSummaryPage.getEffectiveDate())
+                .isEqualTo(PRACTICE_EFFECTIVE_DATE);
+        assertThat(individualSummaryPage.getPracticeAddressLine1())
+                .isEqualToIgnoringWhitespace(PRACTICE_ADDRESS_1);
+        assertThat(individualSummaryPage.getPracticeAddressLine2())
+                .isEqualToIgnoringWhitespace(PRACTICE_ADDRESS_2);
+        assertThat(individualSummaryPage.getPracticeCity())
+                .isEqualToIgnoringWhitespace(PRACTICE_CITY);
+        assertThat(individualSummaryPage.getPracticeState())
+                .isEqualToIgnoringWhitespace(PRACTICE_STATE_ABBR);
+        assertThat(individualSummaryPage.getPracticeZip())
+                .isEqualToIgnoringWhitespace(PRACTICE_ZIP);
+        assertThat(individualSummaryPage.getPracticePhoneNumber())
+                .isEqualToIgnoringWhitespace(PRACTICE_PHONE);
+        assertThat(individualSummaryPage.isBillingAddressSameAsPracticeAddress())
+                .isTrue();
+        assertThat(individualSummaryPage.getFein())
+                .isEqualToIgnoringWhitespace(PRACTICE_FEIN);
+        assertThat(individualSummaryPage.getStateTaxId())
+                .isEqualToIgnoringWhitespace(PRACTICE_STATE_TAX_ID);
+        assertThat(individualSummaryPage.getFiscalYearEnd())
+                .isEqualToIgnoringWhitespace(PRACTICE_YEAR_END);
+        assertThat(individualSummaryPage.getEftVendorNumber())
+                .isEqualToIgnoringWhitespace(PRACTICE_EFT_VENDOR_NUMBER);
+        assertThat(individualSummaryPage.getRemittanceSequence())
+                .isEqualToIgnoringWhitespace("Patient Account or Own Reference Number Order");
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
@@ -1,0 +1,195 @@
+package gov.medicaid.features.enrollment.ui;
+
+import net.serenitybdd.core.annotations.findby.By;
+import net.thucydides.core.pages.PageObject;
+
+import java.time.LocalDate;
+
+import static gov.medicaid.features.IntegrationTests.DATE_FORMATTER;
+
+/**
+ * PageObject to interact with the "Personal Info" step of an individual
+ * provider enrollment. This page is reached by logging in, creating an
+ * enrollment, and selecting an individual provider type.
+ */
+public class IndividualSummaryPage extends PageObject {
+    private static final String FIRST_LICENSE_ROW_SELECTOR =
+            "#licenseTable > tbody > tr:nth-child(1)";
+    private static final String PRACTICE_ADDRESS_SELECTOR = ".h-adr.practice";
+    private static final String BILLING_ADDRESS_SELECTOR = ".h-adr.billing";
+
+    public String getFirstName() {
+        return textOf("#firstName");
+    }
+
+    public String getMiddleName() {
+        return textOf("#middleName");
+    }
+
+    public String getLastName() {
+        return textOf("#lastName");
+    }
+
+    public String getNPI() {
+        return textOf("#npi");
+    }
+
+    public String getSSN() {
+        return textOf("#ssn");
+    }
+
+    public LocalDate getDOB() {
+        return parseDateField("#dob");
+    }
+
+    public String getEmail() {
+        return textOf("#email");
+    }
+
+    public boolean isProviderAtPublicHealthServiceIndianHospital() {
+        return parseYesNoField("#worksOnReservation");
+    }
+
+    public String getFirstLicenseType() {
+        return textOf(FIRST_LICENSE_ROW_SELECTOR + " > td:nth-child(2)");
+    }
+
+    public String getFirstLicenseNumber() {
+        return textOf(FIRST_LICENSE_ROW_SELECTOR + " > td:nth-child(3)");
+    }
+
+    public LocalDate getFirstLicenseOriginalIssueDate() {
+        return parseDateField(FIRST_LICENSE_ROW_SELECTOR + " > td:nth-child(4)");
+    }
+
+    public LocalDate getFirstLicenseRenewalEndDate() {
+        return parseDateField(FIRST_LICENSE_ROW_SELECTOR + " > td:nth-child(5)");
+    }
+
+    public String getFirstLicenseIssuingState() {
+        return textOf(FIRST_LICENSE_ROW_SELECTOR + " > td:nth-child(6)");
+    }
+
+    public boolean isPrivatePractice() {
+        return parseYesNoField("#maintainsOwnPrivatePractice");
+    }
+
+    public boolean isPartOfGroupPractice() {
+        return parseYesNoField("#employedOrContractedByGroup");
+    }
+
+    public String getPrivatePracticeName() {
+        return textOf("#privatePracticeName");
+    }
+
+    public String getPrimaryPracticeName() {
+        return textOf("#primaryPracticeName");
+    }
+
+    public String getGroupNPI() {
+        return textOf("#groupNPI");
+    }
+
+    public LocalDate getEffectiveDate() {
+        return parseDateField("#effectiveDate");
+    }
+
+    public String getPracticeAddressLine1() {
+        return textOf(PRACTICE_ADDRESS_SELECTOR + " > .p-street-address");
+    }
+
+    public String getPracticeAddressLine2() {
+        return textOf(PRACTICE_ADDRESS_SELECTOR + " > .p-extended-address");
+    }
+
+    public String getPracticeCity() {
+        return textOf(PRACTICE_ADDRESS_SELECTOR + " > .p-locality");
+    }
+
+    public String getPracticeState() {
+        return textOf(PRACTICE_ADDRESS_SELECTOR + " > .p-region.state");
+    }
+
+    public String getPracticeZip() {
+        return textOf(PRACTICE_ADDRESS_SELECTOR + " > .p-postal-code");
+    }
+
+    public String getPracticeCounty() {
+        return textOf(PRACTICE_ADDRESS_SELECTOR + " > .p-region.county");
+    }
+
+    public String getPracticePhoneNumber() {
+        return textOf("#practicePhoneNumber");
+    }
+
+    public String getPracticeFaxNumber() {
+        return textOf("#practiceFaxNumber");
+    }
+
+    public boolean isBillingAddressSameAsPracticeAddress() {
+        return 0 < getDriver().findElements(By.id("billingSameAsPrimary")).size();
+    }
+
+    public String getBillingAddressLine1() {
+        return textOf(BILLING_ADDRESS_SELECTOR + " > .p-street-address");
+    }
+
+    public String getBillingAddressLine2() {
+        return textOf(BILLING_ADDRESS_SELECTOR + " > .p-extended-address");
+    }
+
+    public String getBillingCity() {
+        return textOf(BILLING_ADDRESS_SELECTOR + " > .p-locality");
+    }
+
+    public String getBillingState() {
+        return textOf(BILLING_ADDRESS_SELECTOR + " > .p-region.state");
+    }
+
+    public String getBillingZip() {
+        return textOf(BILLING_ADDRESS_SELECTOR + " > .p-postal-code");
+    }
+
+    public String getBillingCounty() {
+        return textOf(BILLING_ADDRESS_SELECTOR + " > .p-region.county");
+    }
+
+    public String getFein() {
+        return textOf("#fein");
+    }
+
+    public String getStateTaxId() {
+        return textOf("#stateTaxId");
+    }
+
+    public String getFiscalYearEnd() {
+        return textOf("#fiscalYearEnd");
+    }
+
+    public String getEftVendorNumber() {
+        return textOf("#eftVendorNumber");
+    }
+
+    public String getRemittanceSequence() {
+        return textOf("#remittanceSequence");
+    }
+
+    public void clickNext() {
+        $("#nextBtn").click();
+    }
+
+    private String textOf(String xpathOrCssSelector) {
+        return $(xpathOrCssSelector).getText();
+    }
+
+    private LocalDate parseDateField(String xpathOrCssSelector) {
+        return LocalDate.parse(
+                textOf(xpathOrCssSelector),
+                DATE_FORMATTER
+        );
+    }
+
+    private boolean parseYesNoField(String xpathOrCssSelector) {
+        return textOf(xpathOrCssSelector).contains("Yes");
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -1,0 +1,103 @@
+package gov.medicaid.features.enrollment.ui;
+
+import net.thucydides.core.pages.PageObject;
+
+import java.time.LocalDate;
+
+import static gov.medicaid.features.IntegrationTests.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PracticeInfoPage extends PageObject {
+    public void checkNoPrivatePractice() {
+        $("[name=_04_maintainsOwnPrivatePractice][value=N]").click();
+        assertThat($("#privatePracitce > div").getText().contains("Private Practice"));
+    }
+
+    public void checkYesPrivatePractice() {
+        $("[name=_04_maintainsOwnPrivatePractice][value=Y]").click();
+    }
+
+    public void checkNoGroupPractice() {
+        $("[name=_04_employedOrContractedByGroup][value=N]").click();
+    }
+
+    public void checkYesGroupPractice() {
+        $("[name=_04_employedOrContractedByGroup][value=Y]").click();
+    }
+
+    public void enterPracticeName(String practiceName) {
+        $("[name=_05_name]").type(practiceName);
+    }
+
+    public void enterGroupNPI(String npi) {
+        $("[name=_05_npi]").type(npi);
+    }
+
+    public void enterEffectiveDate(LocalDate effectiveDate) {
+        $("[name=_05_effectiveDate]").type(
+                format(effectiveDate)
+        );
+    }
+
+    public void enterPracticeAddress1(String practiceAddress) {
+        $("[name=_05_addressLine1]").type(practiceAddress);
+    }
+
+    public void enterPracticeAddress2(String practiceAddress) {
+        $("[name=_05_addressLine2]").type(practiceAddress);
+    }
+
+    public void enterCity(String city) {
+        $("[name=_05_city]").type(city);
+    }
+
+    public void enterState(String state) {
+        $("[name=_05_state]").selectByVisibleText(state);
+    }
+
+    public void enterZipCode(String zipCode) {
+        $("[name=_05_zip]").type(zipCode);
+    }
+
+    public void enterPhoneNumber(String phoneNumber) {
+        String[] phoneNumberParts = phoneNumber.split("-");
+        String areaCode = phoneNumberParts[0];
+        String exchangeCode = phoneNumberParts[1];
+        String subscriberNumber = phoneNumberParts[2];
+        $("[name=_05_phone1]").type(areaCode);
+        $("[name=_05_phone2]").type(exchangeCode);
+        $("[name=_05_phone3]").type(subscriberNumber);
+    }
+
+    public void clickSameAsAbove() {
+        $("[name=_05_billingSameAsPrimary]").click();
+    }
+
+    public void enterFein(String fein) {
+        $("[name=_05_fein]").type(fein);
+    }
+
+    public void enterStateTaxId(String stateTaxId) {
+        $("[name=_05_stateTaxId]").type(stateTaxId);
+    }
+
+    public void enterFiscalYearEnd(String yearEnd) {
+        String[] yearEndParts = yearEnd.split("/");
+        String month = yearEndParts[0];
+        String day = yearEndParts[1];
+        $("[name=_05_fye1]").type(month);
+        $("[name=_05_fye2]").type(day);
+    }
+
+    public void enterEftVendorNumber(String eftVendorNumber) {
+        $("[name=_05_eftVendorNo]").type(eftVendorNumber);
+    }
+
+    public void checkFirstRemittanceSequence() {
+        $("input[value='PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'").click();
+    }
+
+    public void clickNext() {
+        $("#nextBtn").click();
+    }
+}

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -47,3 +47,9 @@ Feature: Data Coverage Checks
     When I enter valid license information
     And I upload a valid license
     Then the license is accepted
+
+  Scenario: Accepts practice information
+    Given I am on the individual provider practice info page
+    When I enter a valid private practice
+    Then the practice information is accepted
+    And the summary page shows expected information


### PR DESCRIPTION
Make the summary page more testable (as described in #351), and then rewrite one of Kevin's tests from #332 to enter practice data and take advantage of the newly-introduced testability to verify that practice data.

Resolves #351 Make summary page table more accessible for testing