### PR TITLE
Widen zipcode input: #290

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -46,7 +46,7 @@
                         </span>
                         <span class="last">
                             <label>Zip:</label>
-                            <input type="text" class="normalInput inputS zipInput" name="zip"/>
+                            <input type="text" class="normalInput inputS zipInputFor" name="zip"/>
                         </span>
                         <div class="clear"></div>
                         </form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -46,7 +46,7 @@
                         </span>
                         <span class="last">
                             <label>Zip:</label>
-                            <input type="text" class="normalInput inputS" name="zip"/>
+                            <input type="text" class="normalInput inputS zipInput" name="zip"/>
                         </span>
                         <div class="clear"></div>
                         </form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
@@ -201,7 +201,7 @@
                             <c:set var="formName" value="_06_reimbursementZip"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <label class="smallLabel">ZIP Code<span class="required">*</span> : </label>
-                            <input ${reimbursementAddressMarkup} type="text" class="${disableReimbursementAddress ? 'disabled' : '' } zipInput" name="${formName}" value="${formValue}" maxlength="10"/>
+                            <input ${reimbursementAddressMarkup} type="text" class="${disableReimbursementAddress ? 'disabled' : '' } zipInputFor" id="primaryReimbursementZip" name="${formName}" value="${formValue}" maxlength="10"/>
                         </div>
                     </div>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -191,7 +191,7 @@
                             <c:set var="formName" value="_05_billingZip"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <label class="smallLabel">ZIP Code<span class="required">*</span> : </label>
-                            <input ${billingAddressMarkup} type="text" class="${disableBillingAddress ? 'disabled' : '' } zipInput" name="${formName}" value="${formValue}" maxlength="10"/>
+                            <input ${billingAddressMarkup} type="text" class="${disableBillingAddress ? 'disabled' : '' } zipInputFor" id="privateReimbursementZip" name="${formName}" value="${formValue}" maxlength="10"/>
                             <c:set var="formName" value="_05_billingCounty"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <label class="smallLabel">County : </label>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1767,10 +1767,6 @@ a.purpleSmallBtn:hover{
 				width:350px;
 				}
 				
-			.affiliationPanel table tr td .zipInput{
-				width:120px;
-				}
-			
 			.affiliationPanel table tr td .groupNameInput{
 				width:674px;
 				}
@@ -4931,7 +4927,7 @@ td.nopad {
 	width: 204px;
 }
 
-input.zipInput, input.zipInputFor {
+input.zipInputFor {
 	width: 75px !important;
 }
 

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4932,7 +4932,15 @@ td.nopad {
 }
 
 input.zipInput, input.zipInputFor {
-	width: 50px !important;
+	width: 75px !important;
+}
+
+select.countySelect, select.countySelectFor {
+    width: 100px !important;
+}
+
+select.stateSelect, select.stateSelectFor {
+    width: 100px !important;
 }
 
 .noteInputPanel, .noteInputPanel .noteText {

--- a/psm-app/cms-web/WebContent/js/admin/script.js
+++ b/psm-app/cms-web/WebContent/js/admin/script.js
@@ -1008,23 +1008,6 @@ $(document).ready(function () {
     $('.buttonBox').show();
   }
 
-  //Same As Above
-  $('.reimbursementAddressRow .checkbox').live('click', function () {
-    if ($(this).attr('checked')) {
-      $(this).parents('.reimbursementAddressRow').find('.addressInput').val($(this).parents('.wholeCol').find('.addressInputFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.cityInput').val($(this).parents('.wholeCol').find('.cityInputFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.stateSelect').val($(this).parents('.wholeCol').find('.stateSelectFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.zipInput').val($(this).parents('.wholeCol').find('.zipInputFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.countryInput').val($(this).parents('.wholeCol').find('.conurtyInputFor').val());
-    } else {
-      $(this).parents('.reimbursementAddressRow').find('.addressInput').val('');
-      $(this).parents('.reimbursementAddressRow').find('.cityInput').val('');
-      $(this).parents('.reimbursementAddressRow').find('.stateSelect').val('Please select');
-      $(this).parents('.reimbursementAddressRow').find('.zipInput').val('');
-      $(this).parents('.reimbursementAddressRow').find('.countryInput').val('');
-    }
-  });
-
   //Add License
   if ($('#tablePractice tbody tr').length < 2) {
     $('#tablePractice .remove').hide();

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -695,20 +695,16 @@ $(document).ready(function () {
     $('.buttonBox').show();
   }
 
-  //Same As Above
+  // Same As Above
   $('.reimbursementAddressRow .checkbox').live('click', function () {
     if ($(this).attr('checked')) {
-      $(this).parents('.reimbursementAddressRow').find('.addressInput').val('').addClass("disabled").prop('disabled', true);
-      $(this).parents('.reimbursementAddressRow').find('.cityInput').val('').addClass("disabled").prop('disabled', true);
-      $(this).parents('.reimbursementAddressRow').find('.stateSelect').val('').addClass("disabled").prop('disabled', true);
-      $(this).parents('.reimbursementAddressRow').find('.zipInput').val('').addClass("disabled").prop('disabled', true);
-      $(this).parents('.reimbursementAddressRow').find('.countryInput').val('').addClass("disabled").prop('disabled', true);
+        $(this).parents('.reimbursementAddressRow').find('input:text, select').each(function () {
+            $(this).val('').addClass("disabled").prop("disabled", true);
+        });
     } else {
-      $(this).parents('.reimbursementAddressRow').find('.addressInput').val('').removeClass("disabled").prop('disabled', false);
-      $(this).parents('.reimbursementAddressRow').find('.cityInput').val('').removeClass("disabled").prop('disabled', false);
-      $(this).parents('.reimbursementAddressRow').find('.stateSelect').val('').removeClass("disabled").prop('disabled', false);
-      $(this).parents('.reimbursementAddressRow').find('.zipInput').val('').removeClass("disabled").prop('disabled', false);
-      $(this).parents('.reimbursementAddressRow').find('.countryInput').val('').removeClass("disabled").prop('disabled', false);
+        $(this).parents('.reimbursementAddressRow').find('input:text, select').each(function () {
+            $(this).val('').removeClass("disabled").prop('disabled', false);
+        });
     }
   });
 

--- a/psm-app/cms-web/WebContent/js/system/script.js
+++ b/psm-app/cms-web/WebContent/js/system/script.js
@@ -475,23 +475,6 @@ $(document).ready(function () {
     $('.buttonBox').show();
   }
 
-  //Same As Above
-  $('.reimbursementAddressRow .checkbox').live('click', function () {
-    if ($(this).attr('checked')) {
-      $(this).parents('.reimbursementAddressRow').find('.addressInput').val($(this).parents('.wholeCol').find('.addressInputFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.cityInput').val($(this).parents('.wholeCol').find('.cityInputFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.stateSelect').val($(this).parents('.wholeCol').find('.stateSelectFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.zipInput').val($(this).parents('.wholeCol').find('.zipInputFor').val());
-      $(this).parents('.reimbursementAddressRow').find('.countryInput').val($(this).parents('.wholeCol').find('.conurtyInputFor').val());
-    } else {
-      $(this).parents('.reimbursementAddressRow').find('.addressInput').val('');
-      $(this).parents('.reimbursementAddressRow').find('.cityInput').val('');
-      $(this).parents('.reimbursementAddressRow').find('.stateSelect').val('Please select');
-      $(this).parents('.reimbursementAddressRow').find('.zipInput').val('');
-      $(this).parents('.reimbursementAddressRow').find('.countryInput').val('');
-    }
-  });
-
   //Add License
   if ($('#tablePractice tbody tr').length < 2) {
     $('#tablePractice .remove').hide();


### PR DESCRIPTION
Show that the zipcode accepts 10 digits (zip plus 4, with the hyphen).
Narrow the county and state dropdowns to keep all these on one line.

I checked these on the individual and group provider applications, and from the perspective of an admin.

Issue #290 Add 4 extra digits to zipcode field(s)