### PR TITLE
Add contact phone number to individual providers

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
@@ -9,3 +9,17 @@
     <span class="floatL"><b>:</b></span>
     <span>${requestScope['_02_contactEmail']}</span>
 </div>
+
+<div class="row">
+    <label>Contact Phone Number</label>
+    <span class="floatL"><b>:</b></span>
+    <span>
+        ${requestScope['_02_contactPhone1']}
+        <c:if test="${requestScope['_02_contactPhone2'] ne ''}"> - </c:if>
+        ${requestScope['_02_contactPhone2']}
+        <c:if test="${requestScope['_02_contactPhone3'] ne ''}"> - </c:if>
+        ${requestScope['_02_contactPhone3']}
+        <c:if test="${requestScope['_02_contactPhone4'] ne ''}"> ext. </c:if>
+        ${requestScope['_02_contactPhone4']}
+    </span>
+</div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -108,6 +108,51 @@
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input ${disableContact} type="text" class="${disableContact} normalInput" id="contactEmail" name="${formName}" value="${formValue}" maxlength="50"/>
             </div>
+            <div class="row">
+                <label>Contact Phone Number</label>
+                <span class="floatL"><b>:</b></span>
+
+                <c:set var="formName" value="_02_contactPhone1"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input ${disableContact}
+                    id="contactPhone1"
+                    type="text"
+                    class="${disableContact} autotab smallInput"
+                    name="${formName}"
+                    value="${formValue}"
+                    maxlength="3"/>
+                <span class="sep">-</span>
+                <c:set var="formName" value="_02_contactPhone2"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input ${disableContact}
+                    id="contactPhone2"
+                    type="text"
+                    class="${disableContact}
+                    autotab smallInput"
+                    name="${formName}"
+                    value="${formValue}"
+                    maxlength="3"/>
+                <span class="sep">-</span>
+                <c:set var="formName" value="_02_contactPhone3"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input ${disableContact}
+                    id="contactPhone3"
+                    type="text"
+                    class="${disableContact} autotab smallInputP"
+                    name="${formName}"
+                    value="${formValue}"
+                    maxlength="4"/>
+                <span class="sep"><strong>ext.</strong></span>
+                <c:set var="formName" value="_02_contactPhone4"></c:set>
+                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+                <input ${disableContact}
+                    id="contactPhone4"
+                    type="text"
+                    class="${disableContact} autotab smallInput"
+                    name="${formName}"
+                    value="${formValue}"
+                    maxlength="3"/>
+            </div>
             <div class="clearFixed"></div>
         </div>
     </div>

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -299,12 +299,22 @@ $(document).ready(function () {
 
   //Save As Above
   $('#sameAsAbove').live('click', function () {
+    contactFormElements = [
+      '#contactName',
+      '#contactEmail',
+      '#contactPhone1',
+      '#contactPhone2',
+      '#contactPhone3',
+      '#contactPhone4'
+    ];
     if ($(this).attr('checked')) {
-      $('#contactName').val('').addClass("disabled").prop('disabled', true);
-      $('#contactEmail').val('').addClass("disabled").prop('disabled', true);
+      contactFormElements.forEach(function (element) {
+        $(element).val('').addClass("disabled").prop('disabled', true);
+      });
     } else {
-      $('#contactName').val('').removeClass("disabled").prop('disabled', false);
-      $('#contactEmail').val('').removeClass("disabled").prop('disabled', false);
+      contactFormElements.forEach(function (element) {
+        $(element).val('').removeClass("disabled").prop('disabled', false);
+      });
     }
   });
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
@@ -105,6 +105,14 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
             enrollment.setContactSameAsApplicant("N");
             enrollmentContact.setName(param(request, "contactName"));
             enrollmentContact.setEmailAddress(param(request, "contactEmail"));
+            enrollmentContact.setPhoneNumber(
+                    BinderUtils.concatPhone(
+                            param(request, "contactPhone1"),
+                            param(request, "contactPhone2"),
+                            param(request, "contactPhone3"),
+                            param(request, "contactPhone4")
+                    )
+            );
         }
         return exceptions;
     }
@@ -136,6 +144,11 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
         } else {
             attr(mv, "contactName", enrollmentContact.getName());
             attr(mv, "contactEmail", enrollmentContact.getEmailAddress());
+            String[] phone = BinderUtils.splitPhone(enrollmentContact.getPhoneNumber());
+            attr(mv, "contactPhone1", phone[0]);
+            attr(mv, "contactPhone2", phone[1]);
+            attr(mv, "contactPhone3", phone[2]);
+            attr(mv, "contactPhone4", phone[3]);
         }
     }
 
@@ -278,6 +291,9 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
                         person.setContactInformation(new ContactInformation());
                     }
                     person.getContactInformation().setEmail(enrollment.getContactInformation().getEmailAddress());
+                    person.getContactInformation().setPhoneNumber(
+                            enrollment.getContactInformation().getPhoneNumber()
+                    );
                     found = true;
                 }
             }
@@ -291,6 +307,9 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
                 person.setName(enrollment.getContactInformation().getName());
                 person.setContactInformation(new ContactInformation());
                 person.getContactInformation().setEmail(enrollment.getContactInformation().getEmailAddress());
+                person.getContactInformation().setPhoneNumber(
+                        enrollment.getContactInformation().getPhoneNumber()
+                );
                 profile.getDesignatedContacts().add(designatedContact);
             }
         }
@@ -320,6 +339,7 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
                 if (hContact != null) {
                     ContactInformationType contact = XMLUtility.nsGetContactInformation(individual);
                     contact.setEmailAddress(hContact.getEmail());
+                    contact.setPhoneNumber(hContact.getPhoneNumber());
                 }
             }
 
@@ -333,6 +353,7 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
                         xContact.setName(hPerson.getName());
                         if (hPerson.getContactInformation() != null) {
                             xContact.setEmailAddress(hPerson.getContactInformation().getEmail());
+                            xContact.setPhoneNumber(hPerson.getContactInformation().getPhoneNumber());
                         }
                         found = true;
                     }
@@ -389,6 +410,7 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
         contactInfo.addCell(PDFHelper.createHeaderCell("Contact Information", 2));
         PDFHelper.addLabelValueCell(contactInfo, "Contact Name", PDFHelper.value(model, ns, "contactName"));
         PDFHelper.addLabelValueCell(contactInfo, "Contact Email Address", PDFHelper.value(model, ns, "contactEmail"));
+        PDFHelper.addLabelValueCell(contactInfo, "Contact Phone Number", PDFHelper.getPhone(model, ns, "contactPhone"));
 
         document.add(contactInfo);
     }


### PR DESCRIPTION
One of our requirements is to collect an (optional) phone number for the contact person of an individual provider. The `ContactInformation` entity already has a phone number field; we just need to use it.

Add four-part phone number fields (area code, prefix, line number, extension) like we use elsewhere, and wire those into our data model.

![screenshot 2017-09-18 17 14 03](https://user-images.githubusercontent.com/1494855/30565009-cdbb0534-9c94-11e7-9687-0259b6d62504.png)


---

There are a few different pieces to this; here are the scenarios I tested:
- Clicking the "Same as above" checkbox correctly enables/disables the phone number fields
- Entering a phone number, clicking next, and clicking back to confirm it stayed
- Entering a phone number, saving a draft, and looking in the database (`SELECT * FROM contacts`)
- Submitting an enrollment, and viewing the details (as provider and as admin)
- Exporting the PDF of the submitted enrollment

A scenario that failed is editing the contact phone number as an admin; it turns out that [admins can't yet edit contact name or email](https://github.com/OpenTechStrategies/psm/issues/432), so it makes sense that they can't edit phone numbers, either. The fix to that issue should also fix this scenario.

---

Deployment: nothing special! The `contacts` table already includes a phone number column.

---

Resolves #346 Capture contact phone # for individual provider enrollments