### PR TITLE
Change userdocs template to bizstyle

### DIFF
--- a/docs/userhelp/source/conf.py
+++ b/docs/userhelp/source/conf.py
@@ -88,7 +88,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'bizstyle'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -107,10 +107,10 @@ html_theme = 'alabaster'
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
     '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
+#        'about.html',
+#        'navigation.html',
+         'relations.html',  # needs 'show_related': True theme option to display
+         'searchbox.html',
     ]
 }
 


### PR DESCRIPTION
Took out About and Navigation bits from sidebar since they aren't available built-in with this theme, apparently. Can figure out how to put them back if necessary.