### PR TITLE
Add Review button to pending enrollment admin view

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -31,6 +31,11 @@
                         <h1>View Enrollment Details</h1>
                         <a class="greyBtn" href="<c:url value="/provider/enrollment/export" />"><span class="btR"><span class="btM"><img alt="" src="<c:url value="/i/icon-pdf.png" />" />Export to PDF</span></span></a>
                         <a class="greyBtn printModalBtn" href="javascript:printThis();"><span class="btR"><span class="btM"><img alt="" src="<c:url value="/i/icon-print.png" />" />Print</span></span></a>
+                        <c:if test="${showReviewLink}">
+                          <a class="greyBtn" href="<c:url value="/agent/enrollment/screeningReview?id=${enrollment.objectId}" />">
+                            <span class="btR"><span class="btM">Review</span></span>
+                          </a>
+                        </c:if>
                     </div>
                    	<c:if test="${requestScope['_99_legacyInd'] eq 'Y'}">
                       	<div class="legacyInfo">If you enrolled with DHS prior to November 1st 2013, the data fields below may not be correct. 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -53,6 +53,7 @@ import gov.medicaid.entities.Note;
 import gov.medicaid.entities.PracticeLookup;
 import gov.medicaid.entities.PracticeSearchCriteria;
 import gov.medicaid.entities.ProviderLookup;
+import gov.medicaid.entities.Role;
 import gov.medicaid.entities.SearchResult;
 import gov.medicaid.entities.StateType;
 import gov.medicaid.entities.Validity;
@@ -812,6 +813,15 @@ public class EnrollmentPageFlowController extends BaseController {
         if (isSubmitted(enrollment.getStatus())) {
             page = null; // go to first page.
         }
+
+        Role role = ControllerHelper.getCurrentUser().getRole();
+        if (ViewStatics.ROLE_SVC_ADMIN.equals(role.getDescription()) &&
+                ViewStatics.PENDING_STATUS.equals(enrollment.getStatus())) {
+            model.addAttribute("showReviewLink", true);
+        } else {
+            model.addAttribute("showReviewLink", false);
+        }
+
         return showPage(page, enrollment);
     }
 


### PR DESCRIPTION
I find that I frequently want to be able to review an enrollment directly from the enrollment details page. Previously, the only way was to go to the enrollment list, go to the pending tab, find the enrollment in the list, and click "Review". Add a button to pending enrollments that allow the admin to go directly to the review page.

![screenshot 2017-09-18 16 30 51](https://user-images.githubusercontent.com/1494855/30563120-d49ca048-9c8e-11e7-837f-0468f49458b3.png)

I tested this by viewing several submitted enrollments as both admin and provider, and verifying that only pending (submitted, unapproved, unrejected) enrollments would show the link, and would only show the link to the admin.