### PR TITLE
Save both lines of additional practice locations

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -110,7 +110,7 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
                     line2 = line1;
                     line1 = null;
                 }
-                address.setAddressLine2(line1);
+                address.setAddressLine1(line1);
                 address.setAddressLine2(line2);
                 address.setCity(param(request, "city", i));
                 address.setState(param(request, "state", i));


### PR DESCRIPTION
Fix a typo that caused the first line of additional practice locations to be ignored.

I stumbled upon this while working on the wrong address line being marked as an error in #292.

---

To test, as admin I edited a submitted enrollment, added an additional practice location with data in both address lines, resubmitted, and verified that the practice info view correctly showed both lines.

---

Resolves #282 Address entry / preservation problems for Additional Practice Location