### PR TITLE
Remove indices, search page from table of contents in user help

### DIFF
--- a/docs/userhelp/source/enrollment.rst
+++ b/docs/userhelp/source/enrollment.rst
@@ -134,12 +134,18 @@ enrollment.
 What can I do to reduce the risk of delay or rejection for an enrollment?
 -------------------------------------------------------------------------
 
-You should: \* Include clear, accurate scans of your
-licenses/certifications \* Make sure your NPI number, address, and other
-details in the application are correct \* Check the `NPPES (National
-Plan and Provider Enumeration System)
-website <https://nppes.cms.hhs.gov/>`__ to ensure your NPI status is
-active \* Check the state Medicaid provider guidelines
+You should:
+
+-  Include clear, accurate scans of your licenses/certifications
+
+-  Make sure your NPI number, address, and other details in the
+   application are correct
+
+-  Check the `NPPES (National Plan and Provider Enumeration System)
+   website <https://nppes.cms.hhs.gov/>`__ to ensure your NPI status is
+   active
+
+-  Check the state Medicaid provider guidelines
 
 What is the difference between a private practice and a group practice?
 -----------------------------------------------------------------------

--- a/docs/userhelp/source/index.rst
+++ b/docs/userhelp/source/index.rst
@@ -28,10 +28,3 @@ emails to this mailing list
    service-agent-help
    service-admin-help
    system-admin-help
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
The search page is available via the sidebar, and we currently do not use the indices. If we decide to use [the indexing facilities provided by Sphinx](http://www.sphinx-doc.org/en/stable/markup/misc.html#index-generating-markup) at some future time, we can add these links back to the ToC. This commit removes them to reduce clutter in the user help Table of Contents and in the exported PDF and ePub files.

This PR also fixes the formatting of a bulleted list in the enrollment docs.