### PR TITLE
Fix missing individual owner home address error highlight

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -6,25 +6,25 @@ import gov.medicaid.domain.model.*
 import gov.medicaid.domain.rules.inference.*
 
 function Calendar getNow() {
-	Calendar cal = Calendar.getInstance();
-	// reset time part
-	cal.set(Calendar.HOUR_OF_DAY, cal.getActualMinimum(Calendar.HOUR_OF_DAY));
-  	cal.set(Calendar.MINUTE, cal.getActualMinimum(Calendar.MINUTE));
-  	cal.set(Calendar.SECOND, cal.getActualMinimum(Calendar.SECOND));
-  	cal.set(Calendar.MILLISECOND, cal.getActualMinimum(Calendar.MILLISECOND));
-	return cal;
+    Calendar cal = Calendar.getInstance();
+    // reset time part
+    cal.set(Calendar.HOUR_OF_DAY, cal.getActualMinimum(Calendar.HOUR_OF_DAY));
+    cal.set(Calendar.MINUTE, cal.getActualMinimum(Calendar.MINUTE));
+    cal.set(Calendar.SECOND, cal.getActualMinimum(Calendar.SECOND));
+    cal.set(Calendar.MILLISECOND, cal.getActualMinimum(Calendar.MILLISECOND));
+    return cal;
 }
 
 function Calendar get1YearFromNow() {
-	Calendar cal = Calendar.getInstance();
-	// reset time part
-	cal.set(Calendar.HOUR_OF_DAY, cal.getActualMinimum(Calendar.HOUR_OF_DAY));
-  	cal.set(Calendar.MINUTE, cal.getActualMinimum(Calendar.MINUTE));
-  	cal.set(Calendar.SECOND, cal.getActualMinimum(Calendar.SECOND));
-  	cal.set(Calendar.MILLISECOND, cal.getActualMinimum(Calendar.MILLISECOND));
-  	// subtract 1 year
-	cal.add(Calendar.YEAR, -1);
-	return cal;
+    Calendar cal = Calendar.getInstance();
+    // reset time part
+    cal.set(Calendar.HOUR_OF_DAY, cal.getActualMinimum(Calendar.HOUR_OF_DAY));
+    cal.set(Calendar.MINUTE, cal.getActualMinimum(Calendar.MINUTE));
+    cal.set(Calendar.SECOND, cal.getActualMinimum(Calendar.SECOND));
+    cal.set(Calendar.MILLISECOND, cal.getActualMinimum(Calendar.MILLISECOND));
+    // subtract 1 year
+    cal.add(Calendar.YEAR, -1);
+    return cal;
 }
 
 function Calendar getEarliestAcceptableDate() {
@@ -35,16 +35,16 @@ function Calendar getEarliestAcceptableDate() {
 }
 
 function Calendar get18YearsFromNow() {
-	Calendar cal = Calendar.getInstance();
-	// reset time part
-	cal.set(Calendar.HOUR_OF_DAY, cal.getActualMinimum(Calendar.HOUR_OF_DAY));
-  	cal.set(Calendar.MINUTE, cal.getActualMinimum(Calendar.MINUTE));
-  	cal.set(Calendar.SECOND, cal.getActualMinimum(Calendar.SECOND));
-  	cal.set(Calendar.MILLISECOND, cal.getActualMinimum(Calendar.MILLISECOND));
-  	// subtract 18 years
-	cal.add(Calendar.YEAR, -18);
-	return cal;
-} 
+    Calendar cal = Calendar.getInstance();
+    // reset time part
+    cal.set(Calendar.HOUR_OF_DAY, cal.getActualMinimum(Calendar.HOUR_OF_DAY));
+    cal.set(Calendar.MINUTE, cal.getActualMinimum(Calendar.MINUTE));
+    cal.set(Calendar.SECOND, cal.getActualMinimum(Calendar.SECOND));
+    cal.set(Calendar.MILLISECOND, cal.getActualMinimum(Calendar.MILLISECOND));
+    // subtract 18 years
+    cal.add(Calendar.YEAR, -18);
+    return cal;
+}
 
 rule '1099 Address Index Must Reference An Existing Address'
 dialect 'mvel'
@@ -60,7 +60,7 @@ dialect 'mvel'
         IsOrganization($provider: provider)
         AlternateAddressesType($alternateAddressSize : address.size()) from $provider.alternateAddresses
         OrganizationApplicantType( ten99AddressIndex < 0 || ten99AddressIndex > ($alternateAddressSize + 1))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/Ten99AddressIndex",
@@ -85,7 +85,7 @@ dialect 'mvel'
         ProviderTypeException(type == "EducationPlan", providerType == $provider.providerType)
         OrganizationApplicantType($contactInformation: contactInformation, contactInformation != null )
         not AddressType(  ) from $contactInformation.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address",
@@ -110,7 +110,7 @@ dialect 'mvel'
         $practice: PracticeInformationType(  ) from $provider.practiceInformation
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType(address == null) from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -137,7 +137,7 @@ dialect 'mvel'
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType() from $locations
         $address: AddressType() from $location.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         insertLogical(new AddressEntry(
@@ -178,7 +178,7 @@ dialect 'mvel'
         $practice: PracticeInformationType(  ) from $provider.practiceInformation
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType(effectiveDate == null) from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -198,7 +198,7 @@ dialect 'mvel'
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType($effectiveDate : effectiveDate, effectiveDate != null) from $locations
         eval($effectiveDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -224,7 +224,7 @@ dialect 'mvel'
         $practice: PracticeInformationType(  ) from $provider.practiceInformation
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType(groupName == null || groupName matches "^[\\s]*$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -250,7 +250,7 @@ dialect 'mvel'
         $practice: PracticeInformationType(  ) from $provider.practiceInformation
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType(groupName != null, groupName not matches "^.{0,100}$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -276,7 +276,7 @@ dialect 'mvel'
         $practice: PracticeInformationType(  ) from $provider.practiceInformation
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType(groupNPI == null || groupNPI matches "^[\\s]*$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -302,7 +302,7 @@ dialect 'mvel'
         $practice: PracticeInformationType(  ) from $provider.practiceInformation
         AdditionalPracticeLocationsType($locations :practiceLocation) from $practice.additionalPracticeLocations
         $location: PracticeLocationType(groupNPI != null, groupNPI not matches "^.{0,100}$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -517,7 +517,7 @@ dialect 'mvel'
         LookupEntry($value : value, type == "POBoxWordRegex")
         AddressType($addressLine2: addressLine2, addressLine2 != null, addressLine1 == null || addressLine1 matches "^[\\s]*$") from $entry.address
         eval($addressLine2.matches($value))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnLine1("Y"),
@@ -541,7 +541,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnLine1 != "Y")
         AddressType(addressLine2 == null || addressLine2 matches "^[\\s]*$", addressLine1 != null, addressLine1 != "") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnLine1("Y")
@@ -568,7 +568,7 @@ dialect 'mvel'
         LookupEntry($value : value, type == "POBoxWordRegex")
         AddressType($addressLine1: addressLine1, addressLine1 != null) from $entry.address
         eval($addressLine1.matches($value))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnLine1("Y")
@@ -594,7 +594,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.DAY_TREATMENT.value())
         FacilityCredentialsType(adultDayTreatmentApplication == null) from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/AdultDayTreatmentApplication",
@@ -774,7 +774,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AgencyApplication", providerType == $provider.providerType)
         OrganizationApplicantType($contactInformation: contactInformation, contactInformation != null )
         not AddressType(  ) from $contactInformation.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address",
@@ -927,7 +927,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskForAgencyEligibility", providerType == $provider.providerType)
         not AgencyEligibilityType( ) from $provider.agencyEligibility
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AgencyEligibility",
@@ -951,7 +951,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         not ProviderTypeException(type == "AskForAgencyEligibility", providerType == $provider.providerType)
         AgencyEligibilityType( ) from $provider.agencyEligibility
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AgencyEligibility",
@@ -1000,7 +1000,7 @@ dialect 'mvel'
         $report: ErrorReporter()
     then
         insertLogical(new PhoneNumberEntry(
-            "Agency Fax Number", 
+            "Agency Fax Number",
             "/ProviderInformation/AgencyInformation/FaxNumber",
             $faxNumber
         ));
@@ -1249,7 +1249,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnCity != "Y")
         AddressType(city == null || city matches "^[\\s]*$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnCity("Y")
@@ -1274,7 +1274,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnCity != "Y")
         AddressType(city != null, city not matches "^[\\s]*$", city not matches "^.{0,100}$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnCity("Y")
@@ -1299,7 +1299,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnCounty != "Y")
         AddressType(county != null, county not matches "^[\\s]*$", county not matches "^.{0,100}$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnCounty("Y")
@@ -1324,7 +1324,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnLine1 != "Y")
         AddressType(addressLine1 != null, addressLine1 not matches "^[\\s]*$",  addressLine1 not matches "^.{0,28}$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnLine1("Y")
@@ -1349,7 +1349,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnLine2 != "Y")
         AddressType(addressLine2 == null || addressLine2 matches "^[\\s]*$", addressLine1 == null || addressLine1 matches "^[\\s]*$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnLine2("Y")
@@ -1374,7 +1374,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnLine2 != "Y")
         AddressType(addressLine2 != null, addressLine2 not matches "^[\\s]*$",  addressLine2 not matches "^.{0,28}$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnLine2("Y")
@@ -1399,7 +1399,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnState != "Y")
         AddressType(state == null || state matches "^[\\s]*$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnState("Y")
@@ -1424,7 +1424,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnState != "Y")
         AddressType(state != null, state not matches "^[\\s]*$", state not matches "^.{0,2}$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnState("Y")
@@ -1449,7 +1449,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnZip != "Y")
         AddressType(zipCode == null || zipCode matches "^[\\s]*$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnZip("Y")
@@ -1474,7 +1474,7 @@ dialect 'mvel'
     when
         $entry: AddressEntry(errorOnZip != "Y")
         AddressType(zipCode != null, zipCode not matches "^[\\s]*$", zipCode not matches "^.{0,10}$") from $entry.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setErrorOnZip("Y")
@@ -1500,14 +1500,14 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         AlternateAddressesType($addresses: address) from $provider.alternateAddresses
         $address: AddressType(attentionTo == null || attentionTo matches "^[\\s]*$") from $addresses
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $addresses.indexOf($address);
         $report.addError(
             "/ProviderInformation/AlternateAddresses/Address[" + index + "]/AttentionTo",
             "00001",
             "Alternate Address " + (index + 1) + " attention to is required."
-        );      
+        );
 
 end
 
@@ -1529,7 +1529,7 @@ dialect 'mvel'
         int index = $addresses.indexOf($address);
         insertLogical(new AddressEntry(
             "Alternate Address " + (index + 1),
-            "/ProviderInformation/AlternateAddresses/Address[" + index + "]", 
+            "/ProviderInformation/AlternateAddresses/Address[" + index + "]",
             $address
         ));
 
@@ -1546,7 +1546,7 @@ dialect 'mvel'
  */
     when
         $entry: PhoneNumberEntry(phoneNumber not matches "([0-9]{3}) ([0-9]{3})-([0-9]{4})( ext [0-9]{1,3})?", validated != "Y")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($entry) {
             setValidated("Y")
@@ -1569,7 +1569,7 @@ dialect 'mvel'
  */
     when
         ProviderInformationType(applicantType == null)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantType",
@@ -1593,7 +1593,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_HEALTH_CLINIC.value(), ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
         AttachedDocumentsType($attachments : attachment) from $provider.attachedDocuments
         not DocumentType(name == DocumentNames.ARTICLES_OF_INCORPORATION.value()) from $attachments
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AttachedDocuments/Document[name=\"Articles of Incorporation\"]",
@@ -1616,7 +1616,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_HEALTH_CLINIC.value(), ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
         not AttachedDocumentsType(  ) from $provider.attachedDocuments
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AttachedDocuments/Document[name=\"Articles of Incorporation\"]",
@@ -1739,9 +1739,9 @@ dialect 'mvel'
         insertLogical(new LookupEntry("FieldGroup", "Ownership Information", "Ownership Information"));
         insertLogical(new LookupEntry("FieldGroup", "Organization Disclosure", "Organization Disclosure"));
         insertLogical(new LookupEntry("FieldGroup", "Facility Credentials", "Facility Credentials"));
-        insertLogical(new LookupEntry("FieldGroup", "Organization Provider Statement", "Organization Provider Statement"));        
-        insertLogical(new LookupEntry("FieldGroup", "Agency Eligibility", "Agency Eligibility"));        
-        insertLogical(new LookupEntry("FieldGroup", "Qualified Professionals", "Qualified Professionals"));        
+        insertLogical(new LookupEntry("FieldGroup", "Organization Provider Statement", "Organization Provider Statement"));
+        insertLogical(new LookupEntry("FieldGroup", "Agency Eligibility", "Agency Eligibility"));
+        insertLogical(new LookupEntry("FieldGroup", "Qualified Professionals", "Qualified Professionals"));
 
 end
 
@@ -1808,7 +1808,7 @@ dialect 'mvel'
         ProviderInformationType(assignedAgencyId != null, assignedAgencyId not matches "^[\\s]*$")
         IsOrganization($provider : provider)
         not ProviderTypeException(type == "AskAgencyId", providerType == $provider.providerType)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AssignedAgencyId",
@@ -1833,7 +1833,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskForQualifiedProfessionals", providerType == $provider.providerType)
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         not QualifiedProfessionalType(  ) from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/QualifiedProfessionals",
@@ -1857,7 +1857,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskOwnershipInfo", providerType == $provider.providerType)
         not OwnershipInformationType( ) from $provider.ownershipInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation",
@@ -1882,7 +1882,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskOwnershipInfo", providerType == $provider.providerType)
         $ownershipInformation: OwnershipInformationType(  ) from $provider.ownershipInformation
         not BeneficialOwnerType( ) from $ownershipInformation.beneficialOwner
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation",
@@ -1903,10 +1903,10 @@ dialect 'mvel'
  */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
-        $provider: ProviderInformationType(providerType in 
+        $provider: ProviderInformationType(providerType in
             (
               ProviderType.COUNTY_CONTRACTED_MENTAL_HEALTH_REHAB.value()
-            ) 
+            )
         )
         FacilityCredentialsType(signedContract == null) from $provider.facilityCredentials
         $report: ErrorReporter()
@@ -1930,10 +1930,10 @@ dialect 'mvel'
  */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
-        $provider: ProviderInformationType(providerType in 
+        $provider: ProviderInformationType(providerType in
             (
               ProviderType.COUNTY_CONTRACTED_MENTAL_HEALTH_REHAB.value()
-            ) 
+            )
         )
         FacilityCredentialsType($contractList : signedContract, signedContract != null) from $provider.facilityCredentials
         not SignedContractType(  ) from $contractList
@@ -1961,7 +1961,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.FAMILY_PLANNING_AGENCY.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         not GroupMemberType(providerType == ProviderType.PHYSICIAN.value()) from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -1986,7 +1986,7 @@ activation-group "member-info-license-required"
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskIndividualMemberInfo", providerType == $provider.providerType)
         not MemberInformationType( ) from $provider.memberInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -2012,7 +2012,7 @@ activation-group "member-info-license-required"
         ProviderTypeException(type == "AskIndividualMemberInfo", providerType == $provider.providerType)
         $memberInformation: MemberInformationType( ) from $provider.memberInformation
         not GroupMemberType(  ) from $memberInformation.groupMember
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -2036,7 +2036,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskProviderSetupInfo", providerType == $provider.providerType)
         not ProviderSetupInformationType( ) from $provider.providerSetupInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderSetupInformation",
@@ -2061,7 +2061,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskProviderSetupInfo", providerType == $provider.providerType)
         $setupInformation: ProviderSetupInformationType( ) from $provider.providerSetupInformation
         not PayToProviderType( ) from $setupInformation.payToProvider
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderSetupInformation",
@@ -2084,7 +2084,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
         ProviderStatementType(name == null || name matches "^[\\s]*$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Name",
@@ -2107,7 +2107,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
         ProviderStatementType(name != null, name not matches "^.{0,100}$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Name",
@@ -2124,7 +2124,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
         eval($signDate.after(Calendar.getInstance()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/SignDate",
@@ -2141,7 +2141,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
         eval($signDate.before(getNow()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/SignDate",
@@ -2164,7 +2164,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
         ProviderStatementType(signDate == null) from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/SignDate",
@@ -2187,7 +2187,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
         ProviderStatementType(title == null || title matches "^[\\s]*$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Title",
@@ -2210,7 +2210,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
         ProviderStatementType(title != null, title not matches "^.{0,100}$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Title",
@@ -2234,7 +2234,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.BACKGROUND_STUDY.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -2250,7 +2250,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
         ProviderTypeException(type == "AgencyApplication", providerType == $provider.providerType)
-        EnrollmentType(effectiveDate == null) 
+        EnrollmentType(effectiveDate == null)
         $report: ErrorReporter()
     then
         $report.addError(
@@ -2268,7 +2268,7 @@ dialect 'mvel'
         IsOrganization($provider: provider)
         ProviderTypeException(type == "AgencyApplication", providerType == $provider.providerType)
         EnrollmentType($effectiveDate: effectiveDate, effectiveDate != null)
-        eval($effectiveDate.before(getEarliestAcceptableDate())) 
+        eval($effectiveDate.before(getEarliestAcceptableDate()))
         $report: ErrorReporter()
     then
         $report.addError(
@@ -2294,7 +2294,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "N") from $ownerList
         OrganizationType( contactInformation == null || contactInformation.address == null) from $owner.entityInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2321,7 +2321,7 @@ dialect 'mvel'
         $owner: BeneficialOwnerType(personInd == "N") from $ownerList
         OrganizationType($contactInformation: contactInformation, contactInformation != null) from $owner.entityInformation
         $address: AddressType( ) from $contactInformation.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         insertLogical(new AddressEntry(
@@ -2348,7 +2348,7 @@ dialect 'mvel'
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType($dateOfBirth: dateOfBirth, dateOfBirth != null ) from $owner.personInformation
         eval($dateOfBirth.after(java.util.Calendar.getInstance()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2367,8 +2367,8 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType($dateOfBirth: dateOfBirth, dateOfBirth != null ) from $owner.personInformation
-        eval($dateOfBirth.before(getEarliestAcceptableDate())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.before(getEarliestAcceptableDate()))
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2394,7 +2394,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType( dateOfBirth == null ) from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2419,7 +2419,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(entityInformation == null, personInd == "N") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2445,7 +2445,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "N") from $ownerList
         OrganizationType( FEIN == null || FEIN matches "^[\\s]*$") from $owner.entityInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2471,7 +2471,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType( firstName == null || firstName matches "^[\\s]*$") from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2497,7 +2497,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType() from $ownerList
         PersonType(firstName != null, firstName not matches "^.{0,50}$") from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2523,7 +2523,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "N") from $ownerList
         OrganizationType( legalName == null || legalName matches "^[\\s]*$") from $owner.entityInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2549,7 +2549,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType() from $ownerList
         OrganizationType(legalName != null, legalName not matches "^.{0,100}$") from $owner.entityInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2567,7 +2567,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(hireDate == null, personInd == "Y", beneficialOwnerType in ("Subcontractor", "Managing Employee", "Board Member or Officer")) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2584,8 +2584,8 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType($hireDate: hireDate, hireDate != null) from $ownerList
-        eval($hireDate.before(getEarliestAcceptableDate())) 
-        $report: ErrorReporter() 
+        eval($hireDate.before(getEarliestAcceptableDate()))
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2610,7 +2610,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType( lastName == null || lastName matches "^[\\s]*$") from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2636,7 +2636,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType() from $ownerList
         PersonType(lastName != null, lastName not matches "^.{0,50}$") from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2662,7 +2662,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType() from $ownerList
         PersonType(middleName != null, middleName not matches "^.{0,50}$") from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2687,7 +2687,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(otherInterestName != null, otherInterestName not matches "^.{0,100}$") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2712,7 +2712,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(otherInterestInd == "Y", otherInterestPercentOwnership == null) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2737,7 +2737,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(otherInterestInd == "Y", otherInterestAddress == null) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2763,7 +2763,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(otherInterestInd == "Y", otherInterestAddress != null) from $ownerList
         $address : AddressType( ) from $owner.otherInterestAddress
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         insertLogical(new AddressEntry(
@@ -2788,7 +2788,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(otherInterestInd == "Y", otherInterestName == null || otherInterestName matches "^[\\s]*$") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2813,7 +2813,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd != "Y", personInd != "N") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2839,7 +2839,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         not PersonType( ) from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2864,7 +2864,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(relationship != null, relationship not in ("Spouse", "Child", "Parent", "Sibling")) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2890,7 +2890,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType(contactInformation == null || contactInformation.address == null) from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2917,7 +2917,7 @@ dialect 'mvel'
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType($contactInformation: contactInformation, contactInformation != null) from $owner.personInformation
         $address: AddressType( ) from $contactInformation.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         insertLogical(new AddressEntry(
@@ -2943,7 +2943,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(personInd == "Y") from $ownerList
         PersonType( socialSecurityNumber == null || socialSecurityNumber matches "^[\\s]*$") from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2962,7 +2962,7 @@ dialect 'mvel'
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType() from $ownerList
         PersonType(socialSecurityNumber != null, socialSecurityNumber not matches "^[\\s]*$", socialSecurityNumber not matches "\\d{9}") from $owner.personInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -2987,7 +2987,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType( beneficialOwnerType == "Other", otherBeneficialOwnerDescription == null || otherBeneficialOwnerDescription matches "^[\\s]*$") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -3012,7 +3012,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(otherBeneficialOwnerDescription != null, otherBeneficialOwnerDescription not matches "^.{0,100}$") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -3037,7 +3037,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(beneficialOwnerType == null || beneficialOwnerType matches "^[\\s]*$") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -3062,7 +3062,7 @@ dialect 'mvel'
         IsOrganization($provider: provider)
         AlternateAddressesType($alternateAddressSize : address.size()) from $provider.alternateAddresses
         OrganizationApplicantType( billingAddressIndex < 0 || billingAddressIndex > ($alternateAddressSize + 1))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/BillingAddressIndex",
@@ -3085,7 +3085,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
         PracticeInformationType(billingAddress == null) from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/BillingAddress",
@@ -3108,7 +3108,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(billingAddress != null) from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/BillingAddress",
@@ -3135,7 +3135,7 @@ dialect 'mvel'
     then
         insertLogical(new AddressEntry(
             "Billing Address",
-            "/ProviderInformation/PracticeInformation/BillingAddress", 
+            "/ProviderInformation/PracticeInformation/BillingAddress",
             $address
         ));
 
@@ -3155,7 +3155,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.COUNTY_CONTRACTED_MENTAL_HEALTH_REHAB.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         GroupMemberType(enrolled != "Y") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -3179,7 +3179,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.CERTIFICATE_OF_COMPLIANCE_FROM_MN_DEPARTMENT_OF_HUMAN_RIGHTS.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -3196,7 +3196,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PRIVATE_DUTY_NURSING_AGENCY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.CLASS_A_LICENSE_FOR_PRIVATE_DUTY_NURSING_SERVICES.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -3220,7 +3220,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PUBLIC_HEALTH_NURSING_ORGANIZATION.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.CLASS_A_LICENSE_FOR_PRIVATE_DUTY_NURSING_SERVICES.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -3244,7 +3244,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.HOME_HEALTH_AGENCY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.CLASS_A_PROFESSIONAL_HOME_CARE_LICENSE.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -3269,7 +3269,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : CLIACertificate) from $provider.facilityCredentials
         $license: CLIACertificateType( attachmentObjectId == null || certificateNumber matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -3288,7 +3288,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : ambulanceServices) from $provider.facilityCredentials
         $license: AmbulanceServicesType( attachmentObjectId == null || attachmentObjectId matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -3316,9 +3316,9 @@ salience 10
         insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.PUBLIC_HEALTH_NURSING_ORGANIZATION.value()));
         // insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.NURSING_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.RENAL_DIALYSIS_FACILITY.value()));
-		insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.PHYSICIAN_CLINIC.value()));
-		insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.RURAL_HEALTH_CLINIC.value()));
-		insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.AMBULATORY_SURGICAL_CENTER.value()));
+        insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.PHYSICIAN_CLINIC.value()));
+        insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.RURAL_HEALTH_CLINIC.value()));
+        insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.AMBULATORY_SURGICAL_CENTER.value()));
 end
 
 /**
@@ -3326,19 +3326,19 @@ end
  */
 rule 'CLIA Certification is required'
 dialect 'mvel'
-	when
-		LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
+    when
+        LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskCLIACertificationsInfo", providerType == $provider.providerType)
         FacilityCredentialsType(cLIACertificate.size() == 0) from $provider.facilityCredentials
         $report: ErrorReporter()
-	then
-		$report.addError(
+    then
+        $report.addError(
             "/ProviderInformation/FacilityCredentials",
             "00001",
             "CLIA Certification is required for this provider."
         );
-end  
+end
 
 rule 'CLIA Certifications Must Be Left Empty'
 dialect 'mvel'
@@ -3355,7 +3355,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AskCLIACertificationsInfo", providerType == $provider.providerType)
         ProviderInformationType($facilityCredentials: facilityCredentials, facilityCredentials != null)
         CLIACertificateType(  ) from $facilityCredentials.CLIACertificate
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -3435,7 +3435,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : CLIACertificate) from $provider.facilityCredentials
         $license: CLIACertificateType( certificateNumber == null || certificateNumber matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -3462,7 +3462,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : CLIACertificate) from $provider.facilityCredentials
         $license: CLIACertificateType( certificateNumber != null, certificateNumber not matches "^.{0,100}$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -3487,8 +3487,8 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         GroupMemberType($specialties: specialties, providerType != ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value(), highestDegreeEarned != "DOCTORATE") from $memberList
-        not SpecialtiesType(specialtyName contains "Psychiatry") from $specialties 
-        $report: ErrorReporter() 
+        not SpecialtiesType(specialtyName contains "Psychiatry") from $specialties
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -3558,7 +3558,7 @@ dialect 'mvel'
         IsOrganization($provider: provider)
         ProviderTypeException(type == "EducationPlan", providerType == $provider.providerType)
         OrganizationApplicantType( name != null, name not matches "^.{0,100}$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/Name",
@@ -3578,11 +3578,11 @@ dialect 'mvel'
  * @since Provider Enrollment Drools Front End Validation Part 1
  */
     when
-        $enrollment: EnrollmentType() 
+        $enrollment: EnrollmentType()
         ContactInformationType($faxNumber: faxNumber, faxNumber != null) from $enrollment.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Contact Fax Number", 
+            "Contact Fax Number",
             "/ContactInformation/FaxNumber",
             $faxNumber
         ));
@@ -3599,11 +3599,11 @@ dialect 'mvel'
  * @since Provider Enrollment Drools Front End Validation Part 1
  */
     when
-        $enrollment: EnrollmentType() 
+        $enrollment: EnrollmentType()
         ContactInformationType($phoneNumber: phoneNumber, phoneNumber != null) from $enrollment.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Contact Phone Number", 
+            "Contact Phone Number",
             "/ContactInformation/PhoneNumber",
             $phoneNumber
         ));
@@ -3623,7 +3623,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider, provider.providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
         $credentials: FacilityCredentialsType() from $provider.facilityCredentials
-        not CountyContractType() from $credentials.contractWithCounty 
+        not CountyContractType() from $credentials.contractWithCounty
         $report: ErrorReporter()
     then
         $report.addError(
@@ -3650,7 +3650,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskTCMForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType( ) from $provider.facilityCredentials
         not CountyContractType( ) from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty",
@@ -3676,7 +3676,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPHNForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType( ) from $provider.facilityCredentials
         not CountyContractType( ) from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty",
@@ -3703,7 +3703,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AskTCMForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType( ) from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty",
@@ -3861,7 +3861,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
         FacilityCredentialsType($contractList : signedContract, signedContract != null) from $provider.facilityCredentials
-        $contract: SignedContractType(name not in 
+        $contract: SignedContractType(name not in
             (
                 DocumentNames.ADULT_REHABILITATIVE_MENTAL_HEALTH_SERVICES.value(),
                 DocumentNames.CHILDREN_S_THERAPEUTIC_SERVICES_AND_SUPPORTS_CTSS.value(),
@@ -3892,10 +3892,10 @@ dialect 'mvel'
  */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
-        $provider: ProviderInformationType(providerType not in 
+        $provider: ProviderInformationType(providerType not in
             (
               ProviderType.COUNTY_CONTRACTED_MENTAL_HEALTH_REHAB.value()
-            ) 
+            )
         )
         FacilityCredentialsType(signedContract.size() > 0) from $provider.facilityCredentials
         $report: ErrorReporter()
@@ -3921,7 +3921,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider, provider.providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
         $credentials: FacilityCredentialsType() from $provider.facilityCredentials
-        CountyContractType(contractAttachmentObjectId == null) from $credentials.contractWithCounty 
+        CountyContractType(contractAttachmentObjectId == null) from $credentials.contractWithCounty
         $report: ErrorReporter()
     then
         $report.addError(
@@ -3999,7 +3999,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskForAgencyEligibility", providerType == $provider.providerType)
         $eligibility: AgencyEligibilityType(programType == "A county contracted provider") from $provider.agencyEligibility
-        not CountyContractType(contractAttachmentObjectId != null) from $eligibility.contractWithCounty 
+        not CountyContractType(contractAttachmentObjectId != null) from $eligibility.contractWithCounty
         $report: ErrorReporter()
     then
         $report.addError(
@@ -4023,7 +4023,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider, provider.providerType == ProviderType.DAY_TREATMENT.value())
         $credentials: FacilityCredentialsType(facilityType == "A county contracted provider") from $provider.facilityCredentials
-        not CountyContractType(contractAttachmentObjectId != null) from $credentials.contractWithCounty 
+        not CountyContractType(contractAttachmentObjectId != null) from $credentials.contractWithCounty
         $report: ErrorReporter()
     then
         $report.addError(
@@ -4098,7 +4098,7 @@ dialect 'mvel'
         IsOrganization()
         $provider: ProviderInformationType(facilityCredentials != null)
         $eligibility: AgencyEligibilityType(programType == "A county contracted provider") from $provider.agencyEligibility
-        CountyContractType(contractAttachmentObjectId != null) from $eligibility.contractWithCounty 
+        CountyContractType(contractAttachmentObjectId != null) from $eligibility.contractWithCounty
         not AttachedDocumentsType(  ) from $provider.attachedDocuments
         $report: ErrorReporter()
     then
@@ -4124,7 +4124,7 @@ dialect 'mvel'
         IsOrganization()
         $provider: ProviderInformationType(facilityCredentials != null)
         $eligibility: AgencyEligibilityType(programType == "A county contracted provider") from $provider.agencyEligibility
-        $contract: CountyContractType(contractAttachmentObjectId != null) from $eligibility.contractWithCounty 
+        $contract: CountyContractType(contractAttachmentObjectId != null) from $eligibility.contractWithCounty
         $attachedDocuments: AttachedDocumentsType(  ) from $provider.attachedDocuments
         not DocumentType( objectId == $contract.contractAttachmentObjectId ) from $attachedDocuments.attachment
         $report: ErrorReporter()
@@ -4153,7 +4153,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskTCMForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType(coverSheetAttachmentObjectId == null) from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/CoverSheetAttachmentObjectId",
@@ -4225,7 +4225,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.FEDERALLY_QUALIFIED_HEALTH_CENTER.value())
         FacilityCredentialsType(federalQualificationType != null) from $provider.facilityCredentials
         not AttachedDocumentsType(  ) from $provider.attachedDocuments
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AttachedDocuments",
@@ -4243,7 +4243,7 @@ dialect 'mvel'
         $credentials:  FacilityCredentialsType(federalQualificationType != null) from $provider.facilityCredentials
         $attachedDocuments: AttachedDocumentsType(  ) from $provider.attachedDocuments
         not DocumentType( name == $credentials.federalQualificationType ) from $attachedDocuments.attachment
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AttachedDocuments[name=\"Federal Qualification Type\"]",
@@ -4259,8 +4259,8 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider)
         IndividualApplicantType($dateOfBirth: dateOfBirth, dateOfBirth != null)
-        eval($dateOfBirth.after(java.util.Calendar.getInstance())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.after(java.util.Calendar.getInstance()))
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/DateOfBirth",
@@ -4276,8 +4276,8 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider)
         IndividualApplicantType($dateOfBirth: dateOfBirth, dateOfBirth != null)
-        eval($dateOfBirth.before(getEarliestAcceptableDate())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.before(getEarliestAcceptableDate()))
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/DateOfBirth",
@@ -4299,8 +4299,8 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider)
-        IndividualApplicantType(dateOfBirth == null) 
-        $report: ErrorReporter() 
+        IndividualApplicantType(dateOfBirth == null)
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/DateOfBirth",
@@ -4324,7 +4324,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.DAY_TRAINING_AND_HABILITATION_DAY_ACTIVITY_CENTER.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.DAY_TRAINING_HABILITATION_LICENSE.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -4402,7 +4402,7 @@ dialect 'mvel'
     when
         IsOrganization($provider: provider, provider.providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
         OrganizationApplicantType( name != null, name not matches "^.{0,100}$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/Name",
@@ -4626,9 +4626,9 @@ dialect 'mvel'
 salience 10
     when
     then
-    	insertLogical(new ProviderTypeException("CanBeUMPI", ProviderType.HOME_AND_COMMUNITY_BASED_SERVICES_WAIVERED_SERVICES.value()));
+        insertLogical(new ProviderTypeException("CanBeUMPI", ProviderType.HOME_AND_COMMUNITY_BASED_SERVICES_WAIVERED_SERVICES.value()));
 end
-    
+
 rule 'Define Possible Specialties For Clinical Nurse Specialist'
 dialect 'mvel'
 salience 10
@@ -4816,7 +4816,7 @@ dialect 'mvel'
 salience 10
     when
     then
-        insertLogical(new ProviderTypeException("PrivatePracticeExemption", ProviderType.ALLIED_DENTAL_PROFESSIONAL.value()));    
+        insertLogical(new ProviderTypeException("PrivatePracticeExemption", ProviderType.ALLIED_DENTAL_PROFESSIONAL.value()));
 
 end
 
@@ -4832,7 +4832,7 @@ dialect 'mvel'
 salience 10
     when
     then
-        insertLogical(new ProviderTypeException("PrivatePracticeExemption", ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value()));    
+        insertLogical(new ProviderTypeException("PrivatePracticeExemption", ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value()));
 
 end
 
@@ -4848,7 +4848,7 @@ dialect 'mvel'
 salience 10
     when
     then
-        insertLogical(new ProviderTypeException("PrivatePracticeExemption", ProviderType.PHYSICIAN_ASSISTANT.value()));    
+        insertLogical(new ProviderTypeException("PrivatePracticeExemption", ProviderType.PHYSICIAN_ASSISTANT.value()));
 
 end
 
@@ -4863,7 +4863,7 @@ dialect 'mvel'
  */
 salience 10
     when
-        ProviderInformationType($providerType: providerType, 
+        ProviderInformationType($providerType: providerType,
             providerType in (
                 ProviderType.CERTIFIED_PROFESSIONAL_MIDWIFE.value(),
                 ProviderType.CLINICAL_NURSE_SPECIALIST.value(),
@@ -5058,7 +5058,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
         ProviderInformationType(hasCriminalConviction == null || hasCriminalConviction matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCriminalConviction",
@@ -5081,7 +5081,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
         ProviderInformationType(hasCriminalConviction != null, hasCriminalConviction not matches "^[\\s]*$", hasCriminalConviction not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCriminalConviction",
@@ -5104,7 +5104,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
         ProviderInformationType(hasCivilPenalty == null || hasCivilPenalty matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCivilPenalty",
@@ -5127,7 +5127,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
         ProviderInformationType(hasCivilPenalty != null, hasCivilPenalty not matches "^[\\s]*$", hasCivilPenalty not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCivilPenalty",
@@ -5150,7 +5150,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
         ProviderInformationType(hasPreviousExclusion == null || hasPreviousExclusion matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasPreviousExclusion",
@@ -5173,7 +5173,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
         ProviderInformationType(hasPreviousExclusion != null, hasPreviousExclusion not matches "^[\\s]*$", hasPreviousExclusion not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasPreviousExclusion",
@@ -5195,7 +5195,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider, provider.providerType not in (
-                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(), 
+                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(),
                 ProviderType.NURSING_FACILITY.value(),
                 ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()
             )
@@ -5225,7 +5225,7 @@ rule 'Doing Business As Maximum Length Check'
 dialect 'mvel'
     when
         IsOrganization($provider: provider, provider.providerType not in (
-                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(), 
+                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(),
                 ProviderType.NURSING_FACILITY.value(),
                 ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()
             )
@@ -5234,7 +5234,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AgencyApplication", providerType == $provider.providerType)
         not ProviderTypeException(type == "EducationPlan", providerType == $provider.providerType)
         OrganizationApplicantType( name != null, name not matches "^.{0,100}$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/Name",
@@ -5258,7 +5258,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
         PracticeInformationType(EFTVendorNumber != null, EFTVendorNumber not matches "^.{0,14}$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/EFTVendorNumber",
@@ -5281,7 +5281,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(EFTVendorNumber != null, EFTVendorNumber != "") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/EFTVendorNumber",
@@ -5304,7 +5304,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider, provider.providerType == ProviderType.PERSONAL_CARE_ASSISTANT.value())
         ProviderInformationType( eighteenAndAbove == null )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EighteenAndAbove",
@@ -5327,7 +5327,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual()
         ProviderInformationType( eighteenAndAbove != null, eighteenAndAbove != "Y", eighteenAndAbove != "N"  )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EighteenAndAbove",
@@ -5351,7 +5351,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskForAgencyEligibility", providerType == $provider.providerType)
         AgencyEligibilityType(programType == null || programType matches "^[\\s]*$" ) from $provider.agencyEligibility
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AgencyEligibility/ProgramType",
@@ -5374,9 +5374,9 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskForAgencyEligibility", providerType == $provider.providerType)
-        AgencyEligibilityType(programType != null, programType not matches "^[\\s]*$", 
+        AgencyEligibilityType(programType != null, programType not matches "^[\\s]*$",
             programType not in ("A Community Mental Health Center", "An outpatient Hospital", "A county contracted provider" ) ) from $provider.agencyEligibility
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AgencyEligibility/ProgramType",
@@ -5398,10 +5398,10 @@ dialect 'mvel'
     when
         IsIndividual($provider : provider)
         $individual: IndividualApplicantType()
-        ContactInformationType(emailAddress != null, emailAddress not matches "^[\\s]*$", 
+        ContactInformationType(emailAddress != null, emailAddress not matches "^[\\s]*$",
             emailAddress matches "^.{0,100}$",
             emailAddress not matches "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}") from $individual.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/EmailAddress",
@@ -5424,7 +5424,7 @@ dialect 'mvel'
         IsIndividual($provider : provider)
         $individual: IndividualApplicantType()
         ContactInformationType(emailAddress != null, emailAddress not matches "^.{0,100}$") from $individual.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/EmailAddress",
@@ -5440,7 +5440,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(employedOrContractedByGroup  == null || employedOrContractedByGroup matches "^[\\s]*$" )
         not ProviderTypeException(type == "PrivatePracticeExemption", providerType == $provider.providerType )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployedOrContractedByGroup",
@@ -5455,7 +5455,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(employedOrContractedByGroup != null, employedOrContractedByGroup not matches "^[YN]$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployedOrContractedByGroup",
@@ -5471,7 +5471,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(maintainsOwnPrivatePractice == "N",  employedOrContractedByGroup == "N")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MaintainsOwnPrivatePractice",
@@ -5490,11 +5490,11 @@ dialect 'mvel'
  * @since Provider Enrollment Drools Front End Validation Part 1
  */
     when
-        $enrollment: EnrollmentType() 
-        ContactInformationType(emailAddress != null, emailAddress not matches "^[\\s]*$",  
+        $enrollment: EnrollmentType()
+        ContactInformationType(emailAddress != null, emailAddress not matches "^[\\s]*$",
             emailAddress matches "^.{0,100}$",
             emailAddress not matches "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}") from $enrollment.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ContactInformation/EmailAddress",
@@ -5514,9 +5514,9 @@ dialect 'mvel'
  * @since Provider Enrollment Drools Front End Validation Part 1
  */
     when
-        $enrollment: EnrollmentType() 
+        $enrollment: EnrollmentType()
         ContactInformationType(emailAddress not matches "^.{0,100}$") from $enrollment.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ContactInformation/EmailAddress",
@@ -5536,9 +5536,9 @@ dialect 'mvel'
  * @since Provider Enrollment Drools Front End Validation Part 1
  */
     when
-        $enrollment: EnrollmentType() 
+        $enrollment: EnrollmentType()
         ContactInformationType(name != null, name not matches "^.{0,100}$") from $enrollment.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ContactInformation/Name",
@@ -5560,9 +5560,9 @@ dialect 'mvel'
  */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value() || value == UISection.ORGANIZATION_INFORMATION.value())
-        $enrollment: EnrollmentType() 
+        $enrollment: EnrollmentType()
         ContactInformationType(name == null || name matches "^[\\s]*$") from $enrollment.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ContactInformation/Name",
@@ -5584,9 +5584,9 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
-        $enrollment: EnrollmentType() 
+        $enrollment: EnrollmentType()
         ContactInformationType(phoneNumber == null || phoneNumber matches "^[\\s]*$") from $enrollment.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ContactInformation/PhoneNumber",
@@ -5638,7 +5638,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == "Other", otherEntityDescription == null || otherEntityDescription matches "^[\\s]*$") from $provider.ownershipInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation/OtherEntityDescription",
@@ -5661,7 +5661,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(otherEntityDescription != null, otherEntityDescription not matches "^.{0,100}$") from $provider.ownershipInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation/OtherEntityDescription",
@@ -5684,9 +5684,9 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskOwnershipInfo", providerType == $provider.providerType)
-        OwnershipInformationType(entityType == EntityType.PROFESSIONAL_ASSOCIATION.value(), entitySubType != null, 
+        OwnershipInformationType(entityType == EntityType.PROFESSIONAL_ASSOCIATION.value(), entitySubType != null,
             entitySubType not matches "^[\\s]*$", entitySubType not in ("Non-Profit", "For-Profit")) from $provider.ownershipInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation/EntitySubType",
@@ -5710,7 +5710,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskOwnershipInfo", providerType == $provider.providerType)
         OwnershipInformationType(entityType == null || entityType matches "^[\\s]*$") from $provider.ownershipInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation/EntityType",
@@ -5734,7 +5734,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($entityType: entityType, entityType != null, entityType not matches "^[\\s]*$") from $provider.ownershipInformation
         not LookupEntry( type == "EntityType", value == $entityType )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation/EntityType",
@@ -5778,7 +5778,7 @@ salience 10
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.INDEPENDENT_LABORATORY.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.INDIAN_HEALTH_SERVICE_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.INTENSIVE_RESIDENTIAL_TREATMENT_FACILITY.value()));
-        
+
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.PHARMACY.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.PRIVATE_DUTY_NURSING_AGENCY.value()));
@@ -5789,21 +5789,21 @@ salience 10
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.TARGETED_CASE_MANAGEMENT.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.X_RAY_SERVICES.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.FEDERALLY_QUALIFIED_HEALTH_CENTER.value()));
-        
+
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.AMBULATORY_SURGICAL_CENTER.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.CHILD_AND_TEEN_CHECKUP_CLINIC.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.COUNTY_CONTRACTED_MENTAL_HEALTH_REHAB.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.DAY_TRAINING_AND_HABILITATION_DAY_ACTIVITY_CENTER.value()));
-        
+
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.DAY_TREATMENT.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.HOME_AND_COMMUNITY_BASED_SERVICES_WAIVERED_SERVICES.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.NURSING_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.HOSPITAL.value()));
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.HOSPICE.value()));
-        
-        // Added for PESP-301 
+
+        // Added for PESP-301
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()));
         // Added for PESP-297
         insertLogical(new ProviderTypeException("AskFacilityCredentialsInfo", ProviderType.RENAL_DIALYSIS_FACILITY.value()));
@@ -5826,7 +5826,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskFacilityCredentialsInfo", providerType == $provider.providerType)
         ProviderInformationType(facilityCredentials == null)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -5906,7 +5906,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType( attachmentObjectId == null ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -5932,7 +5932,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType( issuingState == null || issuingState matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -5958,7 +5958,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType( issuingState != null, issuingState not matches "^.{0,20}$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -5984,7 +5984,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType( licenseNumber == null || licenseNumber matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6010,7 +6010,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType( licenseNumber != null, licenseNumber not matches "^.{0,100}$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6029,7 +6029,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType( originalIssueDate == null) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6048,7 +6048,7 @@ dialect 'mvel'
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType($originalIssueDate: originalIssueDate, originalIssueDate != null) from $licenseList
         eval($originalIssueDate.after(Calendar.getInstance()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6067,7 +6067,7 @@ dialect 'mvel'
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType($originalIssueDate: originalIssueDate, originalIssueDate != null) from $licenseList
         eval($originalIssueDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6087,7 +6087,7 @@ dialect 'mvel'
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType($originalIssueDate: originalIssueDate, originalIssueDate != null) from $licenseList
         eval($originalIssueDate.after($effectiveDate))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6105,13 +6105,13 @@ dialect 'mvel'
         IsOrganization()
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
-        $license: LicenseType( renewalDate == null, licenseType not in 
-        					 ( LicenseNames.BACKGROUND_STUDY.value(),
-        					   LicenseNames.LICENSE_AND_TRANSMITTAL_CMS_1539_FORM_FROM_MN_DEPARTMENT_OF_HEALTH.value(),
-        					   LicenseNames.HCFA_MEDICARE_CERTIFICATION.value()
-        					 ))
-        					  from $licenseList
-        $report: ErrorReporter() 
+        $license: LicenseType( renewalDate == null, licenseType not in
+                             ( LicenseNames.BACKGROUND_STUDY.value(),
+                               LicenseNames.LICENSE_AND_TRANSMITTAL_CMS_1539_FORM_FROM_MN_DEPARTMENT_OF_HEALTH.value(),
+                               LicenseNames.HCFA_MEDICARE_CERTIFICATION.value()
+                             ))
+                              from $licenseList
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6131,7 +6131,7 @@ dialect 'mvel'
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType($renewalDate: renewalDate, renewalDate != null) from $licenseList
         eval($renewalDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6157,7 +6157,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         $license: LicenseType( licenseType == null || licenseType matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenseList.indexOf($license);
         $report.addError(
@@ -6182,7 +6182,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         not ProviderTypeException(type == "AskFacilityCredentialsInfo", providerType == $provider.providerType)
         ProviderInformationType(facilityCredentials != null)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -6205,7 +6205,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider, provider.providerType == ProviderType.DAY_TREATMENT.value())
         FacilityCredentialsType( facilityType == null || facilityType matches "^[\\s]*$") from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/FacilityType",
@@ -6227,9 +6227,9 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider, provider.providerType == ProviderType.DAY_TREATMENT.value())
-        FacilityCredentialsType(facilityType != null, facilityType not matches "^[\\s]*$", 
+        FacilityCredentialsType(facilityType != null, facilityType not matches "^[\\s]*$",
             facilityType not in ("A Community Mental Health Center", "An outpatient Hospital", "A county contracted provider" ) ) from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/FacilityType",
@@ -6254,7 +6254,7 @@ dialect 'mvel'
         ContactInformationType($faxNumber: faxNumber, faxNumber != null) from $individual.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Fax Number", 
+            "Fax Number",
             "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/FaxNumber",
             $faxNumber
         ));
@@ -6273,8 +6273,8 @@ dialect 'mvel'
  */
     when
         IsIndividual($provider : provider)
-        IndividualApplicantType(firstName != null, firstName not matches "^.{0,50}$") 
-        $report: ErrorReporter() 
+        IndividualApplicantType(firstName != null, firstName not matches "^.{0,50}$")
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/FirstName",
@@ -6353,7 +6353,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
         PracticeInformationType(fiscalYearEnd == null || fiscalYearEnd matches "^[\\s]*$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/FiscalYearEnd",
@@ -6376,7 +6376,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
         PracticeInformationType(fiscalYearEnd != null, fiscalYearEnd not matches "^[\\d]{2}/[\\d]{2}$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/FiscalYearEnd",
@@ -6423,7 +6423,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(fiscalYearEnd != null, fiscalYearEnd != "") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/FiscalYearEnd",
@@ -6446,10 +6446,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == EntityType.CORPORATION_LLC.value(), $ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Managing Employee", "Owner - 5% or more of Ownership Interest", "Other")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6473,10 +6473,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(personInd == "N", beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(personInd == "N", beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Owner - 5% or more of Ownership Interest", "Other")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6500,10 +6500,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == EntityType.HOSPITAL_BASED.value(), $ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Managing Employee", "Owner - 5% or more of Ownership Interest", "Board Member or Officer", "Other")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6527,10 +6527,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == EntityType.NON_PROFIT.value(), $ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(personInd == "Y", beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(personInd == "Y", beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Managing Employee", "Board Member or Officer", "Other")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6554,10 +6554,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == EntityType.PARTNERSHIP.value(), $ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Managing Employee", "Owner - 5% or more of Ownership Interest", "Other")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6588,10 +6588,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(personInd == "Y", beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(personInd == "Y", beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Managing Director", "Program Manager", "Subcontractor", "Managing Employee", "Owner - 5% or more of Ownership Interest", "Board Member or Officer", "Other")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6615,10 +6615,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == EntityType.PUBLIC.value(), $ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Managing Director", "Program Manager")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6642,10 +6642,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == EntityType.SOLE_PROPRIETORSHIP.value(), $ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Managing Employee", "Owner - 5% or more of Ownership Interest", "Other")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6669,10 +6669,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         OwnershipInformationType(entityType == EntityType.PARTNERSHIP.value(), $ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$", 
+        $owner: BeneficialOwnerType(beneficialOwnerType != null, beneficialOwnerType not matches "^[\\s]*$",
             beneficialOwnerType not in ("Subcontractor", "Managing Employee")
         ) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -6697,7 +6697,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         GroupAffiliationsType($locations :groupInformation) from $provider.groupAffiliations
         $location: PracticeLocationType(address == null) from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -6723,7 +6723,7 @@ dialect 'mvel'
         GroupAffiliationsType($locations :groupInformation) from $provider.groupAffiliations
         $location: PracticeLocationType() from $locations
         $address: AddressType() from $location.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         insertLogical(new AddressEntry(
@@ -6748,7 +6748,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         GroupAffiliationsType($locations :groupInformation) from $provider.groupAffiliations
         $location: PracticeLocationType(groupName == null || groupName matches "^[\\s]*$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -6773,7 +6773,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         GroupAffiliationsType($locations :groupInformation) from $provider.groupAffiliations
         $location: PracticeLocationType(groupName != null, groupName not matches "^.{0,100}$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -6798,7 +6798,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         GroupAffiliationsType($locations :groupInformation) from $provider.groupAffiliations
         $location: PracticeLocationType(groupNPI == null || groupNPI matches "^[\\s]*$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -6816,7 +6816,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         GroupAffiliationsType($locations :groupInformation) from $provider.groupAffiliations
         $location: PracticeLocationType(groupNPI != null, groupNPI not matches "^.{0,100}$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         $report.addError(
@@ -6834,7 +6834,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         GroupAffiliationsType($locations :groupInformation) from $provider.groupAffiliations
         $location: PracticeLocationType($npi: groupNPI, groupNPI != null, groupNPI not matches "^[\\s]*$") from $locations
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $locations.indexOf($location);
         insertLogical(new NPIEntry(
@@ -6858,7 +6858,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.HOME_HEALTH_AGENCY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.HCFA_MEDICARE_CERTIFICATION.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -6881,8 +6881,8 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.HEAD_START.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
-        not LicenseType( licenseType == LicenseNames.HEAD_START_AGENCY_CERTIFICATION.value() ) from $licenseList 
-        $report: ErrorReporter() 
+        not LicenseType( licenseType == LicenseNames.HEAD_START_AGENCY_CERTIFICATION.value() ) from $licenseList
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -6948,8 +6948,8 @@ dialect 'mvel'
         $report: ErrorReporter()
     then
         insertLogical(new LookupEntry(
-            "AskForHighestDegreeEarned", 
-            "Y", 
+            "AskForHighestDegreeEarned",
+            "Y",
             "Highest degree earned is required for certified mental health rehab professional."
         ));
 
@@ -6964,8 +6964,8 @@ dialect 'mvel'
         $report: ErrorReporter()
     then
         insertLogical(new LookupEntry(
-            "AskForHighestDegreeEarned", 
-            "Y", 
+            "AskForHighestDegreeEarned",
+            "Y",
             "Highest degree earned is required for licensed independent clinical social worker."
         ));
 
@@ -6980,8 +6980,8 @@ dialect 'mvel'
         $report: ErrorReporter()
     then
         insertLogical(new LookupEntry(
-            "AskForHighestDegreeEarned", 
-            "Y", 
+            "AskForHighestDegreeEarned",
+            "Y",
             "Highest degree earned is required for clinical nurse specialist with specialty on mental health."
         ));
 
@@ -6994,8 +6994,8 @@ dialect 'mvel'
         ProviderInformationType(providerType == ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value())
     then
         insertLogical(new LookupEntry(
-            "AskForHighestDegreeEarned", 
-            "Y", 
+            "AskForHighestDegreeEarned",
+            "Y",
             "Highest degree earned is required for licensed marriage and family therapist."
         ));
 
@@ -7008,8 +7008,8 @@ dialect 'mvel'
         ProviderInformationType(providerType == ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value())
     then
         insertLogical(new LookupEntry(
-            "AskForHighestDegreeEarned", 
-            "Y", 
+            "AskForHighestDegreeEarned",
+            "Y",
             "Highest degree earned is required for licensed professional clinical counselor."
         ));
 
@@ -7022,8 +7022,8 @@ dialect 'mvel'
         ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
     then
         insertLogical(new LookupEntry(
-            "AskForHighestDegreeEarned", 
-            "Y", 
+            "AskForHighestDegreeEarned",
+            "Y",
             "Highest degree earned is required for licensed psychologist."
         ));
 
@@ -7038,8 +7038,8 @@ dialect 'mvel'
         $report: ErrorReporter()
     then
         insertLogical(new LookupEntry(
-            "AskForHighestDegreeEarned", 
-            "Y", 
+            "AskForHighestDegreeEarned",
+            "Y",
             "Highest degree earned is required for nurse practitioner with specialty on mental health."
         ));
 
@@ -7050,7 +7050,7 @@ dialect 'mvel'
     when
         IsIndividual($provider : provider)
         IndividualApplicantType(highestDegreeEarned != null, highestDegreeEarned not matches "^.{0,50}$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/HighestDegreeEarned",
@@ -7098,7 +7098,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.X_RAY_SERVICES.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.INDEPENDENT_OR_PORTABLE_X_RAY_CERTIFICATION_FROM_CMS.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -7145,19 +7145,19 @@ salience 10
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.HEAD_START.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.HOME_HEALTH_AGENCY.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.INDIAN_HEALTH_SERVICE_FACILITY.value()));
-        
+
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.PUBLIC_HEALTH_CLINIC.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.REGIONAL_TREATMENT_CENTER.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.FEDERALLY_QUALIFIED_HEALTH_CENTER.value()));
-        
+
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.AMBULATORY_SURGICAL_CENTER.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST_GROUP.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.COMMUNITY_HEALTH_CLINIC.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.COUNTY_CONTRACTED_MENTAL_HEALTH_REHAB.value()));
-        
+
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.DAY_TREATMENT.value()));
-        
+
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.PHYSICIAN_CLINIC.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.DENTAL_CLINIC.value()));
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.DENTAL_HYGIENIST_CLINIC.value()));
@@ -7167,8 +7167,8 @@ salience 10
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.BILLING_ENTITY_FOR_PHYSICIAN_SERVICES.value()));
         // Fix for PESP-364
         insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.BIRTHING_CENTER.value()));
-	// Fix for issue #60
-	insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value()));
+    // Fix for issue #60
+    insertLogical(new ProviderTypeException("AskIndividualMemberInfo", ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value()));
 end
 
 rule 'Infer individual'
@@ -7330,8 +7330,8 @@ dialect 'mvel'
  */
     when
         IsIndividual($provider : provider)
-        IndividualApplicantType(lastName != null, lastName not matches "^.{0,50}$") 
-        $report: ErrorReporter() 
+        IndividualApplicantType(lastName != null, lastName not matches "^.{0,50}$")
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/LastName",
@@ -7375,7 +7375,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider, provider.providerType not in (
-                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(), 
+                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(),
                 ProviderType.NURSING_FACILITY.value(),
                 ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()
             )
@@ -7402,13 +7402,13 @@ rule 'Legal Name Maximum Length Check'
 dialect 'mvel'
     when
         IsOrganization($provider: provider, provider.providerType not in (
-                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(), 
+                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(),
                 ProviderType.NURSING_FACILITY.value(),
                 ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()
             )
         )
         OrganizationApplicantType( legalName != null, legalName not matches "^.{0,35}$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/LegalName",
@@ -7792,7 +7792,7 @@ dialect 'mvel'
         not LookupEntry(value == $providerType, type == "SpecialtyTypeBehavior")
         LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         $license: LicenseType(objectType == "S", specialtyType != null, specialtyType != "") from $licenses
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenses.indexOf($license);
         $report.addError(
@@ -7937,7 +7937,7 @@ dialect 'mvel'
     when
         $provider: ProviderInformationType( )
         AlternateAddressesType( address.size() > 2 ) from $provider.alternateAddresses
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AlternateAddresses",
@@ -7961,7 +7961,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.REHABILITATION_AGENCY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.MEDICARE_APPROVAL_LETTER.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -7985,7 +7985,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.RURAL_HEALTH_CLINIC.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.MEDICARE_APPROVAL_LETTER.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -8009,7 +8009,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PUBLIC_HEALTH_NURSING_ORGANIZATION.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.MEDICARE_CERTIFICATION_FOR_HOME_HEALTH_AIDE_AND_SKILLED_NURSING_SERVICES.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -8033,7 +8033,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.AMBULATORY_SURGICAL_CENTER.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.MEDICARE_CERTIFICATION.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -8057,8 +8057,8 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType($dateOfBirth: dateOfBirth, dateOfBirth != null) from $memberList
-        eval($dateOfBirth.after(java.util.Calendar.getInstance())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.after(java.util.Calendar.getInstance()))
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8076,8 +8076,8 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType($dateOfBirth: dateOfBirth, dateOfBirth != null) from $memberList
-        eval($dateOfBirth.before(getEarliestAcceptableDate())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.before(getEarliestAcceptableDate()))
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8103,7 +8103,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(dateOfBirth  == null) from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8124,7 +8124,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AskIndividualMemberInfo", providerType == $provider.providerType)
         $memberInformation: MemberInformationType( ) from $provider.memberInformation
         GroupMemberType(  ) from $memberInformation.groupMember
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -8148,7 +8148,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(fullName == null || fullName matches "^[\\s]*$") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8172,7 +8172,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(fullName != null, fullName not matches "^.{0,100}$") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8197,7 +8197,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(NPI == null || NPI matches "^[\\s]*$") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8214,7 +8214,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(NPI != null, NPI not matches "^.{0,10}$") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8255,7 +8255,7 @@ dialect 'mvel'
         MemberInformationType($memberList : groupMember, groupMember != null) from $provider.memberInformation
         $member: GroupMemberType($providerType: providerType, providerType != null, providerType not matches "^[\\s]*$") from $memberList
         not LookupEntry(type == "ProviderType", value == $providerType)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8280,7 +8280,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(providerType == null || providerType matches "^[\\s]*$") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8305,7 +8305,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(socialSecurityNumber == null || socialSecurityNumber matches "^[\\s]*$") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8322,7 +8322,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(socialSecurityNumber != null, socialSecurityNumber not matches "^[\\s]*$", socialSecurityNumber not matches "\\d{9}") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8340,7 +8340,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(startDate == null) from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8359,7 +8359,7 @@ dialect 'mvel'
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType($startDate : startDate, startDate != null) from $memberList
         eval($startDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -8382,8 +8382,8 @@ dialect 'mvel'
  */
     when
         IsIndividual($provider : provider)
-        IndividualApplicantType(middleName != null, middleName not matches "^.{0,50}$") 
-        $report: ErrorReporter() 
+        IndividualApplicantType(middleName != null, middleName not matches "^.{0,50}$")
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/MiddleName",
@@ -8406,10 +8406,10 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST_GROUP.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
-        Number(intValue < 2) from accumulate( 
+        Number(intValue < 2) from accumulate(
             i : GroupMemberType( enrolled == "Y", providerType == ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value() ) from $memberList,
             count( i ) )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -8433,7 +8433,7 @@ dialect 'mvel'
         IsOrganization($provider: provider)
         ProviderTypeException(type == "NonPracticeOrganization", providerType == $provider.providerType)
         EnrollmentType(personWhoAccomplishedForm == null || personWhoAccomplishedForm matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/PersonWhoAccomplishedForm",
@@ -8456,7 +8456,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
         EnrollmentType(personWhoAccomplishedForm != null, personWhoAccomplishedForm not matches "^.{0,100}$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/PersonWhoAccomplishedForm",
@@ -8480,7 +8480,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         AlternateAddressesType($alternateAddressSize : address.size()) from $provider.alternateAddresses
         NotificationSettingsType( authorizationRequestAndServiceAgreements < 0 || authorizationRequestAndServiceAgreements > ($alternateAddressSize + 1)) from $provider.notificationSettings
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NotificationSettings/AuthorizationRequestAndServiceAgreements",
@@ -8504,7 +8504,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         AlternateAddressesType($alternateAddressSize : address.size()) from $provider.alternateAddresses
         NotificationSettingsType( credentialsEnrollmentStatus < 0 || credentialsEnrollmentStatus > ($alternateAddressSize + 1)) from $provider.notificationSettings
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NotificationSettings/CredentialsEnrollmentStatus",
@@ -8528,7 +8528,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         AlternateAddressesType($alternateAddressSize : address.size()) from $provider.alternateAddresses
         NotificationSettingsType( providerCorrespondence  < 0 || providerCorrespondence > ($alternateAddressSize + 1)) from $provider.notificationSettings
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NotificationSettings/ProviderCorrespondence",
@@ -8552,7 +8552,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         AlternateAddressesType($alternateAddressSize : address.size()) from $provider.alternateAddresses
         NotificationSettingsType( reimbursementCheck < 0 || reimbursementCheck > ($alternateAddressSize + 1)) from $provider.notificationSettings
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NotificationSettings/ReimbursementCheck",
@@ -8576,7 +8576,7 @@ dialect 'mvel'
         $provider: ProviderInformationType( )
         AlternateAddressesType($alternateAddressSize : address.size()) from $provider.alternateAddresses
         NotificationSettingsType( remittanceAdvice < 0 || remittanceAdvice > ($alternateAddressSize + 1)) from $provider.notificationSettings
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NotificationSettings/RemittanceAdvice",
@@ -8599,7 +8599,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value() || value == UISection.ORGANIZATION_INFORMATION.value())
         $provider: ProviderInformationType($npi : NPI, $npi == null || $npi matches "^[\\s]*$" )
         not ProviderTypeException(type == "NPIExemption", providerType == $provider.providerType )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NPI",
@@ -8613,7 +8613,7 @@ rule 'NPI Maximum Length Check'
 dialect 'mvel'
     when
         ProviderInformationType(NPI != null, NPI not matches "^.{0,10}$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NPI",
@@ -8626,7 +8626,7 @@ end
 rule 'Verify Check Digit For NPI'
     when
         $npi: NPIEntry(validated == "N", valid == "N")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         modify($npi) {
             setValidated("Y")
@@ -8658,7 +8658,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         ProviderTypeException(type == "AskFacilityCapacity", providerType == $provider.providerType)
         FacilityCredentialsType(numberOfBedsEffectiveDate == null, numberOfBeds != null)  from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/NumberOfBedsEffectiveDate",
@@ -8676,7 +8676,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskFacilityCapacity", providerType == $provider.providerType)
         FacilityCredentialsType($numberOfBedsEffectiveDate: numberOfBedsEffectiveDate, numberOfBedsEffectiveDate != null)  from $provider.facilityCredentials
         eval($numberOfBedsEffectiveDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/NumberOfBedsEffectiveDate",
@@ -8700,7 +8700,7 @@ dialect 'mvel'
         IsOrganization()
         $provider: ProviderInformationType(facilityCredentials != null)
         FacilityCredentialsType(numberOfBedsEffectiveDate != null, numberOfBeds == null)  from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/NumberOfBedsEffectiveDate",
@@ -8725,7 +8725,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         ProviderTypeException(type == "AskFacilityCapacity", providerType == $provider.providerType)
         FacilityCredentialsType(numberOfBeds == null ) from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/NumberOfBeds",
@@ -8750,7 +8750,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(facilityCredentials != null)
         not ProviderTypeException(type == "AskFacilityCapacity", providerType == $provider.providerType)
         FacilityCredentialsType(numberOfBeds != null ) from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/NumberOfBeds",
@@ -8774,7 +8774,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.INDEPENDENT_DIAGNOSTIC_TESTING_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.OFF_SITE_APPROVAL_LETTER_FROM_MEDICARE.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -8800,7 +8800,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AgencyApplication", providerType == $provider.providerType)
         OrganizationApplicantType($contactInformation: contactInformation, contactInformation != null )
         not AddressType(  ) from $contactInformation.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address",
@@ -8848,7 +8848,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
         OrganizationApplicantType( contactInformation  == null )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation",
@@ -8949,7 +8949,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskDisclosureInfo", providerType == $provider.providerType)
         ProviderInformationType(hasCriminalConviction == null || hasCriminalConviction matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCriminalConviction",
@@ -8972,7 +8972,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization()
         ProviderInformationType(hasCriminalConviction != null, hasCriminalConviction not matches "^[\\s]*$", hasCriminalConviction not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCriminalConviction",
@@ -8996,7 +8996,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskDisclosureInfo", providerType == $provider.providerType)
         ProviderInformationType(hasCivilPenalty == null || hasCivilPenalty matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCivilPenalty",
@@ -9019,7 +9019,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization()
         ProviderInformationType(hasCivilPenalty != null, hasCivilPenalty not matches "^[\\s]*$", hasCivilPenalty not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasCivilPenalty",
@@ -9043,7 +9043,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskDisclosureInfo", providerType == $provider.providerType)
         ProviderInformationType(hasPreviousExclusion == null || hasPreviousExclusion matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasPreviousExclusion",
@@ -9066,7 +9066,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization()
         ProviderInformationType(hasPreviousExclusion != null, hasPreviousExclusion not matches "^[\\s]*$", hasPreviousExclusion not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/HasPreviousExclusion",
@@ -9090,7 +9090,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskDisclosureInfo", providerType == $provider.providerType)
         ProviderInformationType(employeeHasCriminalConviction == null || employeeHasCriminalConviction matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployeeHasCriminalConviction",
@@ -9113,7 +9113,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization()
         ProviderInformationType(employeeHasCriminalConviction != null, employeeHasCriminalConviction not matches "^[\\s]*$", employeeHasCriminalConviction not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployeeHasCriminalConviction",
@@ -9137,7 +9137,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskDisclosureInfo", providerType == $provider.providerType)
         ProviderInformationType(employeeHasCivilPenalty == null || employeeHasCivilPenalty matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployeeHasCivilPenalty",
@@ -9160,7 +9160,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization()
         ProviderInformationType(employeeHasCivilPenalty != null, employeeHasCivilPenalty not matches "^[\\s]*$", employeeHasCivilPenalty not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployeeHasCivilPenalty",
@@ -9184,7 +9184,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskDisclosureInfo", providerType == $provider.providerType)
         ProviderInformationType(employeeHasPreviousExclusion == null || employeeHasPreviousExclusion matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployeeHasPreviousExclusion",
@@ -9207,7 +9207,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization()
         ProviderInformationType(employeeHasPreviousExclusion != null, employeeHasPreviousExclusion not matches "^[\\s]*$", employeeHasPreviousExclusion not matches "^[YN]$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/EmployeeHasPreviousExclusion",
@@ -9233,7 +9233,7 @@ dialect 'mvel'
         ContactInformationType($faxNumber: faxNumber, faxNumber != null, faxNumber not matches "^[\\s]*$") from $organization.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Organization Fax Number", 
+            "Organization Fax Number",
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/FaxNumber",
             $faxNumber
         ));
@@ -9253,7 +9253,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
         OrganizationApplicantType(FEIN == null || FEIN matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/FEIN",
@@ -9276,7 +9276,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
         OrganizationApplicantType(FEIN != null, FEIN not matches "^\\d{2}-\\d{7}$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/FEIN",
@@ -9346,7 +9346,7 @@ dialect 'mvel'
         ProviderTypeException(type == "NonPracticeOrganization", providerType == $provider.providerType)
         not ProviderTypeException(type == "AgencyApplication", providerType == $provider.providerType)
         OrganizationApplicantType( name != null, name not matches "^.{0,100}$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/Name",
@@ -9370,7 +9370,7 @@ dialect 'mvel'
         IsOrganization()
         $organization: OrganizationApplicantType(contactInformation != null )
         ContactInformationType(phoneNumber == null || phoneNumber matches "^[\\s]*$") from $organization.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/PhoneNumber",
@@ -9396,7 +9396,7 @@ dialect 'mvel'
         ContactInformationType($phoneNumber: phoneNumber, phoneNumber != null, phoneNumber not matches "^[\\s]*$") from $organization.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Organization Phone Number", 
+            "Organization Phone Number",
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/PhoneNumber",
             $phoneNumber
         ));
@@ -9413,7 +9413,7 @@ dialect 'mvel'
         LookupEntry($value : value, type == "POBoxWordRegex")
         AddressType($addressLine2: addressLine2, addressLine2 != null) from $contactInformation.address
         eval($addressLine2.matches($value))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address",
@@ -9433,7 +9433,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "EducationPlan", providerType == $provider.providerType)
         OrganizationApplicantType($contactInformation: contactInformation, contactInformation != null )
         not AddressType(  ) from $contactInformation.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address",
@@ -9481,7 +9481,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
         not ProviderStatementType() from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement",
@@ -9504,7 +9504,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
         OrganizationApplicantType(stateTaxID != null, stateTaxID not matches "^.{0,7}$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/StateTaxID",
@@ -9536,7 +9536,7 @@ salience 10
         insertLogical(new ProviderTypeException("AskDisclosureInfo", ProviderType.INDIAN_HEALTH_SERVICE_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskDisclosureInfo", ProviderType.INTENSIVE_RESIDENTIAL_TREATMENT_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskDisclosureInfo", ProviderType.OPTICAL_SUPPLIER.value()));
-        
+
         insertLogical(new ProviderTypeException("AskDisclosureInfo", ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value()));
         insertLogical(new ProviderTypeException("AskDisclosureInfo", ProviderType.AMBULATORY_SURGICAL_CENTER.value()));
         insertLogical(new ProviderTypeException("AskDisclosureInfo", ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST_GROUP.value()));
@@ -9577,7 +9577,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($rpList: realProperty) from $provider.ownershipInformation
         $rp: RealPropertyType(address == null) from $rpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $rpList.indexOf($rp);
         $report.addError(
@@ -9603,7 +9603,7 @@ dialect 'mvel'
         OwnershipInformationType($rpList: realProperty) from $provider.ownershipInformation
         $rp: RealPropertyType(address != null) from $rpList
         $address: AddressType(  ) from $rp.address
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $rpList.indexOf($rp);
         insertLogical(new AddressEntry(
@@ -9628,7 +9628,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($rpList: realProperty) from $provider.ownershipInformation
         $rp: RealPropertyType(legalName == null || legalName matches "^[\\s]*$") from $rpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $rpList.indexOf($rp);
         $report.addError(
@@ -9653,7 +9653,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($rpList: realProperty) from $provider.ownershipInformation
         $rp: RealPropertyType(legalName != null, legalName not matches "^[\\s]*$", legalName not matches "^.{0,100}$") from $rpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $rpList.indexOf($rp);
         $report.addError(
@@ -9678,7 +9678,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         not ProviderTypeException(type == "AskOwnershipInfo", providerType == $provider.providerType)
         OwnershipInformationType( ) from $provider.ownershipInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation",
@@ -9710,7 +9710,7 @@ salience 10
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.INDIAN_HEALTH_SERVICE_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.INTENSIVE_RESIDENTIAL_TREATMENT_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.OPTICAL_SUPPLIER.value()));
-        
+
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.AMBULATORY_SURGICAL_CENTER.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST_GROUP.value()));
@@ -9737,11 +9737,11 @@ salience 10
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.NURSING_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.HOSPITAL.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.HOSPICE.value()));
-        
+
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.RENAL_DIALYSIS_FACILITY.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.PHYSICIAN_CLINIC.value()));
-        
+
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.DENTAL_CLINIC.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.DENTAL_HYGIENIST_CLINIC.value()));
         insertLogical(new ProviderTypeException("AskOwnershipInfo", ProviderType.BILLING_ENTITY_FOR_MENTAL_HEALTH.value()));
@@ -9765,7 +9765,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(beneficialOwnerType == "Owner - 5% or more of Ownership Interest", percentOwnership == null) from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -9790,7 +9790,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($rpList: realProperty) from $provider.ownershipInformation
         $rp: RealPropertyType(ownershipType == null || ownershipType matches "^[\\s]*$") from $rpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $rpList.indexOf($rp);
         $report.addError(
@@ -9815,7 +9815,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($rpList: realProperty) from $provider.ownershipInformation
         $rp: RealPropertyType(ownershipType != null, ownershipType not matches "^[\\s]*$", ownershipType not in ("Own", "Manage", "Lease")) from $rpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $rpList.indexOf($rp);
         $report.addError(
@@ -9840,7 +9840,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType(contactName == null || contactName matches "^[\\s]*$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -9865,7 +9865,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null) from $provider.providerSetupInformation
         $payTo: PayToProviderType(contactName != null, contactName not matches "^.{0,100}$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -9883,7 +9883,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType(effectiveDate == null) from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -9902,7 +9902,7 @@ dialect 'mvel'
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType($effectiveDate : effectiveDate, effectiveDate != null) from $payToList
         eval($effectiveDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -9928,7 +9928,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType(name == null || name matches "^[\\s]*$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -9953,7 +9953,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null) from $provider.providerSetupInformation
         $payTo: PayToProviderType(name != null, name not matches "^.{0,100}$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -9971,7 +9971,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType(NPI == null || NPI matches "^[\\s]*$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -9989,7 +9989,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null) from $provider.providerSetupInformation
         $payTo: PayToProviderType(NPI != null, NPI not matches "^.{0,10}$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -10008,7 +10008,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null) from $provider.providerSetupInformation
         $payTo: PayToProviderType($npi: NPI, NPI != null, NPI not matches "^[\\s]*$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         insertLogical(new NPIEntry(
@@ -10032,7 +10032,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType(phoneNumber == null || phoneNumber matches "^[\\s]*$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -10060,7 +10060,7 @@ dialect 'mvel'
     then
         int index = $payToList.indexOf($payTo);
         insertLogical(new PhoneNumberEntry(
-            "Pay-To Provider phone number", 
+            "Pay-To Provider phone number",
             "/ProviderInformation/ProviderSetupInformation/PayToProvider[" + index + "]/PhoneNumber",
             $phoneNumber
         ));
@@ -10082,7 +10082,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AskProviderSetupInfo", providerType == $provider.providerType)
         $setupInformation: ProviderSetupInformationType( ) from $provider.providerSetupInformation
         PayToProviderType( ) from $setupInformation.payToProvider
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderSetupInformation",
@@ -10106,7 +10106,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType(type == null || type matches "^[\\s]*$") from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -10131,7 +10131,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         ProviderSetupInformationType($payToList : payToProvider, payToProvider != null ) from $provider.providerSetupInformation
         $payTo: PayToProviderType(type != null , type not matches "^[\\s]*$", type not in ("Claim", "ERA", "Both")) from $payToList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $payToList.indexOf($payTo);
         $report.addError(
@@ -10150,8 +10150,8 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType($dateOfBirth: dateOfBirth, dateOfBirth != null, designationType == "PCA_BILLING") from $contactList
-        eval($dateOfBirth.after(java.util.Calendar.getInstance())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.after(java.util.Calendar.getInstance()))
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10170,8 +10170,8 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType($dateOfBirth: dateOfBirth, dateOfBirth != null, designationType == "PCA_BILLING") from $contactList
-        eval($dateOfBirth.before(getEarliestAcceptableDate())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.before(getEarliestAcceptableDate()))
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10190,8 +10190,8 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType($hireDate: hireDate, hireDate != null, designationType == "PCA_BILLING") from $contactList
-        eval($hireDate.after(java.util.Calendar.getInstance())) 
-        $report: ErrorReporter() 
+        eval($hireDate.after(java.util.Calendar.getInstance()))
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10210,8 +10210,8 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType($hireDate: hireDate, hireDate != null, designationType == "PCA_BILLING") from $contactList
-        eval($hireDate.before(getEarliestAcceptableDate())) 
-        $report: ErrorReporter() 
+        eval($hireDate.before(getEarliestAcceptableDate()))
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10253,7 +10253,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         ProviderInformationType( designatedContactInformation == null )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/DesignatedContactInformation",
@@ -10278,7 +10278,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         not DesignatedContactType(designationType == "PCA_BILLING") from $contactList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/DesignatedContactInformation",
@@ -10303,7 +10303,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType(fullName == null || fullName matches "^[\\s]*$", designationType == "PCA_BILLING") from $contactList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10329,7 +10329,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType(fullName != null, fullName not matches "^.{0,100}$", designationType == "PCA_BILLING") from $contactList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10355,7 +10355,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType(socialSecurityNumber == null || socialSecurityNumber matches "^[\\s]*$", designationType == "PCA_BILLING") from $contactList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10374,7 +10374,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType(socialSecurityNumber != null, socialSecurityNumber not matches "^[\\s]*$", socialSecurityNumber not matches "\\d{9}", designationType == "PCA_BILLING") from $contactList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10400,7 +10400,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType(prefix == null || prefix matches "^[\\s]*$", designationType == "PCA_BILLING") from $contactList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10426,7 +10426,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPCABillingPersonDesignation", providerType == $provider.providerType)
         DesignatedContactInformationType($contactList : designatedContact) from $provider.designatedContactInformation
         $contact: DesignatedContactType(prefix != null, prefix not matches "^.{0,100}$", designationType == "PCA_BILLING") from $contactList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $contactList.indexOf($contact);
         $report.addError(
@@ -10499,7 +10499,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PHARMACY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.PHARMACY_LICENSE.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -10525,7 +10525,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPHNForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType(contractAttachmentObjectId == null, countyInd == "N") from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/ContractAttachmentObjectId",
@@ -10551,7 +10551,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPHNForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType( ) from $provider.facilityCredentials
         CountyContractType( countyInd != "Y", countyInd != "N") from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/CountyInd",
@@ -10577,7 +10577,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPHNForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType(countyName == null || countyName matches "^[\\s]*$",  countyInd == "Y") from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/CountyName",
@@ -10603,7 +10603,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskPHNForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType(countyName != null, countyName not matches "^[\\s]*$", countyName not matches "^.{0,100}$", countyInd == "Y") from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/CountyName",
@@ -10644,7 +10644,7 @@ dialect 'mvel'
         ContactInformationType($phoneNumber: phoneNumber, phoneNumber != null) from $individual.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Phone Number", 
+            "Phone Number",
             "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/PhoneNumber",
             $phoneNumber
         ));
@@ -10664,7 +10664,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.BILLING_ENTITY_FOR_PHYSICAL_REHABILITATIVE_PROVIDERS.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
-        GroupMemberType(providerType not in 
+        GroupMemberType(providerType not in
             (
                 ProviderType.OCCUPATIONAL_THERAPIST.value(),
                 ProviderType.AUDIOLOGIST.value(),
@@ -10674,7 +10674,7 @@ dialect 'mvel'
                 ProviderType.HEARING_AID_DISPENSER.value()
             )
         ) from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -10698,7 +10698,7 @@ dialect 'mvel'
         IsIndividual($provider : provider)
         $practice: PracticeInformationType() from $provider.practiceInformation
         ContactInformationType( address == null ) from $practice.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/ContactInformation/Address",
@@ -10716,9 +10716,9 @@ dialect 'mvel'
         $practice: PracticeInformationType() from $provider.practiceInformation
         $contactInformation: ContactInformationType(  ) from $practice.contactInformation
         LookupEntry($value : value, type == "POBoxWordRegex")
-        AddressType($addressLine2: addressLine2, addressLine2 != null) from $contactInformation.address 
+        AddressType($addressLine2: addressLine2, addressLine2 != null) from $contactInformation.address
         eval($addressLine2.matches($value))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/ContactInformation/Address",
@@ -10746,7 +10746,7 @@ dialect 'mvel'
     then
         insertLogical(new AddressEntry(
             "Practice Address",
-            "/ProviderInformation/PracticeInformation/ContactInformation/Address", 
+            "/ProviderInformation/PracticeInformation/ContactInformation/Address",
             $address
         ));
 
@@ -10765,7 +10765,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
         PracticeInformationType(contactInformation == null) from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/ContactInformation",
@@ -10791,7 +10791,7 @@ dialect 'mvel'
         ContactInformationType($faxNumber: faxNumber, faxNumber != null, faxNumber not matches "^[\\s]*$") from $practice.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Practice Fax Number", 
+            "Practice Fax Number",
             "/ProviderInformation/PracticeInformation/ContactInformation/FaxNumber",
             $faxNumber
         ));
@@ -10811,7 +10811,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
         PracticeInformationType(FEIN != null, FEIN not matches "^.{0,100}$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/FEIN",
@@ -10834,7 +10834,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(FEIN != null, FEIN != "") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/FEIN",
@@ -10850,7 +10850,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(groupNPI == null || groupNPI matches "^[\\s]*$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/GroupNPI",
@@ -10865,7 +10865,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(effectiveDate == null) from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/EffectiveDate",
@@ -10881,7 +10881,7 @@ dialect 'mvel'
         $provider: ProviderInformationType()
         PracticeInformationType($effectiveDate: effectiveDate, effectiveDate != null) from $provider.practiceInformation
         eval($effectiveDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/EffectiveDate",
@@ -10896,7 +10896,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType()
         PracticeInformationType(groupNPI != null, groupNPI not matches "^.{0,100}$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/GroupNPI",
@@ -10957,7 +10957,7 @@ dialect 'mvel'
         IsIndividual($provider : provider)
         $practice: PracticeInformationType() from $provider.practiceInformation
         ContactInformationType( phoneNumber == null || phoneNumber matches "^[\\s]*$") from $practice.contactInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/ContactInformation/PhoneNumber",
@@ -10983,7 +10983,7 @@ dialect 'mvel'
         ContactInformationType($phoneNumber: phoneNumber, phoneNumber != null, phoneNumber not matches "^[\\s]*$") from $practice.contactInformation
     then
         insertLogical(new PhoneNumberEntry(
-            "Practice Phone Number", 
+            "Practice Phone Number",
             "/ProviderInformation/PracticeInformation/ContactInformation/PhoneNumber",
             $phoneNumber
         ));
@@ -11003,7 +11003,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(name == null || name matches "^[\\s]*$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/Name",
@@ -11026,7 +11026,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(name != null, name not matches "^.{0,100}$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/Name",
@@ -11042,7 +11042,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(maintainsOwnPrivatePractice  == null || maintainsOwnPrivatePractice matches "^[\\s]*$" )
         not ProviderTypeException(type == "PrivatePracticeExemption", providerType == $provider.providerType )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MaintainsOwnPrivatePractice",
@@ -11057,7 +11057,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(maintainsOwnPrivatePractice != null, maintainsOwnPrivatePractice not matches "^[YN]$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MaintainsOwnPrivatePractice",
@@ -11080,7 +11080,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
         PracticeInformationType(name == null || name matches "^[\\s]*$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/Name",
@@ -11103,7 +11103,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
         PracticeInformationType(name != null, name not matches "^.{0,100}$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/Name",
@@ -11126,9 +11126,9 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
         ProviderTypeException(type == "AskOwnershipInfo", providerType == $provider.providerType)
-        OwnershipInformationType(entityType == EntityType.PROFESSIONAL_ASSOCIATION.value(), 
+        OwnershipInformationType(entityType == EntityType.PROFESSIONAL_ASSOCIATION.value(),
             entitySubType == null || entitySubType matches "^[\\s]*$") from $provider.ownershipInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation/EntitySubType",
@@ -11151,7 +11151,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(maintainsOwnPrivatePractice == "Y")
         ProviderTypeException(type == "PrivatePracticeExemption", providerType == $provider.providerType )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MaintainsOwnPrivatePractice",
@@ -11192,7 +11192,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
         not ProviderStatementType() from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement",
@@ -11215,7 +11215,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
         ProviderStatementType(name == null || name matches "^[\\s]*$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Name",
@@ -11238,7 +11238,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
         ProviderStatementType(name != null, name not matches "^.{0,100}$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Name",
@@ -11255,7 +11255,7 @@ dialect 'mvel'
         IsIndividual($provider : provider)
         ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
         eval($signDate.after(Calendar.getInstance()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/SignDate",
@@ -11272,7 +11272,7 @@ dialect 'mvel'
         IsIndividual($provider : provider)
         ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
         eval($signDate.before(getNow()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/SignDate",
@@ -11295,7 +11295,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
         ProviderStatementType(signDate == null) from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/SignDate",
@@ -11318,7 +11318,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
         ProviderStatementType(title == null || title matches "^[\\s]*$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Title",
@@ -11341,7 +11341,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
         ProviderStatementType(title != null, title not matches "^.{0,100}$") from $provider.providerStatement
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderStatement/Title",
@@ -11386,7 +11386,7 @@ dialect 'mvel'
  */
     when
         ProviderInformationType(providerType == null || providerType matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderType",
@@ -11408,7 +11408,7 @@ dialect 'mvel'
     when
         ProviderInformationType($providerType: providerType, providerType != null, providerType not matches "^[\\s]*$")
         not LookupEntry(type == "ProviderType", value == $providerType)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ProviderType",
@@ -11430,7 +11430,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         $provider: ProviderInformationType(NPI != null, providerType in ("TBD"))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/NPI",
@@ -11447,7 +11447,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(BGSClearanceDate == null) from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11465,7 +11465,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($clearanceDate: BGSClearanceDate, BGSClearanceDate != null) from $qpList
         eval($clearanceDate.after(Calendar.getInstance()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11483,7 +11483,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($clearanceDate: BGSClearanceDate, BGSClearanceDate != null) from $qpList
         eval($clearanceDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11509,7 +11509,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(BGSNumber == null || BGSNumber matches "^[\\s]*$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11534,7 +11534,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(BGSNumber != null, BGSNumber not matches "^[\\s]*$", BGSNumber not matches "^.{0,100}$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11552,7 +11552,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(startDate == null) from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11571,7 +11571,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($startDate: startDate, startDate != null) from $qpList
         eval($startDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11590,7 +11590,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(dateOfBirth  == null) from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11608,7 +11608,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($dateOfBirth: dateOfBirth, dateOfBirth  != null) from $qpList
         eval($dateOfBirth.after(Calendar.getInstance()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11626,7 +11626,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($dateOfBirth: dateOfBirth, dateOfBirth  != null) from $qpList
         eval($dateOfBirth.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11691,7 +11691,7 @@ dialect 'mvel'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         not LicenseType(licenseType  == LicenseNames.PCA_1_OR_3_DAY_STEPS_FOR_SUCCESS_TRAINING.value()) from $licenseList
         $license: LicenseType(attachmentObjectId == null) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11712,7 +11712,7 @@ dialect 'mvel'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         not LicenseType(licenseType  == LicenseNames.PCA_1_OR_3_DAY_STEPS_FOR_SUCCESS_TRAINING.value()) from $licenseList
         $license: LicenseType(issuingState == null || issuingState matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11732,7 +11732,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         $license: LicenseType(issuingState == null, issuingState not matches "^[\\s]*$", issuingState not matches "^.{0,20}$") from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11753,7 +11753,7 @@ dialect 'mvel'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         not LicenseType(licenseType  == LicenseNames.PCA_1_OR_3_DAY_STEPS_FOR_SUCCESS_TRAINING.value()) from $licenseList
         $license: LicenseType(licenseNumber == null || licenseNumber matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11773,7 +11773,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         $license: LicenseType(licenseNumber != null, licenseNumber not matches "^[\\s]*$", licenseNumber not matches "^.{0,100}$") from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11793,7 +11793,7 @@ rule 'QP License Original Issue Date Is Required'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         not LicenseType(licenseType  == LicenseNames.PCA_1_OR_3_DAY_STEPS_FOR_SUCCESS_TRAINING.value()) from $licenseList
         $license: LicenseType(originalIssueDate == null) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11812,7 +11812,7 @@ rule 'QP License Original Issue Date Cannot Be A Future Date'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         $license: LicenseType($originalIssueDate : originalIssueDate, originalIssueDate != null) from $licenseList
         eval($originalIssueDate.after(Calendar.getInstance()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11831,7 +11831,7 @@ rule 'QP License Original Issue Date Cannot Be Before 01-01-1900'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         $license: LicenseType($originalIssueDate : originalIssueDate, originalIssueDate != null) from $licenseList
         eval($originalIssueDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11850,7 +11850,7 @@ rule 'QP License Renewal Date Cannot Be Before 01-01-1900'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         $license: LicenseType($renewalDate : renewalDate, renewalDate != null) from $licenseList
         eval($renewalDate.before(getEarliestAcceptableDate()))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11871,7 +11871,7 @@ dialect 'mvel'
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         not LicenseType(licenseType  == LicenseNames.PCA_1_OR_3_DAY_STEPS_FOR_SUCCESS_TRAINING.value()) from $licenseList
         $license: LicenseType(renewalDate == null) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11897,7 +11897,7 @@ dialect 'mvel'
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType($licenseList: license) from $qpList
         $license: LicenseType(licenseType == null || licenseType matches "^[\\s]*$" ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         int index2 = $licenseList.indexOf($license);
@@ -11923,7 +11923,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(fullName == null || fullName matches "^[\\s]*$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11948,7 +11948,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(fullName != null, fullName not matches "^[\\s]*$", fullName not matches "^.{0,100}$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -11966,7 +11966,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(NPI != null, NPI not matches "^[\\s]*$", NPI not matches "^.{0,10}$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -12007,7 +12007,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(socialSecurityNumber == null || socialSecurityNumber matches "^[\\s]*$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -12025,7 +12025,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(socialSecurityNumber != null, socialSecurityNumber not matches "^[\\s]*$", socialSecurityNumber not matches "^.{0,9}$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -12050,7 +12050,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(type == null || type matches "^[\\s]*$") from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -12075,7 +12075,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         QualifiedProfessionalsType($qpList : qualifiedProfessional) from $provider.qualifiedProfessionals
         $qp: QualifiedProfessionalType(type != null, type not matches "^[\\s]*$", type not in ("Registered Nurse","Licensed Social Worker","Mental Health Professional","Qualified Developmental Disability Specialist")) from $qpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $qpList.indexOf($qp);
         $report.addError(
@@ -12099,7 +12099,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.FEDERALLY_QUALIFIED_HEALTH_CENTER.value())
         FacilityCredentialsType(federalQualificationType == null) from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/FederalQualificationType",
@@ -12129,7 +12129,7 @@ dialect 'mvel'
                 DocumentNames.COMPACT_WITH_THE_INDIAN_HEALTH_SERVICE.value()
             )
         ) from $provider.facilityCredentials
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/FederalQualificationType",
@@ -12169,7 +12169,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         ProviderTypeException(type == "AskForQualifiedProfessionals", providerType == $provider.providerType)
         not QualifiedProfessionalsType( ) from $provider.qualifiedProfessionals
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/QualifiedProfessionals",
@@ -12193,7 +12193,7 @@ dialect 'mvel'
         IsOrganization( $provider : provider )
         not ProviderTypeException(type == "AskForQualifiedProfessionals", providerType == $provider.providerType)
         QualifiedProfessionalsType() from $provider.qualifiedProfessionals
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/QualifiedProfessionals",
@@ -12218,7 +12218,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AskResidentialPropertyOwnership", providerType == $provider.providerType)
         OwnershipInformationType($rpList: realProperty) from $provider.ownershipInformation
         RealPropertyType(  ) from $rpList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/OwnershipInformation",
@@ -12242,7 +12242,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.REGIONAL_TREATMENT_CENTER.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.REGIONAL_TREATMENT_CENTER_CERTIFICATION.value() )  from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -12265,7 +12265,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(reimbursementAddress == null) from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/ReimbursementAddress",
@@ -12288,7 +12288,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
         PracticeInformationType(reimbursementAddress != null) from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/ReimbursementAddress",
@@ -12315,7 +12315,7 @@ dialect 'mvel'
     then
         insertLogical(new AddressEntry(
             "Reimbursement Address",
-            "/ProviderInformation/PracticeInformation/ReimbursementAddress", 
+            "/ProviderInformation/PracticeInformation/ReimbursementAddress",
             $address
         ));
 
@@ -12337,7 +12337,7 @@ salience 10
         insertLogical(new ProviderTypeException("AskRemittanceSequence", ProviderType.TARGETED_CASE_MANAGEMENT.value()));
         insertLogical(new ProviderTypeException("AskRemittanceSequence", ProviderType.WIC_PROGRAM.value()));
         insertLogical(new ProviderTypeException("AskRemittanceSequence", ProviderType.X_RAY_SERVICES.value()));
-        
+
         insertLogical(new ProviderTypeException("AskRemittanceSequence", ProviderType.FEDERALLY_QUALIFIED_HEALTH_CENTER.value()));
         insertLogical(new ProviderTypeException("AskRemittanceSequence", ProviderType.INDIVIDUAL_EDUCATION_PLAN.value()));
 
@@ -12355,7 +12355,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y", remittanceSequenceNumber == null || remittanceSequenceNumber matches "^[\\s]*$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/RemittanceSequenceNumber",
@@ -12376,7 +12376,7 @@ dialect 'mvel'
  */
     when
         $provider: ProviderInformationType(remittanceSequenceNumber != null, remittanceSequenceNumber not matches "^.{0,100}$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/RemittanceSequenceNumber",
@@ -12399,7 +12399,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         $provider: ProviderInformationType(remittanceSequenceNumber != null, remittanceSequenceNumber != "")
         ProviderTypeException(type == "AskRemittanceSequence", providerType == $provider.providerType)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/RemittanceSequenceNumber",
@@ -12421,7 +12421,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y", remittanceSequenceNumber != null, remittanceSequenceNumber != "")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/RemittanceSequenceNumber",
@@ -12443,7 +12443,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider, provider.providerType not in (
-                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(), 
+                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(),
                 ProviderType.NURSING_FACILITY.value(),
                 ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()
             )
@@ -12451,7 +12451,7 @@ dialect 'mvel'
         // not ProviderTypeException(type == "NonPracticeOrganization", providerType == $provider.providerType)
         not ProviderTypeException(type == "AgencyApplication", providerType == $provider.providerType)
         not ProviderTypeException(type == "EducationPlan", providerType == $provider.providerType)
-        EnrollmentType(effectiveDate == null) 
+        EnrollmentType(effectiveDate == null)
         $report: ErrorReporter()
     then
         $report.addError(
@@ -12467,7 +12467,7 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         ProviderInformationType($providerType: providerType, providerType not in (
-                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(), 
+                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(),
                 ProviderType.NURSING_FACILITY.value(),
                 ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()
             )
@@ -12476,7 +12476,7 @@ dialect 'mvel'
         not ProviderTypeException(type == "AgencyApplication", providerType == $providerType)
         not ProviderTypeException(type == "EducationPlan", providerType == $providerType)
         EnrollmentType($effectiveDate: effectiveDate, effectiveDate != null)
-        eval($effectiveDate.before(get1YearFromNow())) 
+        eval($effectiveDate.before(get1YearFromNow()))
         $report: ErrorReporter()
     then
         $report.addError(
@@ -12492,7 +12492,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
         ProviderTypeException(type == "EducationPlan", providerType == $provider.providerType)
-        EnrollmentType(effectiveDate == null) 
+        EnrollmentType(effectiveDate == null)
         $report: ErrorReporter()
     then
         $report.addError(
@@ -12510,7 +12510,7 @@ dialect 'mvel'
         IsOrganization($provider: provider)
         ProviderTypeException(type == "EducationPlan", providerType == $provider.providerType)
         EnrollmentType($effectiveDate: effectiveDate, effectiveDate != null)
-        eval($effectiveDate.before(getEarliestAcceptableDate())) 
+        eval($effectiveDate.before(getEarliestAcceptableDate()))
         $report: ErrorReporter()
     then
         $report.addError(
@@ -12559,9 +12559,9 @@ dialect 'mvel'
         IsIndividual()
         $individual: IndividualApplicantType(contactInformation != null, contactInformation.address != null)
         LookupEntry($value : value, type == "POBoxWordRegex")
-        AddressType($addressLine2: addressLine2, addressLine2 != null) from $individual.contactInformation.address 
+        AddressType($addressLine2: addressLine2, addressLine2 != null) from $individual.contactInformation.address
         eval($addressLine2.matches($value))
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/Address",
@@ -12584,7 +12584,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider, provider.providerType == ProviderType.PERSONAL_CARE_ASSISTANT.value())
         IndividualApplicantType(contactInformation != null, contactInformation.address == null)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/Address",
@@ -12607,7 +12607,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider, provider.providerType == ProviderType.PERSONAL_CARE_ASSISTANT.value())
         IndividualApplicantType(contactInformation == null)
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/Address",
@@ -12630,7 +12630,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual()
         $individual: IndividualApplicantType(contactInformation != null, contactInformation.address != null)
-        $address: AddressType(  ) from $individual.contactInformation.address 
+        $address: AddressType(  ) from $individual.contactInformation.address
     then
         insertLogical(new AddressEntry(
             "Residential Address",
@@ -12670,7 +12670,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.RULE_29_LICENSE.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -12694,7 +12694,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.INTENSIVE_RESIDENTIAL_TREATMENT_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.RULE_36_LICENSED_FACILITY.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -12718,7 +12718,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.RULE_5_LICENSE_ISSUED_FROM_MN_DEPARTMENT_OF_HUMAN_SERVICES.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -12744,7 +12744,7 @@ dialect 'mvel'
         AgencyEligibilityType($selectionList: clinicalServices) from $provider.agencyEligibility
         $selection: String() from $selectionList
         not LookupEntry( type  == "ClinicalServices", code == $provider.providerType, value == $selection )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $selectionList.indexOf($selection);
         $report.addError(
@@ -12767,10 +12767,10 @@ dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
-        CategoriesOfServiceType( $serviceList : categoryName ) from $provider.categoriesOfService 
+        CategoriesOfServiceType( $serviceList : categoryName ) from $provider.categoriesOfService
         $service: String() from $serviceList
         not LookupEntry( type  == "ServiceOption", code == $provider.providerType, value == $service )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $serviceList.indexOf($service);
         $report.addError(
@@ -12797,7 +12797,7 @@ dialect 'mvel'
         AgencyEligibilityType($selectionList: eligibleServiceUnits) from $provider.agencyEligibility
         $selection: String() from $selectionList
         not LookupEntry( type  == "ServiceUnits", code == $provider.providerType, value == $selection )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $selectionList.indexOf($selection);
         $report.addError(
@@ -12824,7 +12824,7 @@ dialect 'mvel'
         AgencyEligibilityType($selectionList: supervisionAndQualification) from $provider.agencyEligibility
         $selection: String() from $selectionList
         not LookupEntry( type  == "SupervisionAndQualification", code == $provider.providerType, value == $selection )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $selectionList.indexOf($selection);
         $report.addError(
@@ -12851,7 +12851,7 @@ dialect 'mvel'
         AgencyEligibilityType($targetPopulation: targetPopulation) from $provider.agencyEligibility
         $population: String() from $targetPopulation
         not LookupEntry( type  == "TargetPopulation", code == $provider.providerType, value == $population )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $targetPopulation.indexOf($population);
         $report.addError(
@@ -12873,7 +12873,7 @@ dialect 'mvel'
  */
     when
         not ErrorReporter()
-        $validation: ValidationResultType() 
+        $validation: ValidationResultType()
     then
         insert(new ErrorReporter($validation));
 
@@ -12893,7 +12893,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
         AttachedDocumentsType($attachments : attachment) from $provider.attachedDocuments
         not DocumentType(name == DocumentNames.SLIDING_FEE_SCHEDULE.value()) from $attachments
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AttachedDocuments/Document[name=\"Sliding Fee Schedule\"]",
@@ -12916,7 +12916,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
         not AttachedDocumentsType(  ) from $provider.attachedDocuments
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/AttachedDocuments/Document[name=\"Sliding Fee Schedule\"]",
@@ -12965,7 +12965,7 @@ dialect 'mvel'
         LookupEntry(value == $providerType, type == "SpecialtyTypeBehavior", code=="XOR")
         LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         $license: LicenseType(specialtyType != null, licenseType != null) from $licenses
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenses.indexOf($license);
         $report.addError(
@@ -12991,7 +12991,7 @@ dialect 'mvel'
         LookupEntry(value == $providerType, type == "SpecialtyTypeBehavior", code=="AND")
         LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         $license: LicenseType(specialtyType == null || specialtyType matches "^[\\s]*$") from $licenses
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenses.indexOf($license);
         $report.addError(
@@ -13017,7 +13017,7 @@ dialect 'mvel'
         LookupEntry(value == $providerType, type == "SpecialtyTypeBehavior", code=="XOR" || code == "OR")
         LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         $license: LicenseType(specialtyType == null || specialtyType matches "^[\\s]*$", licenseType == null || licenseType matches "^[\\s]*$") from $licenses
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $licenses.indexOf($license);
         $report.addError(
@@ -13051,7 +13051,7 @@ dialect 'mvel'
         AddressType( $practiceState : state, state != null) from $contact.address
         LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(issuingState == $practiceState) from $licenses
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation",
@@ -13065,8 +13065,8 @@ rule 'SSN Maximum Length Check'
 dialect 'mvel'
     when
         IsIndividual($provider : provider)
-        IndividualApplicantType(socialSecurityNumber != null, socialSecurityNumber not matches "^[\\s]*$", socialSecurityNumber not matches "\\d{9}") 
-        $report: ErrorReporter() 
+        IndividualApplicantType(socialSecurityNumber != null, socialSecurityNumber not matches "^[\\s]*$", socialSecurityNumber not matches "\\d{9}")
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/SocialSecurityNumber",
@@ -13089,7 +13089,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
         PracticeInformationType(stateTaxId != null, stateTaxId not matches "^.{0,100}$") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/StateTaxId",
@@ -13112,7 +13112,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
         PracticeInformationType(stateTaxId != null, stateTaxId != "") from $provider.practiceInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/PracticeInformation/StateTaxId",
@@ -13136,7 +13136,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(beneficialOwnerType == "Subcontractor", subcontractorName == null || subcontractorName matches "^[\\s]*$") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -13161,7 +13161,7 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
         $owner: BeneficialOwnerType(subcontractorName != null, subcontractorName not matches "^.{0,100}$") from $ownerList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $ownerList.indexOf($owner);
         $report.addError(
@@ -13232,13 +13232,13 @@ rule 'TaxPayer Name Maximum Length Check'
 dialect 'mvel'
     when
         IsOrganization(provider.providerType in (
-                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(), 
+                ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value(),
                 ProviderType.NURSING_FACILITY.value(),
                 ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value()
             )
-        )        
+        )
         OrganizationApplicantType( legalName != null, legalName not matches "^.{0,35}$" )
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/OrganizationInformation/LegalName",
@@ -13264,7 +13264,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskTCMForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType(contractAttachmentObjectId == null) from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/ContractAttachmentObjectId",
@@ -13290,7 +13290,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskTCMForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType(coverSheetName == null || coverSheetName matches "^[\\s]*$") from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/CoverSheetName",
@@ -13316,7 +13316,7 @@ dialect 'mvel'
         ProviderTypeException(type == "AskTCMForm", providerType == $provider.providerType)
         $credentials: FacilityCredentialsType(  ) from $provider.facilityCredentials
         CountyContractType(coverSheetName != null, coverSheetName not matches "^[\\s]*$", coverSheetName not in ("DHS-5638","DHS-5639", "DHS-5702")) from $credentials.contractWithCounty
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials/ContractWithCounty/CoverSheetName",
@@ -13402,7 +13402,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType( )
         LicenseInformationType( tribalCode == null || tribalCode matches "^[\\s]*$", worksOnReservation == "Y" ) from $provider.licenseInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/LicenseInformation/TribalCode",
@@ -13425,7 +13425,7 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType( )
         LicenseInformationType(tribalCode != null, tribalCode != "", worksOnReservation != "Y") from $provider.licenseInformation
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/LicenseInformation/TribalCode",
@@ -13446,7 +13446,7 @@ dialect 'mvel'
  */
     when
         ProviderInformationType(UMPI != null, UMPI not matches "^.{0,10}$")
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/UMPI",
@@ -13470,7 +13470,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.INDIAN_HEALTH_SERVICE_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.VERIFICATION_OF_IHS_STATUS.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13487,7 +13487,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.NURSING_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.LICENSE_AND_TRANSMITTAL_CMS_1539_FORM_FROM_MN_DEPARTMENT_OF_HEALTH.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13503,7 +13503,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.INTERMEDIATE_CARE_FACILITIES_FOR_PERSONS_WITH_DEVELOPMENTAL_DISABILITIES.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.LICENSE_AND_TRANSMITTAL_CMS_1539_FORM_FROM_MN_DEPARTMENT_OF_HEALTH.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13519,7 +13519,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.HOSPICE.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.CMS_MEDICARE_CERTIFICATION_LETTER.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13535,7 +13535,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.HOSPICE.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.HOSPICE_LICENSE_FROM_THE_MN_DEPT_OF_HEALTH.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13551,7 +13551,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.HOSPITAL.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.STATE_LICENSE_TO_OPERATE_AS_A_HOSPITAL.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13568,7 +13568,7 @@ salience 10
 end
 
 /**
- * Added by cyberjag - Fix for PESP-297 
+ * Added by cyberjag - Fix for PESP-297
 **/
 rule 'CMS 1539 Form Is Required For Renal Dialysis Facility'
 dialect 'mvel'
@@ -13577,7 +13577,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.RENAL_DIALYSIS_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.LICENSE_AND_TRANSMITTAL_CMS_1539_FORM_FROM_MN_DEPARTMENT_OF_HEALTH.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13593,7 +13593,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.RENAL_DIALYSIS_FACILITY.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.RENAL_DIALYSIS_FACILITY_APPROVAL_LETTER_FROM_REGIONAL_CMS_OFFICE.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -13603,7 +13603,7 @@ dialect 'mvel'
 end
 
 /**
- * Added by cyberjag - Fix for PESP-307 
+ * Added by cyberjag - Fix for PESP-307
 **/
 rule 'Provider age should be 18 or above during enrollment'
 dialect 'mvel'
@@ -13611,8 +13611,8 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider)
         IndividualApplicantType($dateOfBirth: dateOfBirth, dateOfBirth != null)
-        eval($dateOfBirth.after(get18YearsFromNow())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.after(get18YearsFromNow()))
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/ApplicantInformation/PersonalInformation/DateOfBirth",
@@ -13629,8 +13629,8 @@ dialect 'mvel'
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType($dateOfBirth: dateOfBirth, dateOfBirth != null) from $memberList
-        eval($dateOfBirth.after(get18YearsFromNow())) 
-        $report: ErrorReporter() 
+        eval($dateOfBirth.after(get18YearsFromNow()))
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -13647,7 +13647,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(bGSStudyId == null || bGSStudyId matches "^[\\s]*$") from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -13664,7 +13664,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType(bGSClearanceDate == null) from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -13681,8 +13681,8 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member: GroupMemberType($startDate: startDate, startDate != null, $bGSClearanceDate : bGSClearanceDate, bGSClearanceDate != null) from $memberList
-        eval($startDate.before($bGSClearanceDate)) 
-        $report: ErrorReporter() 
+        eval($startDate.before($bGSClearanceDate))
+        $report: ErrorReporter()
     then
         int index = $memberList.indexOf($member);
         $report.addError(
@@ -13694,13 +13694,13 @@ end
 
 /**
  * Added by cyberjag - Fix for PESP-282
- */ 
+ */
 rule 'Dental License is required for Dentist'
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.DENTIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.DENTIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType( licenseType == LicenseNames.DENTAL.value() ) from $licenses
         $report: ErrorReporter()
     then
@@ -13713,12 +13713,12 @@ end
 
 /**
  * Added by cyberjag - Fix for PESP-259
- */ 
+ */
 rule "Acupuncturist License in the state of practice is required for Acupuncturist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.ACUPUNCTURIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.ACUPUNCTURIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType( licenseType == LicenseNames.ACUPUNCTURIST.value() ) from $licenses
         $report: ErrorReporter()
     then
@@ -13727,13 +13727,13 @@ rule "Acupuncturist License in the state of practice is required for Acupuncturi
             "00001",
             "Copy of Acupuncturist License in the state of practice is required."
         );
-end 
+end
 
 rule "Dental Hygienist license is required for Allied Dental Professional"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.ALLIED_DENTAL_PROFESSIONAL.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.ALLIED_DENTAL_PROFESSIONAL.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType( licenseType == LicenseNames.DENTAL_HYGIENIST.value() ) from $licenses
         $report: ErrorReporter()
     then
@@ -13745,10 +13745,10 @@ rule "Dental Hygienist license is required for Allied Dental Professional"
 end
 
 rule "Valid national certification as a certified rehabilitation counselor or Certified psychosocial rehabilitation practitioner is required for CMHRP"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType( licenseType == LicenseNames.PSYCHOSOCIAL_REHAB_PRACTITIONER_CERTIFICATION.value() || licenseType == LicenseNames.REHAB_COUNSELOR_CERTIFICATION.value() ) from $licenses
         $report: ErrorReporter()
     then
@@ -13760,10 +13760,10 @@ rule "Valid national certification as a certified rehabilitation counselor or Ce
 end
 
 rule "Traditional Midwife license is required for Certified Professional Midwife"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_PROFESSIONAL_MIDWIFE.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_PROFESSIONAL_MIDWIFE.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType( licenseType == LicenseNames.TRADITIONAL_MIDWIFE.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13775,10 +13775,10 @@ rule "Traditional Midwife license is required for Certified Professional Midwife
 end
 
 rule "Professional Midwife certification from the North American Registry of Midwives is required for Certified Professional Midwife"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_PROFESSIONAL_MIDWIFE.value())
-   		not SpecialtiesType(specialtyName contains SpecialtyNames.CERTIFIED_PROFESSIONAL_MIDWIFE.value()) from $provider.specialties
+        $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_PROFESSIONAL_MIDWIFE.value())
+        not SpecialtiesType(specialtyName contains SpecialtyNames.CERTIFIED_PROFESSIONAL_MIDWIFE.value()) from $provider.specialties
         $report: ErrorReporter()
     then
         $report.addError(
@@ -13789,10 +13789,10 @@ rule "Professional Midwife certification from the North American Registry of Mid
 end
 
 rule "Registered Nurse license is required for Certified Registered Nurse Anesthetist and Clinical Nurse Specialist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType in (ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value(), ProviderType.CLINICAL_NURSE_SPECIALIST.value()))
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType in (ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value(), ProviderType.CLINICAL_NURSE_SPECIALIST.value()))
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType( licenseType == LicenseNames.REGISTERED_NURSE.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13804,10 +13804,10 @@ rule "Registered Nurse license is required for Certified Registered Nurse Anesth
 end
 
 rule "Clinical Nurse Specialist Certification from the American Nurses Credentialing Center, or other accepted National Board is required for Clinical Nurse Specialist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType in (ProviderType.CLINICAL_NURSE_SPECIALIST.value()))
-   		not SpecialtiesType(specialtyName contains SpecialtyNames.PSYCHIATRIC_MENTAL_HEALTH.value()) from $provider.specialties
+        $provider: ProviderInformationType(providerType in (ProviderType.CLINICAL_NURSE_SPECIALIST.value()))
+        not SpecialtiesType(specialtyName contains SpecialtyNames.PSYCHIATRIC_MENTAL_HEALTH.value()) from $provider.specialties
         $report: ErrorReporter()
     then
         $report.addError(
@@ -13818,10 +13818,10 @@ rule "Clinical Nurse Specialist Certification from the American Nurses Credentia
 end
 
 rule "CRNA Certification from the American Association of Nurse Anesthetists is required for Certified Registered Nurse Anesthetist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value())
-   		not SpecialtiesType(specialtyName contains SpecialtyNames.CRNA_CERTIFICATION.value()) from $provider.specialties
+        $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value())
+        not SpecialtiesType(specialtyName contains SpecialtyNames.CRNA_CERTIFICATION.value()) from $provider.specialties
         $report: ErrorReporter()
     then
         $report.addError(
@@ -13832,10 +13832,10 @@ rule "CRNA Certification from the American Association of Nurse Anesthetists is 
 end
 
 rule "Copy of MnSCU certification is required for Community Health Worker"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType( issuingState == "MN", licenseType == LicenseNames.MN_SCU_CERTIFICATION.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13847,10 +13847,10 @@ rule "Copy of MnSCU certification is required for Community Health Worker"
 end
 
 rule "Copy of Hearing Instrument Dispenser Certificate is required for Hearing Aid Dispenser"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.HEARING_AID_DISPENSER.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.HEARING_AID_DISPENSER.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.HEARING_AID_DISPENSER.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13862,10 +13862,10 @@ rule "Copy of Hearing Instrument Dispenser Certificate is required for Hearing A
 end
 
 rule "Dietician or Nutritionist License from the state of practice is required for Registered Dietician and Nutritionist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.LICENSED_DIETICIAN_OR_LICENSED_NUTRITIONIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.LICENSED_DIETICIAN_OR_LICENSED_NUTRITIONIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.DIETICIAN_OR_NUTRITIONIST.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13877,10 +13877,10 @@ rule "Dietician or Nutritionist License from the state of practice is required f
 end
 
 rule "Clinical Socail Worker License from the state of practice is required for licensed independent clinical social worker"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.CLINICAL_SOCIAL_WORKER.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13892,10 +13892,10 @@ rule "Clinical Socail Worker License from the state of practice is required for 
 end
 
 rule "Marriage and Family Therapist license or equivalent is required for licensed marriage and family therapist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.MARRIAGE_AND_FAMILY_THERAPIST.value()) from $licenses
         $applicant: ApplicantInformationType(  ) from $provider.applicantInformation
         not IndividualApplicantType(highestDegreeEarned == "MASTERS" || highestDegreeEarned == "DOCTORATE") from $applicant.personalInformation
@@ -13909,10 +13909,10 @@ rule "Marriage and Family Therapist license or equivalent is required for licens
 end
 
 rule "Professional Clinical Counselor License from the state of practice is required for licensed professional clinical counselor"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.PROFESSIONAL_CLINICAL_COUNSELOR.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13921,13 +13921,13 @@ rule "Professional Clinical Counselor License from the state of practice is requ
             "00001",
             "Professional Clinical Counselor License is required."
         );
-end 
+end
 
 rule "Current License from the state of practice is required for licensed psychologist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.PSYCHOLOGIST.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13936,13 +13936,13 @@ rule "Current License from the state of practice is required for licensed psycho
             "00001",
             "Current License from the state of practice is required."
         );
-end 
+end
 
 rule "Registered Nurse license in state of practice is required for certified nurse midwife, nurse practitioner"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType in (ProviderType.NURSE_MIDWIFE.value(),  ProviderType.NURSE_PRACTITIONER.value()))
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType in (ProviderType.NURSE_MIDWIFE.value(),  ProviderType.NURSE_PRACTITIONER.value()))
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.REGISTERED_NURSE.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13954,12 +13954,12 @@ rule "Registered Nurse license in state of practice is required for certified nu
 end
 
 rule "Registered Nurse license in state of practice is required for private duty nurse"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType  == ProviderType.PRIVATE_DUTY_NURSE.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
-   		not LicenseType(licenseType == LicenseNames.LICENSED_PRACTICAL_NURSE.value()) from $licenses
-   		not LicenseType(licenseType == LicenseNames.CLASS_A_LICENSE.value()) from $licenses
+        $provider: ProviderInformationType(providerType  == ProviderType.PRIVATE_DUTY_NURSE.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        not LicenseType(licenseType == LicenseNames.LICENSED_PRACTICAL_NURSE.value()) from $licenses
+        not LicenseType(licenseType == LicenseNames.CLASS_A_LICENSE.value()) from $licenses
         not LicenseType(licenseType == LicenseNames.REGISTERED_NURSE.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -13971,10 +13971,10 @@ rule "Registered Nurse license in state of practice is required for private duty
 end
 
 rule "Class A license is required when LPN is selected for private duty nurse"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.PRIVATE_DUTY_NURSE.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.PRIVATE_DUTY_NURSE.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         LicenseType(licenseType == LicenseNames.LICENSED_PRACTICAL_NURSE.value()) from $licenses
         not LicenseType(licenseType == LicenseNames.CLASS_A_LICENSE.value()) from $licenses
         $report: ErrorReporter()
@@ -13987,10 +13987,10 @@ rule "Class A license is required when LPN is selected for private duty nurse"
 end
 
 rule "LPN is required when Class A is selected for private duty nurse"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.PRIVATE_DUTY_NURSE.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.PRIVATE_DUTY_NURSE.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         LicenseType(licenseType == LicenseNames.CLASS_A_LICENSE.value()) from $licenses
         not LicenseType(licenseType == LicenseNames.LICENSED_PRACTICAL_NURSE.value()) from $licenses
         $report: ErrorReporter()
@@ -14003,10 +14003,10 @@ rule "LPN is required when Class A is selected for private duty nurse"
 end
 
 rule "Nurse Midwife Certification from the American Midwifery Certification Board is required for certified nurse midwife"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.NURSE_MIDWIFE.value())
-   		not SpecialtiesType(specialtyName contains SpecialtyNames.CERTIFIED_NURSE_MIDWIFE.value()) from $provider.specialties
+        $provider: ProviderInformationType(providerType == ProviderType.NURSE_MIDWIFE.value())
+        not SpecialtiesType(specialtyName contains SpecialtyNames.CERTIFIED_NURSE_MIDWIFE.value()) from $provider.specialties
         $report: ErrorReporter()
     then
         $report.addError(
@@ -14017,10 +14017,10 @@ rule "Nurse Midwife Certification from the American Midwifery Certification Boar
 end
 
 rule "Copy of license as occupational therapist in state of practice is required for Occupational Therapist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.OCCUPATIONAL_THERAPY.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14032,10 +14032,10 @@ rule "Copy of license as occupational therapist in state of practice is required
 end
 
 rule "Copy of certification by the NBCOT is required for Occupational Therapist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.NBCOT_CERTIFICATION.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14047,10 +14047,10 @@ rule "Copy of certification by the NBCOT is required for Occupational Therapist"
 end
 
 rule "Optometrist License is required for Optometrist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.OPTOMETRIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.OPTOMETRIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.OPTOMETRIST.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14062,10 +14062,10 @@ rule "Optometrist License is required for Optometrist"
 end
 
 rule "Pharmacist License from the state of practice is required for Pharmacist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.PHARMACIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.PHARMACIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.PHARMACIST_LICENSE.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14077,10 +14077,10 @@ rule "Pharmacist License from the state of practice is required for Pharmacist"
 end
 
 rule "Copy of license as a physical therapist in the state of practice is required for Physical Therapist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.PHYSICAL_THERAPIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.PHYSICAL_THERAPIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.PHYSICAL_THERAPIST.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14092,10 +14092,10 @@ rule "Copy of license as a physical therapist in the state of practice is requir
 end
 
 rule "Physician License in the state of practice is required for Physician"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.PHYSICIAN.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14107,10 +14107,10 @@ rule "Physician License in the state of practice is required for Physician"
 end
 
 rule "Physician Assistant License in the state of practice is required for Physician"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN_ASSISTANT.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN_ASSISTANT.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.PHYSICIAN_ASSISTANT.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14122,10 +14122,10 @@ rule "Physician Assistant License in the state of practice is required for Physi
 end
 
 rule "Copy of license as a podiatrist from the MN Board of Podiatric Medicine or current state of practice is required for Podiatrist"
-	when
+    when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
-   		$provider: ProviderInformationType(providerType == ProviderType.PODIATRIST.value())
-   		LicenseInformationType( $licenses: license ) from $provider.licenseInformation
+        $provider: ProviderInformationType(providerType == ProviderType.PODIATRIST.value())
+        LicenseInformationType( $licenses: license ) from $provider.licenseInformation
         not LicenseType(licenseType == LicenseNames.PODIATRIST_LICENSE.value()) from $licenses
         $report: ErrorReporter()
     then
@@ -14149,7 +14149,7 @@ dialect 'mvel'
         List (size  < 2) from collect (GroupMemberType(providerType == ProviderType.CHIROPRACTOR.value()) from $memberList)
         $report: ErrorReporter()
     then
-    	$report.addError(
+        $report.addError(
            "/ProviderInformation/MemberInformation",
            "00001",
            "Minimum of 2 licensed chiropractors working at the clinic is required."
@@ -14166,7 +14166,7 @@ dialect 'mvel'
         List (size  < 2) from collect (GroupMemberType(providerType == ProviderType.PHYSICIAN.value()) from $memberList)
         $report: ErrorReporter()
     then
-    	$report.addError(
+        $report.addError(
            "/ProviderInformation/MemberInformation",
            "00001",
            "Minimum of 2 licensed physician working at the clinic is required."
@@ -14183,7 +14183,7 @@ activation-group "duplicate-member-npi"
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         $member1: PersonType($npi1 : nPI, nPI != null) from $memberList
         $member2: PersonType(nPI == $npi1, this != $member1) from $memberList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
@@ -14193,7 +14193,7 @@ activation-group "duplicate-member-npi"
 end
 
 /**
- * Added by cyberjag - Fix for PESP-308 
+ * Added by cyberjag - Fix for PESP-308
 **/
 rule 'Birth Center license from the MN Department of Health is Required for Birthing Center'
 dialect 'mvel'
@@ -14202,7 +14202,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.BIRTHING_CENTER.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.BIRTH_CENTER_LICENSE_FROM_THE_MN_DEPARTMENT_OF_HEALTH.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -14218,7 +14218,7 @@ dialect 'mvel'
         $provider: ProviderInformationType(providerType == ProviderType.BIRTHING_CENTER.value())
         $credentials: FacilityCredentialsType($licenseList : license) from $provider.facilityCredentials
         not LicenseType( licenseType == LicenseNames.ACCREDITATION_FROM_THE_COMMISSION_FOR_THE_ACCREDITATION_OF_BIRTH_CENTERS.value() ) from $licenseList
-        $report: ErrorReporter() 
+        $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/FacilityCredentials",
@@ -14235,16 +14235,16 @@ activation-group "billing-entity-for-phy-svc-members"
         $provider: ProviderInformationType(providerType == ProviderType.BILLING_ENTITY_FOR_PHYSICIAN_SERVICES.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         not GroupMemberType(providerType in (
-        	ProviderType.PHYSICIAN.value(),
-        	ProviderType.PHYSICIAN_ASSISTANT.value(),
-   			ProviderType.NURSE_PRACTITIONER.value(),
-   			ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
-   			ProviderType.CHIROPRACTOR.value(),
-   			ProviderType.DENTIST.value()									     	
-		)) from $memberList
+            ProviderType.PHYSICIAN.value(),
+            ProviderType.PHYSICIAN_ASSISTANT.value(),
+            ProviderType.NURSE_PRACTITIONER.value(),
+            ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
+            ProviderType.CHIROPRACTOR.value(),
+            ProviderType.DENTIST.value()
+        )) from $memberList
         $report: ErrorReporter()
     then
-    	$report.addError(
+        $report.addError(
            "/ProviderInformation/MemberInformation",
            "00001",
            "Member information must consist of a combination of Physicians, Physician Assistant, Nurse Practitioner, LICSW, Chiropractor, and Dentist."
@@ -14259,16 +14259,16 @@ activation-group "billing-entity-for-phy-svc-members"
         $provider: ProviderInformationType(providerType == ProviderType.BILLING_ENTITY_FOR_PHYSICIAN_SERVICES.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         List (size  < 2) from collect (GroupMemberType(providerType in (
-        	ProviderType.PHYSICIAN.value(),
-        	ProviderType.PHYSICIAN_ASSISTANT.value(),
-   			ProviderType.NURSE_PRACTITIONER.value(),
-   			ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
-   			ProviderType.CHIROPRACTOR.value(),
-   			ProviderType.DENTIST.value()									     	
-		)) from $memberList)
+            ProviderType.PHYSICIAN.value(),
+            ProviderType.PHYSICIAN_ASSISTANT.value(),
+            ProviderType.NURSE_PRACTITIONER.value(),
+            ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
+            ProviderType.CHIROPRACTOR.value(),
+            ProviderType.DENTIST.value()
+        )) from $memberList)
         $report: ErrorReporter()
     then
-    	$report.addError(
+        $report.addError(
            "/ProviderInformation/MemberInformation",
            "00001",
            "Member information must consist of a combination of Physicians, Physician Assistant, Nurse Practitioner, LICSW, Chiropractor, and Dentist."
@@ -14286,15 +14286,15 @@ activation-group "billing-entity-for-mh"
         $provider: ProviderInformationType(providerType == ProviderType.BILLING_ENTITY_FOR_MENTAL_HEALTH.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         not GroupMemberType(providerType in (
-        	ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
-        	ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value(),
-        	ProviderType.LICENSED_PSYCHOLOGIST.value(),
-        	ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value(),
-   			ProviderType.CLINICAL_NURSE_SPECIALIST.value()
-		)) from $memberList
+            ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
+            ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value(),
+            ProviderType.LICENSED_PSYCHOLOGIST.value(),
+            ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value(),
+            ProviderType.CLINICAL_NURSE_SPECIALIST.value()
+        )) from $memberList
         $report: ErrorReporter()
     then
-    	$report.addError(
+        $report.addError(
            "/ProviderInformation/MemberInformation",
            "00001",
            "Member information must consist of a combination of LICSW, LMFT, LP, LPCC, or CNS with mental health specialty."
@@ -14309,15 +14309,15 @@ activation-group "billing-entity-for-mh"
         $provider: ProviderInformationType(providerType == ProviderType.BILLING_ENTITY_FOR_MENTAL_HEALTH.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
         List (size  < 2) from collect (GroupMemberType(providerType in (
-        	ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
-        	ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value(),
-        	ProviderType.LICENSED_PSYCHOLOGIST.value(),
-        	ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value(),
-   			ProviderType.CLINICAL_NURSE_SPECIALIST.value()									     	
-		)) from $memberList)
+            ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value(),
+            ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value(),
+            ProviderType.LICENSED_PSYCHOLOGIST.value(),
+            ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value(),
+            ProviderType.CLINICAL_NURSE_SPECIALIST.value()
+        )) from $memberList)
         $report: ErrorReporter()
     then
-    	$report.addError(
+        $report.addError(
            "/ProviderInformation/MemberInformation",
            "00001",
            "Member information must consist minimum of 2 licensed and enrolled providers of the following types: LICSW, LMFT, LP, LPCC, or CNS with mental health specialty."
@@ -14334,7 +14334,7 @@ dialect 'mvel'
         not GroupMemberType(providerType == ProviderType.PHARMACIST.value()) from $memberList
         $report: ErrorReporter()
     then
-    	$report.addError(
+        $report.addError(
            "/ProviderInformation/MemberInformation",
            "00001",
            "Member information can accept only Pharmacist."
@@ -14343,19 +14343,19 @@ end
 
 // generated rules from dslr
 rule "Require First Name For All Individual Providers"
-	when
-	    LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value()) $report: ErrorReporter()
-	    IndividualApplicantType(firstName == null || firstName matches "^[\\s]*$")
-	then
+    when
+        LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value()) $report: ErrorReporter()
+        IndividualApplicantType(firstName == null || firstName matches "^[\\s]*$")
+    then
 
         $report.addError("/ProviderInformation/ApplicantInformation/PersonalInformation/FirstName", "00001", "First Name is required for individual applicants.");
 end
 
 rule "Require Last Name For All Individual Providers"
-	when
-	    LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value()) $report: ErrorReporter()
-	    IndividualApplicantType(lastName == null || lastName matches "^[\\s]*$")
-	then
+    when
+        LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value()) $report: ErrorReporter()
+        IndividualApplicantType(lastName == null || lastName matches "^[\\s]*$")
+    then
 
         $report.addError("/ProviderInformation/ApplicantInformation/PersonalInformation/LastName", "00001", "Last Name is required for individual applicants.");
 end

--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -536,20 +536,20 @@ dialect 'mvel'
 
 end
 
-rule 'Address Line 1 Should be left empty if Address Line 2 Is Not Provided'
+rule 'Address Line 2 Should be left empty if Address Line 1 Is Not Provided'
 dialect 'mvel'
     when
-        $entry: AddressEntry(errorOnLine1 != "Y")
-        AddressType(addressLine2 == null || addressLine2 matches "^[\\s]*$", addressLine1 != null, addressLine1 != "") from $entry.address
+        $entry: AddressEntry(errorOnLine2 != "Y")
+        AddressType(addressLine1 == null || addressLine1 matches "^[\\s]*$", addressLine2 != null, addressLine2 != "") from $entry.address
         $report: ErrorReporter()
     then
         modify($entry) {
-            setErrorOnLine1("Y")
+            setErrorOnLine2("Y")
         }
         $report.addError(
-            $entry.getPath() + "/AddressLine1",
+            $entry.getPath() + "/AddressLine2",
             "00001",
-            $entry.getType() + " line 1 should be left empty if line 2 is not provided."
+            $entry.getType() + " line 2 should be left empty if line 1 is not provided."
         );
 
 end
@@ -1337,7 +1337,7 @@ dialect 'mvel'
 
 end
 
-rule 'All Addresses Line 2 Is Required'
+rule 'Address must not be empty'
 dialect 'mvel'
 /*
  * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
@@ -1347,15 +1347,15 @@ dialect 'mvel'
  * @since Provider Enrollment Drools Front End Validation Part 3
  */
     when
-        $entry: AddressEntry(errorOnLine2 != "Y")
+        $entry: AddressEntry(errorOnLine1 != "Y")
         AddressType(addressLine2 == null || addressLine2 matches "^[\\s]*$", addressLine1 == null || addressLine1 matches "^[\\s]*$") from $entry.address
         $report: ErrorReporter()
     then
         modify($entry) {
-            setErrorOnLine2("Y")
+            setErrorOnLine1("Y")
         }
         $report.addError(
-            $entry.getPath() + "/AddressLine2",
+            $entry.getPath() + "/AddressLine1",
             "00001",
             $entry.getType() + " street address is required."
         );

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public abstract class AbstractPracticeFormBinder extends BaseFormBinder {
             contact.setFaxNumber(BinderUtils.concatPhone(param(request, "fax1"), param(request, "fax2"),
                 param(request, "fax3"), ""));
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -352,20 +352,24 @@ public abstract class AbstractPracticeFormBinder extends BaseFormBinder {
         return null;
     }
 
-	/**
-	 * For external users with RoleView = EMPLOYER, they cannot touch any information with NPI is not their own
-	 * @param user the current request user
-	 * @param enrollment the
-	 * @return
-	 */
-	protected boolean canModifyExistingPractice(CMSUser user, EnrollmentType enrollment) {
-		if (user.getExternalRoleView() == RoleView.EMPLOYER) {
-			PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
-			if (user.getExternalAccountLink().getExternalUserId().equals(practice.getGroupNPI())) {
-				return true;
-			}
-			return false;
-		}
-		return true;
-	}
+    /**
+     * For external users with RoleView = EMPLOYER, they cannot touch any information with NPI is not their own
+     *
+     * @param user       the current request user
+     * @param enrollment the
+     * @return
+     */
+    protected boolean canModifyExistingPractice(
+            CMSUser user,
+            EnrollmentType enrollment
+    ) {
+        if (user.getExternalRoleView() == RoleView.EMPLOYER) {
+            PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
+            if (user.getExternalAccountLink().getExternalUserId().equals(practice.getGroupNPI())) {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
@@ -177,12 +177,6 @@ public abstract class AbstractPracticeFormBinder extends BaseFormBinder {
         List<StatusMessageType> ruleErrors = messages.getStatusMessage();
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
 
-        PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
-        AddressType xAddress = XMLUtility.nsGetAddress(practice);
-        boolean switchAddressLineFields = false;
-        if (Util.isBlank(xAddress.getAddressLine1())) {
-            switchAddressLineFields = true;
-        }
         synchronized (ruleErrors) {
             for (StatusMessageType ruleError : ruleErrors) {
                 int count = errors.size();
@@ -202,9 +196,9 @@ public abstract class AbstractPracticeFormBinder extends BaseFormBinder {
                     String[] addressLines = new String[]{"addressLine1", "addressLine2"};
                     errors.add(createError(addressLines, ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ContactInformation/Address/AddressLine1")) {
-                    errors.add(createError(switchAddressLineFields ? "addressLine2" : "addressLine1", ruleError.getMessage()));
+                    errors.add(createError("addressLine1", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ContactInformation/Address/AddressLine2")) {
-                    errors.add(createError(switchAddressLineFields ? "addressLine1" : "addressLine2", ruleError.getMessage()));
+                    errors.add(createError("addressLine2", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ContactInformation/Address/City")) {
                     errors.add(createError("city", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ContactInformation/Address/State")) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
@@ -149,19 +149,7 @@ public abstract class AbstractPracticeFormBinder extends BaseFormBinder {
         attr(mv, "name", practice.getName());
         attr(mv, "npi", practice.getGroupNPI());
 
-        AddressType address = XMLUtility.nsGetAddress(practice);
-        String line1 = address.getAddressLine1();
-        String line2 = address.getAddressLine2();
-        if (Util.isBlank(line1)) {
-            line1 = line2;
-            line2 = null;
-        }
-        attr(mv, "addressLine1", line1);
-        attr(mv, "addressLine2", line2);
-        attr(mv, "city", address.getCity());
-        attr(mv, "state", address.getState());
-        attr(mv, "zip", address.getZipCode());
-        attr(mv, "county", address.getCounty());
+        attr(mv, XMLUtility.nsGetAddress(practice));
 
         ContactInformationType contact = XMLUtility.nsGetContactInformation(practice);
         String[] phone = BinderUtils.splitPhone(contact.getPhoneNumber());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public class AdditionalAgencyFormBinder extends BaseFormBinder {
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
         List<BinderException> exceptions = new ArrayList<BinderException>();
-        
+
         AgencyInformationType agency = XMLUtility.nsGetAgencyInformation(enrollment);
         agency.getAffiliation().clear();
 
@@ -105,7 +105,7 @@ public class AdditionalAgencyFormBinder extends BaseFormBinder {
             agency.getAffiliation().add(location);
             i++;
         }
-        
+
         return exceptions;
     }
 
@@ -347,5 +347,4 @@ public class AdditionalAgencyFormBinder extends BaseFormBinder {
             throw new PortalServiceRuntimeException("Cannot verify linked agency.", e);
         }
     }
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -183,18 +183,7 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
 
             AddressType address = location.getAddress();
             if (address != null) {
-                String line1 = address.getAddressLine1();
-                String line2 = address.getAddressLine2();
-                if (Util.isBlank(line1)) {
-                    line1 = line2;
-                    line2 = null;
-                }
-                attr(mv, "addressLine1", i, line1);
-                attr(mv, "addressLine2", i, line2);
-                attr(mv, "city", i, address.getCity());
-                attr(mv, "state", i, address.getState());
-                attr(mv, "zip", i, address.getZipCode());
-                attr(mv, "county", i, address.getCounty());
+                attr(mv, i, address);
             }
             i++;
         }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -120,20 +120,20 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
             }
 
             // for employer view, do not accept any other NPI
-        	if (user.getExternalRoleView() == RoleView.EMPLOYER) {
-        		if (user.getExternalAccountLink().getExternalUserId().equals(location.getGroupNPI())) {
-            		locations.getPracticeLocation().add(location);
-        		}
-        	} else {
-        		locations.getPracticeLocation().add(location);
-        	}
+            if (user.getExternalRoleView() == RoleView.EMPLOYER) {
+                if (user.getExternalAccountLink().getExternalUserId().equals(location.getGroupNPI())) {
+                    locations.getPracticeLocation().add(location);
+                }
+            } else {
+                locations.getPracticeLocation().add(location);
+            }
             i++;
         }
 
         PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
-    	if (user.getExternalRoleView() == RoleView.EMPLOYER) {
-    		retainLocations(practice, locations, user.getExternalAccountLink().getExternalUserId());
-    	}
+        if (user.getExternalRoleView() == RoleView.EMPLOYER) {
+            retainLocations(practice, locations, user.getExternalAccountLink().getExternalUserId());
+        }
         practice.setAdditionalPracticeLocations(locations);
         return exceptions;
     }
@@ -147,19 +147,19 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
      * @param externalUserId the NPI of the current user
      */
     private void retainLocations(PracticeInformationType practice,
-    	AdditionalPracticeLocationsType locations, String externalUserId) {
-    	AdditionalPracticeLocationsType orig = practice.getAdditionalPracticeLocations();
-    	List<PracticeLocationType> base = orig.getPracticeLocation();
-    	for (PracticeLocationType old : base) {
-			if (old.getGroupNPI().equals(externalUserId)) {
-				continue;
-			} else {
-				locations.getPracticeLocation().add(old);
-			}
-		}
-	}
+        AdditionalPracticeLocationsType locations, String externalUserId) {
+        AdditionalPracticeLocationsType orig = practice.getAdditionalPracticeLocations();
+        List<PracticeLocationType> base = orig.getPracticeLocation();
+        for (PracticeLocationType old : base) {
+            if (old.getGroupNPI().equals(externalUserId)) {
+                continue;
+            } else {
+                locations.getPracticeLocation().add(old);
+            }
+        }
+    }
 
-	/**
+    /**
      * Binds the model to the request attributes.
      * @param enrollment the model to bind from
      * @param mv the model and view to bind to
@@ -168,22 +168,22 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
     public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
         attr(mv, "bound", "Y");
         if (user.getExternalRoleView() == RoleView.EMPLOYER) {
-        	attr(mv, "allowAdd", "N");
+            attr(mv, "allowAdd", "N");
         } else {
-        	attr(mv, "allowAdd", "Y");
+            attr(mv, "allowAdd", "Y");
         }
-        
+
         PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
         AdditionalPracticeLocationsType locations = XMLUtility.nsGetOtherLocations(practice);
         List<PracticeLocationType> xList = locations.getPracticeLocation();
         int i = 0;
         for (PracticeLocationType location : xList) {
-        	if (user.getExternalRoleView() == RoleView.EMPLOYER) {
-        		// this view only has access to its own NPI
-        		if (!user.getExternalAccountLink().getExternalUserId().equals(location.getGroupNPI())) {
-        			continue;
-        		}
-        	}
+            if (user.getExternalRoleView() == RoleView.EMPLOYER) {
+                // this view only has access to its own NPI
+                if (!user.getExternalAccountLink().getExternalUserId().equals(location.getGroupNPI())) {
+                    continue;
+                }
+            }
             attr(mv, "objectId", i, location.getObjectId());
             if (Util.isNotBlank(location.getObjectId())) {
                 attr(mv, "objectIdHash", i, Util.hash(location.getObjectId(), getServerHashKey()));
@@ -270,7 +270,7 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
         if (index != null) {
             PracticeLocationType location = locations.getPracticeLocation().get(index);
             message = ruleError.getMessage() + "(Group #" + (index + 1) + ")";
-            
+
             boolean switchAddressLines = false;
             if (location.getAddress() != null || Util.isBlank(location.getAddress().getAddressLine1())) {
                 // since line 2 is populated instead of line 1 by default
@@ -463,5 +463,4 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
             throw new PortalServiceRuntimeException("Cannot verify linked practice.", e);
         }
     }
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -103,19 +103,7 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
                     exceptions.add(e);
                 }
 
-                AddressType address = new AddressType();
-                String line2 = param(request, "addressLine2", i);
-                String line1 = param(request, "addressLine1", i);
-                if (Util.isBlank(line2)) {
-                    line2 = line1;
-                    line1 = null;
-                }
-                address.setAddressLine1(line1);
-                address.setAddressLine2(line2);
-                address.setCity(param(request, "city", i));
-                address.setState(param(request, "state", i));
-                address.setZipCode(param(request, "zip", i));
-                address.setCounty(param(request, "county", i));
+                AddressType address = readIndexedAddress(request, i);
                 location.setAddress(address);
             }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -202,9 +202,6 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
     protected List<FormError> selectErrors(EnrollmentType enrollment, StatusMessagesType messages) {
         List<FormError> errors = new ArrayList<FormError>();
 
-        PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
-        AdditionalPracticeLocationsType locations = XMLUtility.nsGetOtherLocations(practice);
-
         List<StatusMessageType> ruleErrors = messages.getStatusMessage();
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
         synchronized (ruleErrors) {
@@ -216,7 +213,7 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
                 }
 
                 if (path.startsWith(LOCATION_PATH)) {
-                    FormError error = resolveFieldError(locations, ruleError);
+                    FormError error = resolveFieldError(ruleError);
                     errors.add(error);
                 }
                 if (errors.size() > count) { // caught
@@ -235,24 +232,17 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
 
     /**
      * Resolves the specific license that is causing the error from the license list.
-     * @param locations the additional locations
      * @param ruleError the error to resolve
      * @return the resolved error
      */
-    private FormError resolveFieldError(AdditionalPracticeLocationsType locations, StatusMessageType ruleError) {
+    private FormError resolveFieldError(StatusMessageType ruleError) {
         String path = ruleError.getRelatedElementPath();
         Integer index = resolveIndex(path);
 
         String message = ruleError.getMessage();
         if (index != null) {
-            PracticeLocationType location = locations.getPracticeLocation().get(index);
             message = ruleError.getMessage() + "(Group #" + (index + 1) + ")";
 
-            boolean switchAddressLines = false;
-            if (location.getAddress() != null || Util.isBlank(location.getAddress().getAddressLine1())) {
-                // since line 2 is populated instead of line 1 by default
-                switchAddressLines = true;
-            }
             if (path.endsWith("Address")) {
                 return createError(new String[]{"addressLine2", "addressLine1"}, index, message);
             } else if (path.endsWith("EffectiveDate")) {
@@ -262,9 +252,9 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
             } else if (path.endsWith("GroupNPI")) {
                 return createError("npi", index, message);
             } else if (path.endsWith("AddressLine1")) {
-                return createError(switchAddressLines ? "addressLine1" : "addressLine2", index, message);
+                return createError("addressLine1", index, message);
             } else if (path.endsWith("AddressLine2")) {
-                return createError(switchAddressLines ? "addressLine2" : "addressLine1", index, message);
+                return createError("addressLine2", index, message);
             } else if (path.endsWith("City")) {
                 return createError("city", index, message);
             } else if (path.endsWith("State")) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class AdultDayTreatmentApplicationFormBinder extends BaseFormBinder {
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         CountyContractType countyInfo = new CountyContractType();
         credentials.setContractWithCounty(countyInfo);
-        
+
         String attachmentId = (String) request.getAttribute(NAMESPACE + "application");
         if (attachmentId != null) {
             replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, ADULT_DAY_TREATMENT_APPLICATION);
@@ -83,7 +83,7 @@ public class AdultDayTreatmentApplicationFormBinder extends BaseFormBinder {
                 break;
             }
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -117,7 +117,7 @@ public class AdultDayTreatmentApplicationFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -142,7 +142,7 @@ public class AdultDayTreatmentApplicationFormBinder extends BaseFormBinder {
                 if (path == null) {
                     continue;
                 }
-                
+
                 if (path.equals("/ProviderInformation/FacilityCredentials/AdultDayTreatmentApplication")) {
                     errors.add(createError("application", ruleError.getMessage()));
                 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -53,12 +53,12 @@ public class AmbulanceServicesFormBinder extends BaseFormBinder {
      * The namespace for this form.
      */
     public static final String NAMESPACE = "_39_";
-    
+
     /**
      * Ambulance service selection.
      */
     private final List<ServiceCategory> categories = new ArrayList<ServiceCategory>();
-    
+
     /**
      * Initializes the available options for ambulance services.
      */
@@ -75,17 +75,17 @@ public class AmbulanceServicesFormBinder extends BaseFormBinder {
      */
     public AmbulanceServicesFormBinder() {
         super(NAMESPACE);
-        
+
         ServiceCategory cat = new ServiceCategory();
         cat.setCode("basicServices");
         cat.setDescription(DocumentNames.AMBULANCE_SERVICES_BASIC_SERVICE.value());
         categories.add(cat);
-        
+
         ServiceCategory cat2 = new ServiceCategory();
         cat2.setCode("advancedLifeSupport");
         cat2.setDescription(DocumentNames.AMBULANCE_SERVICES_ADVANCED_LIFE_SUPPORT.value());
         categories.add(cat2);
-        
+
         ServiceCategory cat3 = new ServiceCategory();
         cat3.setCode("airTransport");
         cat3.setDescription(DocumentNames.AMBULANCE_SERVICES_AIR_TRANSPORT_WITH_FAA_AIR_WORTHINESS_CERTIFICATE.value());
@@ -105,7 +105,7 @@ public class AmbulanceServicesFormBinder extends BaseFormBinder {
         FacilityCredentialsType creds = XMLUtility.nsGetFacilityCredentials(enrollment);
         List<AmbulanceServicesType> servicesList = creds.getAmbulanceServices();
         AttachedDocumentsType attachments = XMLUtility.nsGetAttachments(provider);
-        
+
         for (ServiceCategory category : categories) {
             String type1Indicator = param(request, category.getCode() + "Indicator");
             if ("Y".equals(type1Indicator)) {
@@ -121,7 +121,7 @@ public class AmbulanceServicesFormBinder extends BaseFormBinder {
         }
         return Collections.EMPTY_LIST;
     }
-    
+
     /**
      * Finds the service with the given name
      * @param servicesList the service list
@@ -134,7 +134,7 @@ public class AmbulanceServicesFormBinder extends BaseFormBinder {
                 return ambulanceServicesType;
             }
         }
-        
+
         AmbulanceServicesType ambulanceServicesType = new AmbulanceServicesType();
         ambulanceServicesType.setServiceType(serviceName);
         servicesList.add(ambulanceServicesType);
@@ -214,7 +214,7 @@ public class AmbulanceServicesFormBinder extends BaseFormBinder {
 
         return errors.isEmpty() ? NO_ERRORS : errors;
     }
-    
+
     /**
      * Resolves the specific license that is causing the error from the license list.
      * @param services the services entered

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -299,6 +299,21 @@ public abstract class BaseFormBinder implements FormBinder {
         attr(mv, prefix + "County", address.getCounty());
     }
 
+    protected void attr(Map<String, Object> mv, int i, AddressType address) {
+        String line1 = address.getAddressLine1();
+        String line2 = address.getAddressLine2();
+        if (Util.isBlank(line1)) {
+            line1 = line2;
+            line2 = null;
+        }
+        attr(mv, "addressLine1", i, line1);
+        attr(mv, "addressLine2", i, line2);
+        attr(mv, "city", i, address.getCity());
+        attr(mv, "state", i, address.getState());
+        attr(mv, "zip", i, address.getZipCode());
+        attr(mv, "county", i, address.getCounty());
+    }
+
     /**
      * Instantiates the correct entity type based on the provider type.
      *

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -525,4 +525,25 @@ public abstract class BaseFormBinder implements FormBinder {
         address.setCounty(param(request, "county"));
         return address;
     }
+
+    AddressType readPrefixedAddress(
+            HttpServletRequest request,
+            String prefix
+    ) {
+        AddressType address = new AddressType();
+        String line1 = param(request, prefix + "AddressLine1");
+        String line2 = param(request, prefix + "AddressLine2");
+        if (Util.isBlank(line2)) { // prioritize line 2 usage
+            line2 = line1;
+            line1 = null;
+        }
+        address.setAddressLine1(line1);
+        address.setAddressLine2(line2);
+        address.setAttentionTo(param(request, prefix + "Attention"));
+        address.setCity(param(request, prefix + "City"));
+        address.setState(param(request, prefix + "State"));
+        address.setZipCode(param(request, prefix + "Zip"));
+        address.setCounty(param(request, prefix + "County"));
+        return address;
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -279,6 +279,26 @@ public abstract class BaseFormBinder implements FormBinder {
         attr(mv, "county", address.getCounty());
     }
 
+    protected void attr(
+            Map<String, Object> mv,
+            String prefix,
+            AddressType address
+    ) {
+        String line1 = address.getAddressLine1();
+        String line2 = address.getAddressLine2();
+        if (Util.isBlank(line1)) {
+            line1 = line2;
+            line2 = null;
+        }
+        attr(mv, prefix + "Attention", address.getAttentionTo());
+        attr(mv, prefix + "AddressLine1", line1);
+        attr(mv, prefix + "AddressLine2", line2);
+        attr(mv, prefix + "City", address.getCity());
+        attr(mv, prefix + "State", address.getState());
+        attr(mv, prefix + "Zip", address.getZipCode());
+        attr(mv, prefix + "County", address.getCounty());
+    }
+
     /**
      * Instantiates the correct entity type based on the provider type.
      *

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -32,7 +32,6 @@ import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.ProviderEnrollmentService;
-import gov.medicaid.services.util.Util;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -265,14 +264,8 @@ public abstract class BaseFormBinder implements FormBinder {
      * @param address the address to add
      */
     protected void attr(Map<String, Object> mv, AddressType address) {
-        String line1 = address.getAddressLine1();
-        String line2 = address.getAddressLine2();
-        if (Util.isBlank(line1)) {
-            line1 = line2;
-            line2 = null;
-        }
-        attr(mv, "addressLine1", line1);
-        attr(mv, "addressLine2", line2);
+        attr(mv, "addressLine1", address.getAddressLine1());
+        attr(mv, "addressLine2", address.getAddressLine2());
         attr(mv, "city", address.getCity());
         attr(mv, "state", address.getState());
         attr(mv, "zip", address.getZipCode());
@@ -284,15 +277,9 @@ public abstract class BaseFormBinder implements FormBinder {
             String prefix,
             AddressType address
     ) {
-        String line1 = address.getAddressLine1();
-        String line2 = address.getAddressLine2();
-        if (Util.isBlank(line1)) {
-            line1 = line2;
-            line2 = null;
-        }
         attr(mv, prefix + "Attention", address.getAttentionTo());
-        attr(mv, prefix + "AddressLine1", line1);
-        attr(mv, prefix + "AddressLine2", line2);
+        attr(mv, prefix + "AddressLine1", address.getAddressLine1());
+        attr(mv, prefix + "AddressLine2", address.getAddressLine2());
         attr(mv, prefix + "City", address.getCity());
         attr(mv, prefix + "State", address.getState());
         attr(mv, prefix + "Zip", address.getZipCode());
@@ -300,14 +287,8 @@ public abstract class BaseFormBinder implements FormBinder {
     }
 
     protected void attr(Map<String, Object> mv, int i, AddressType address) {
-        String line1 = address.getAddressLine1();
-        String line2 = address.getAddressLine2();
-        if (Util.isBlank(line1)) {
-            line1 = line2;
-            line2 = null;
-        }
-        attr(mv, "addressLine1", i, line1);
-        attr(mv, "addressLine2", i, line2);
+        attr(mv, "addressLine1", i, address.getAddressLine1());
+        attr(mv, "addressLine2", i, address.getAddressLine2());
         attr(mv, "city", i, address.getCity());
         attr(mv, "state", i, address.getState());
         attr(mv, "zip", i, address.getZipCode());
@@ -526,14 +507,8 @@ public abstract class BaseFormBinder implements FormBinder {
      */
     protected AddressType readPrimaryAddress(HttpServletRequest request) {
         AddressType address = new AddressType();
-        String line1 = param(request, "addressLine1");
-        String line2 = param(request, "addressLine2");
-        if (Util.isBlank(line2)) { // prioritize line 2 usage
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
+        address.setAddressLine1(param(request, "addressLine1"));
+        address.setAddressLine2(param(request, "addressLine2"));
         address.setCity(param(request, "city"));
         address.setState(param(request, "state"));
         address.setZipCode(param(request, "zip"));
@@ -546,14 +521,8 @@ public abstract class BaseFormBinder implements FormBinder {
             String prefix
     ) {
         AddressType address = new AddressType();
-        String line1 = param(request, prefix + "AddressLine1");
-        String line2 = param(request, prefix + "AddressLine2");
-        if (Util.isBlank(line2)) { // prioritize line 2 usage
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
+        address.setAddressLine1(param(request, prefix + "AddressLine1"));
+        address.setAddressLine2(param(request, prefix + "AddressLine2"));
         address.setAttentionTo(param(request, prefix + "Attention"));
         address.setCity(param(request, prefix + "City"));
         address.setState(param(request, prefix + "State"));
@@ -567,14 +536,8 @@ public abstract class BaseFormBinder implements FormBinder {
             int index
     ) {
         AddressType address = new AddressType();
-        String line1 = param(request, "addressLine1", index);
-        String line2 = param(request, "addressLine2", index);
-        if (Util.isBlank(line2)) {
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
+        address.setAddressLine1(param(request, "addressLine1", index));
+        address.setAddressLine2(param(request, "addressLine2", index));
         address.setCity(param(request, "city", index));
         address.setState(param(request, "state", index));
         address.setZipCode(param(request, "zip", index));

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ public abstract class BaseFormBinder implements FormBinder {
     protected String name(String key) {
         return id() + key;
     }
-    
+
     /**
      * Retrieves the indexed name of the parameter.
      * @param key the base name
@@ -390,7 +390,7 @@ public abstract class BaseFormBinder implements FormBinder {
         error.setMessage(message);
         return error;
     }
-    
+
     /**
      * Creates an error for the given fields.
      *
@@ -449,14 +449,14 @@ public abstract class BaseFormBinder implements FormBinder {
         }
         return mapping;
     }
-    
+
     /**
      * Empty implementation by default.
      *
      * @param enrollment the enrollment to be rendered
      * @param document the PDF document to render on
      * @param model the view model
-     * @throws DocumentException 
+     * @throws DocumentException
      */
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model) throws DocumentException {
     }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -546,4 +546,24 @@ public abstract class BaseFormBinder implements FormBinder {
         address.setCounty(param(request, prefix + "County"));
         return address;
     }
+
+    AddressType readIndexedAddress(
+            HttpServletRequest request,
+            int index
+    ) {
+        AddressType address = new AddressType();
+        String line1 = param(request, "addressLine1", index);
+        String line2 = param(request, "addressLine2", index);
+        if (Util.isBlank(line2)) {
+            line2 = line1;
+            line1 = null;
+        }
+        address.setAddressLine1(line1);
+        address.setAddressLine2(line2);
+        address.setCity(param(request, "city", index));
+        address.setState(param(request, "state", index));
+        address.setZipCode(param(request, "zip", index));
+        address.setCounty(param(request, "county", index));
+        return address;
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -257,6 +257,28 @@ public abstract class BaseFormBinder implements FormBinder {
         mv.put(name(key), values);
     }
 
+
+    /**
+     * Adds an address to the model.
+     *
+     * @param mv the model and view to add to
+     * @param address the address to add
+     */
+    protected void attr(Map<String, Object> mv, AddressType address) {
+        String line1 = address.getAddressLine1();
+        String line2 = address.getAddressLine2();
+        if (Util.isBlank(line1)) {
+            line1 = line2;
+            line2 = null;
+        }
+        attr(mv, "addressLine1", line1);
+        attr(mv, "addressLine2", line2);
+        attr(mv, "city", address.getCity());
+        attr(mv, "state", address.getState());
+        attr(mv, "zip", address.getZipCode());
+        attr(mv, "county", address.getCounty());
+    }
+
     /**
      * Instantiates the correct entity type based on the provider type.
      *

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class BinderUtils {
         } catch (ParseException e) {
             throw new BinderException("Could not covert value to a valid date: " + parameter);
         }
-        
+
         if (!parameter.equals(df.format(cal.getTime()))) {
             throw new BinderException("Could not covert value to a valid date: " + parameter);
         }
@@ -143,7 +143,7 @@ public class BinderUtils {
             return 0;
         }
     }
-    
+
     /**
      * Retrieves the given object as double.
      *
@@ -154,7 +154,7 @@ public class BinderUtils {
         if (objectId == null) {
             return 0;
         }
-        
+
         try {
             return Double.parseDouble(objectId);
         } catch (NumberFormatException e) {
@@ -411,7 +411,7 @@ public class BinderUtils {
             }
         }
     }
-    
+
     /**
      * Unbinds uploaded files from this request.
      *
@@ -452,17 +452,15 @@ public class BinderUtils {
         if (ssn == null) {
             return null;
         }
-        
+
         StringBuilder sb = new StringBuilder(ssn);
         if (sb.length() > 3) {
             sb.insert(3, '-');
         }
-        
+
         if (sb.length() > 6) {
             sb.insert(6, '-');
         }
         return sb.toString();
     }
-    
-    
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class CLIAFormBinder extends BaseFormBinder {
         List<CLIACertificateType> licenseList = new ArrayList<CLIACertificateType>(licenseInfo.getCLIACertificate());
         licenseInfo.getCLIACertificate().clear();
 
-        
+
         // bind licenses
         int i = 0;
         Set<String> linkedAttachments = new HashSet<String>();
@@ -116,7 +116,7 @@ public class CLIAFormBinder extends BaseFormBinder {
                 }
             }
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -198,7 +198,7 @@ public class CLIAFormBinder extends BaseFormBinder {
 
         return errors.isEmpty() ? NO_ERRORS : errors;
     }
-    
+
     /**
      * Resolves the specific license that is causing the error from the license list.
      * @param ruleError the error to resolve

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -68,12 +68,12 @@ public class CMHRTContractFormBinder extends BaseFormBinder {
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         CountyContractType countyInfo = new CountyContractType();
         credentials.setContractWithCounty(countyInfo);
-        
+
         String attachmentId = (String) request.getAttribute(NAMESPACE + "countyContract");
         if (attachmentId != null) {
             replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, CONTRACT_WITH_COUNTY);
         }
-        
+
         AttachedDocumentsType attachments = XMLUtility.nsGetAttachments(provider);
         List<DocumentType> attachment = attachments.getAttachment();
         for (DocumentType doc : attachment) {
@@ -82,7 +82,7 @@ public class CMHRTContractFormBinder extends BaseFormBinder {
                 break;
             }
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -116,7 +116,7 @@ public class CMHRTContractFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -141,7 +141,7 @@ public class CMHRTContractFormBinder extends BaseFormBinder {
                 if (path == null) {
                     continue;
                 }
-                
+
                 if (path.equals("/ProviderInformation/FacilityCredentials/ContractWithCounty/contractAttachmentObjectId")) {
                     errors.add(createError("countyContract", ruleError.getMessage()));
                 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -71,14 +71,14 @@ public class CTCCFormBinder extends BaseFormBinder {
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.COMMUNITY_HEALTH_BOARD_DHS_CONTRACT.value());
         }
-        
+
         FacilityCredentialsType creds = XMLUtility.nsGetFacilityCredentials(enrollment);
         if (param(request, "chbIndicator") != null) {
             creds.setCommunityHealthBoard("Y");
         } else {
             creds.setCommunityHealthBoard("N");
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -92,7 +92,7 @@ public class CTCCFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -112,11 +112,11 @@ public class CTCCFormBinder extends BaseFormBinder {
                 attr(mv, "dhsContract", doc.getObjectId());
             }
         }
-        
+
         FacilityCredentialsType creds = XMLUtility.nsGetFacilityCredentials(enrollment);
         attr(mv, "chbIndicator", creds.getCommunityHealthBoard());
     }
-    
+
     /**
      * Captures the error messages related to the form.
      * @param enrollment the enrollment that was validated

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -66,14 +66,14 @@ public class FacilityCapacityFormBinder extends BaseFormBinder {
         if (StringUtils.isNumeric(beds)) {
             creds.setNumberOfBeds((int) BinderUtils.getAsLong(beds));
         }
-        
+
         try {
             creds.setNumberOfBedsEffectiveDate(BinderUtils.getAsCalendar(param(request, "effectiveDate")));
         } catch (BinderException e) {
             e.setAttribute(name("effectiveDate"), param(request, "effectiveDate"));
             exceptions.add(e);
         }
-        
+
         return exceptions;
     }
 
@@ -113,7 +113,7 @@ public class FacilityCapacityFormBinder extends BaseFormBinder {
                 if (path == null) {
                     continue;
                 }
-                
+
                 if (path.equals("/ProviderInformation/FacilityCredentials/NumberOfBeds")) {
                     errors.add(createError("numberOfBeds", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/FacilityCredentials/NumberOfBedsEffectiveDate")) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class FacilityContractsFormBinder extends BaseFormBinder {
     private static final String[] ALL_CONTRACTS = new String[] {"Adult Rehabilitative Mental Health Services",
         "Children's Therapeutic Services and Supports (CTSS)", "Adult Crisis Response Services - Crisis Assessment & Crisis Intervention",
         "Adult Crisis Response Services - Crisis Stabilization", "Adult Crisis Response Services - Short-Term Residential",};
-    
+
     /**
      * Creates a new binder.
      */
@@ -98,14 +98,14 @@ public class FacilityContractsFormBinder extends BaseFormBinder {
                     e.setAttribute(name("beginDate", i), param(request, "beginDate", i));
                     exceptions.add(e);
                 }
-                
+
                 try {
                     contract.setEndDate(BinderUtils.getAsCalendar(param(request, "endDate", i)));
                 } catch (BinderException e) {
                     e.setAttribute(name("endDate", i), param(request, "endDate", i));
                     exceptions.add(e);
                 }
-    
+
                 String attachmentId = (String) request.getAttribute(name("attachment", i));
                 if (attachmentId == null) { // not uploaded check for old value
                     attachmentId = param(request, "attachmentId", i);
@@ -206,7 +206,7 @@ public class FacilityContractsFormBinder extends BaseFormBinder {
                 if (path.equals("/ProviderInformation/FacilityCredentials/SignedContract")) {
                     errors.add(createError("signedContracts", ruleError.getMessage()));
                 } else if (path.startsWith(LICENSE_PATH)) {
-                    
+
                     FormError error = resolveFieldError(ruleError, indexMap);
                     if (error != null) {
                         errors.add(error);
@@ -244,7 +244,7 @@ public class FacilityContractsFormBinder extends BaseFormBinder {
                 }
                 i++;
             }
-            
+
         }
         return m;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class FacilityEligibilityFormBinder extends BaseFormBinder {
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
         FacilityCredentialsType creds = XMLUtility.nsGetFacilityCredentials(enrollment);
         creds.setPhysicalAndOccupationTherapyServices(param(request, "therapyIndicator"));
-        
+
         creds.setTitle18NumberOfBeds((int) BinderUtils.getAsLong(param(request, "title18BedCount")));
         creds.setTitle19NumberOfBeds((int) BinderUtils.getAsLong(param(request, "title19BedCount")));
         creds.setDualCertifiedNumberOfBeds((int) BinderUtils.getAsLong(param(request, "dualCertBedCount")));
@@ -72,7 +72,7 @@ public class FacilityEligibilityFormBinder extends BaseFormBinder {
 
         return Collections.EMPTY_LIST;
     }
-    
+
     /**
      * Binds the model to the request attributes.
      * @param enrollment the model to bind from
@@ -88,7 +88,7 @@ public class FacilityEligibilityFormBinder extends BaseFormBinder {
         attr(mv, "dualCertBedCount", creds.getDualCertifiedNumberOfBeds());
         attr(mv, "icfBedCount", creds.getICFNumberOfBeds());
     }
-    
+
     /**
      * Captures the error messages related to the form.
      * @param enrollment the enrollment that was validated
@@ -128,14 +128,14 @@ public class FacilityEligibilityFormBinder extends BaseFormBinder {
      *
      * @param enrollment the front end model
      * @param ticket the persistent model
-     * @throws PortalServiceException 
+     * @throws PortalServiceException
      */
     public void bindToHibernate(EnrollmentType enrollment, Enrollment ticket) throws PortalServiceException {
         ProviderProfile profile = ticket.getDetails();
         if (profile == null || !(profile.getEntity() instanceof Organization)) {
             throw new PortalServiceException("Provider type should be bound first.");
         }
-        
+
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         profile.setPhysicalAndOccupationalTherapyInd(credentials.getPhysicalAndOccupationTherapyServices());
         profile.setTitle18NumberOfBeds(credentials.getTitle18NumberOfBeds());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -76,22 +76,22 @@ public class FederalQualificationFormBinder extends BaseFormBinder {
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.APPROVAL_LETTER_FROM_HEALTH_CARE_FINANCE_ADMINISTRATION_HCFA.value());
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "grantDocuments");
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.COPIES_OF_THE_330_GRANT_DOCUMENTS.value());
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "statusContract");
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.COVER_PAGE_OF_PUBLIC_LAW_93_638_STATUS_CONTRACT.value());
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "indianHealthServiceContract");
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.COMPACT_WITH_THE_INDIAN_HEALTH_SERVICE.value());
         }
-        
+
         if (DocumentNames.APPROVAL_LETTER_FROM_HEALTH_CARE_FINANCE_ADMINISTRATION_HCFA.value().equals(creds.getFederalQualificationType())) {
             deleteAttachment(attachments, DocumentNames.COPIES_OF_THE_330_GRANT_DOCUMENTS.value());
             deleteAttachment(attachments, DocumentNames.COVER_PAGE_OF_PUBLIC_LAW_93_638_STATUS_CONTRACT.value());
@@ -109,10 +109,10 @@ public class FederalQualificationFormBinder extends BaseFormBinder {
             deleteAttachment(attachments, DocumentNames.COPIES_OF_THE_330_GRANT_DOCUMENTS.value());
             deleteAttachment(attachments, DocumentNames.COVER_PAGE_OF_PUBLIC_LAW_93_638_STATUS_CONTRACT.value());
         }
-        
+
         return Collections.EMPTY_LIST;
     }
-    
+
     private void deleteAttachment(AttachedDocumentsType attachments2, String name) {
         List<DocumentType> attachments = attachments2.getAttachment();
         if (attachments != null) {
@@ -137,7 +137,7 @@ public class FederalQualificationFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -152,7 +152,7 @@ public class FederalQualificationFormBinder extends BaseFormBinder {
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         AttachedDocumentsType attachments = XMLUtility.nsGetAttachments(provider);
         List<DocumentType> attachment = attachments.getAttachment();
-        
+
         FacilityCredentialsType creds = XMLUtility.nsGetFacilityCredentials(enrollment);
         attr(mv, "qualificationType", creds.getFederalQualificationType());
 
@@ -168,7 +168,7 @@ public class FederalQualificationFormBinder extends BaseFormBinder {
             }
         }
     }
-    
+
     /**
      * Captures the error messages related to the form.
      * @param enrollment the enrollment that was validated
@@ -225,14 +225,14 @@ public class FederalQualificationFormBinder extends BaseFormBinder {
      *
      * @param enrollment the front end model
      * @param ticket the persistent model
-     * @throws PortalServiceException 
+     * @throws PortalServiceException
      */
     public void bindToHibernate(EnrollmentType enrollment, Enrollment ticket) throws PortalServiceException {
         ProviderProfile profile = ticket.getDetails();
         if (profile == null || !(profile.getEntity() instanceof Organization)) {
             throw new PortalServiceException("Provider type should be bound first.");
         }
-        
+
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         Organization org = (Organization) profile.getEntity();
         org.setProviderSubType(credentials.getFederalQualificationType());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -84,14 +84,14 @@ public interface FormBinder {
      */
     public void bindFromHibernate(Enrollment ticket, EnrollmentType enrollment);
 
-    
+
     /**
      * Renders the PDF representation of the form.
      *
      * @param enrollment the enrollment to be rendered
      * @param document the PDF document to render on
      * @param model the view model
-     * @throws DocumentException if the document could not be written 
+     * @throws DocumentException if the document could not be written
      */
     void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model) throws DocumentException;
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public class HighestDegreeFormBinder extends BaseFormBinder {
             e.setAttribute(name("degreeAwardDate"), param(request, "degreeAwardDate"));
             exceptions.add(e);
         }
-        
+
         String attachmentId = (String) request.getAttribute(id() + "copyOfHighestDegree");
         if (Util.isNotBlank(attachmentId)) { // set the document name properly
             AttachedDocumentsType attachments = XMLUtility.nsGetAttachments(provider);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
@@ -124,19 +124,7 @@ public class IndividualPCAInfoFormBinder extends BaseFormBinder implements FormB
 
         ContactInformationType contact = XMLUtility.nsGetContactInformation(individual);
         if (contact.getAddress() != null) {
-            AddressType address = contact.getAddress();
-            String line1 = address.getAddressLine1();
-            String line2 = address.getAddressLine2();
-            if (Util.isBlank(line1)) {
-                line1 = line2;
-                line2 = null;
-            }
-            attr(mv, "addressLine1", line1);
-            attr(mv, "addressLine2", line2);
-            attr(mv, "city", address.getCity());
-            attr(mv, "state", address.getState());
-            attr(mv, "zip", address.getZipCode());
-            attr(mv, "county", address.getCounty());
+            attr(mv, contact.getAddress());
         }
 
         String[] phone = BinderUtils.splitPhone(contact.getPhoneNumber());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -69,12 +69,12 @@ public class IndividualPCAInfoFormBinder extends BaseFormBinder implements FormB
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
         List<BinderException> exceptions = new ArrayList<BinderException>();
-        
+
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         IndividualApplicantType individual = XMLUtility.nsGetIndividual(enrollment);
         individual.setLastName(param(request, "lastName"));
@@ -99,7 +99,7 @@ public class IndividualPCAInfoFormBinder extends BaseFormBinder implements FormB
         // reinstatement UMPI
         provider.setNPI(param(request, "umpi"));
         provider.setEighteenAndAbove(param(request, "adultInd"));
-        
+
         return exceptions;
     }
 
@@ -158,7 +158,7 @@ public class IndividualPCAInfoFormBinder extends BaseFormBinder implements FormB
 
         List<StatusMessageType> ruleErrors = messages.getStatusMessage();
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
-        
+
         IndividualApplicantType individual = XMLUtility.nsGetIndividual(enrollment);
         ContactInformationType contact = XMLUtility.nsGetContactInformation(individual);
         boolean switchAddressLines = false;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
@@ -31,7 +31,6 @@ import gov.medicaid.entities.Person;
 import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.services.PortalServiceException;
-import gov.medicaid.services.util.Util;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -147,13 +146,6 @@ public class IndividualPCAInfoFormBinder extends BaseFormBinder implements FormB
         List<StatusMessageType> ruleErrors = messages.getStatusMessage();
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
 
-        IndividualApplicantType individual = XMLUtility.nsGetIndividual(enrollment);
-        ContactInformationType contact = XMLUtility.nsGetContactInformation(individual);
-        boolean switchAddressLines = false;
-        if (contact.getAddress() == null || Util.isBlank(contact.getAddress().getAddressLine1())) {
-            switchAddressLines = true;;
-        }
-
         synchronized (ruleErrors) {
             for (StatusMessageType ruleError : ruleErrors) {
                 int count = errors.size();
@@ -180,9 +172,9 @@ public class IndividualPCAInfoFormBinder extends BaseFormBinder implements FormB
                 } else if (path.equals(PERSONAL_INFO + "ContactInformation/Address")) {
                     errors.add(createError(new String[] {"addressLine1", "addressLine2"}, ruleError.getMessage()));
                 } else if (path.equals(PERSONAL_INFO + "ContactInformation/Address/AddressLine1")) {
-                    errors.add(createError(switchAddressLines ? "addressLine2" : "addressLine1", ruleError.getMessage()));
+                    errors.add(createError("addressLine1", ruleError.getMessage()));
                 } else if (path.equals(PERSONAL_INFO + "ContactInformation/Address/AddressLine2")) {
-                    errors.add(createError(switchAddressLines ? "addressLine1" : "addressLine2", ruleError.getMessage()));
+                    errors.add(createError("addressLine2", ruleError.getMessage()));
                 } else if (path.equals(PERSONAL_INFO + "ContactInformation/Address/City")) {
                     errors.add(createError("city", ruleError.getMessage()));
                 } else if (path.equals(PERSONAL_INFO + "ContactInformation/Address/State")) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
@@ -178,11 +178,11 @@ public class LicenseInformationFormBinder extends BaseFormBinder {
 
             List<gov.medicaid.entities.StateType> state = new ArrayList<gov.medicaid.entities.StateType>();
             if (enrollment.getProviderInformation().getProviderType().equals(gov.medicaid.domain.model.ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value())
-            		|| enrollment.getProviderInformation().getProviderType().equals(gov.medicaid.domain.model.ProviderType.PERSONAL_CARE_ASSISTANT.value())) {
-            	state = getLookupService().findRelatedLookup(
+                    || enrollment.getProviderInformation().getProviderType().equals(gov.medicaid.domain.model.ProviderType.PERSONAL_CARE_ASSISTANT.value())) {
+                state = getLookupService().findRelatedLookup(
                         gov.medicaid.entities.StateType.class, pt.getCode(), ViewStatics.REL_LICENSE_STATE_OPTIONS);
             } else {
-            	state = getLookupService().findAllLookups(gov.medicaid.entities.StateType.class);
+                state = getLookupService().findAllLookups(gov.medicaid.entities.StateType.class);
             }
             attr(mv, "licenseStates", state);
         }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import com.lowagie.text.pdf.PdfPTable;
 
 /**
  * This binder handles the organization information form.
- * 
+ *
  * @author TCSASSEMBLER
  * @version 1.0
  */
@@ -72,7 +72,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
      *            the model to bind to
      * @param request
      *            the request containing the form fields
-     * 
+     *
      * @throws BinderException
      *             if the format of the fields could not be bound properly
      */
@@ -100,9 +100,9 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
                 exceptions.add(e);
             }
             try {
-            	member.setBGSClearanceDate(BinderUtils.getAsCalendar(param(request, "bgsClearanceDate", i)));
+                member.setBGSClearanceDate(BinderUtils.getAsCalendar(param(request, "bgsClearanceDate", i)));
             } catch (BinderException e) {
-            	e.setAttribute(name("bgsClearanceDate", i), param(request, "bgsClearanceDate", i));
+                e.setAttribute(name("bgsClearanceDate", i), param(request, "bgsClearanceDate", i));
                 exceptions.add(e);
             }
             member.setBGSStudyId(param(request, "bgsStudyId", i));
@@ -144,21 +144,21 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
         }
         attr(mv, "memberSize", members.size());
         if (enrollment.getProviderInformation().getProviderType().equals(gov.medicaid.domain.model.ProviderType.PHARMACY.value())) {
-        	mv.put("onlyPharmacist", true);
+            mv.put("onlyPharmacist", true);
         } else {
-        	mv.put("individualMemberProviderTypes", sortCollection(getLookupService().getProviderTypes(ApplicantType.INDIVIDUAL)));
+            mv.put("individualMemberProviderTypes", sortCollection(getLookupService().getProviderTypes(ApplicantType.INDIVIDUAL)));
         }
-        
+
     }
 
     /**
      * Translates the validation results to form error messages where applicable.
-     * 
+     *
      * @param enrollment
      *            the enrollment that was validated
      * @param messages
      *            the error messages
-     * 
+     *
      * @return the list of errors related to this form
      */
     protected List<FormError> selectErrors(EnrollmentType enrollment, StatusMessagesType messages) {
@@ -195,7 +195,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
 
     /**
      * Resolves the specific license that is causing the error from the license list.
-     * 
+     *
      * @param ruleError
      *            the error to resolve
      * @return the resolved error
@@ -220,9 +220,9 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
             } else if (path.endsWith("SocialSecurityNumber")) {
                 return createError("ssn", index, message);
             } else if (path.endsWith("BGSClearanceDate")) {
-            	return createError("bgsClearanceDate", index, message);
+                return createError("bgsClearanceDate", index, message);
             } else if (path.endsWith("BGSStudyId")) {
-            	return createError("bgsStudyId", index, message);
+                return createError("bgsStudyId", index, message);
             }
         }
 
@@ -232,7 +232,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
 
     /**
      * Resolves the index of the field that caused the error.
-     * 
+     *
      * @param path
      *            the field path
      * @return the index of the field, null if cannot be resolved
@@ -247,7 +247,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
 
     /**
      * Binds the fields of the form to the persistence model.
-     * 
+     *
      * @param enrollment
      *            the front end model
      * @param ticket
@@ -290,7 +290,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
 
     /**
      * Retrieves the primary affiliation, null if not found.
-     * 
+     *
      * @param groups
      *            all affiliations
      * @return the one with PRIMARY=Y
@@ -309,7 +309,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
 
     /**
      * Binds the fields of the persistence model to the front end xml.
-     * 
+     *
      * @param ticket
      *            the persistent model
      * @param enrollment
@@ -374,7 +374,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
 
     /**
      * Sorts the displayed provider types (PESP-252_
-     * 
+     *
      * @param providerTypes
      *            the provider types to sort
      * @return the sorted types
@@ -389,5 +389,4 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
         });
         return sortedList;
     }
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class NonProfitCorporationFormBinder extends BaseFormBinder {
         if (attachmentId != null) {
             replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, DocumentNames.ARTICLES_OF_INCORPORATION.value());
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -102,7 +102,7 @@ public class NonProfitCorporationFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -127,7 +127,7 @@ public class NonProfitCorporationFormBinder extends BaseFormBinder {
                 if (path == null) {
                     continue;
                 }
-                
+
                 if (path.equals("/ProviderInformation/AttachedDocuments/Document[name=\"Articles of Incorporation\"]")) {
                     errors.add(createError("articlesOfIncorporation", ruleError.getMessage()));
                 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -59,17 +59,17 @@ public class OrganizationDisclosureFormBinder extends BaseFormBinder {
      * Disclosure Path.
      */
     private static final String QUESTION_3 = "/ProviderInformation/HasPreviousExclusion";
-    
+
     /**
      * Disclosure Path.
      */
     private static final String QUESTION_4 = "/ProviderInformation/EmployeeHasCriminalConviction";
-    
+
     /**
      * Disclosure Path.
      */
     private static final String QUESTION_5 = "/ProviderInformation/EmployeeHasCivilPenalty";
-    
+
     /**
      * Disclosure Path.
      */
@@ -113,9 +113,9 @@ public class OrganizationDisclosureFormBinder extends BaseFormBinder {
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         // for renewal the form should be blank
         if (enrollment.getRequestType() == RequestType.RENEWAL && provider.getRenewalShowBlankStatement() == null) {
-        	attr(mv, "renewalBlankInit", "Y");
+            attr(mv, "renewalBlankInit", "Y");
         } else {
-        	attr(mv, "criminalConvictionInd", provider.getHasCriminalConviction());
+            attr(mv, "criminalConvictionInd", provider.getHasCriminalConviction());
             attr(mv, "civilPenaltyInd", provider.getHasCivilPenalty());
             attr(mv, "previousExclusionInd", provider.getHasPreviousExclusion());
             attr(mv, "empCriminalConvictionInd", provider.getEmployeeHasCriminalConviction());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -180,19 +180,7 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
         attr(mv, "subType", org.getSubType());
         ContactInformationType contact = XMLUtility.nsGetContactInformation(org);
         if (contact.getAddress() != null) {
-            AddressType address = contact.getAddress();
-            String line1 = address.getAddressLine1();
-            String line2 = address.getAddressLine2();
-            if (Util.isBlank(line1)) {
-                line1 = line2;
-                line2 = null;
-            }
-            attr(mv, "addressLine1", line1);
-            attr(mv, "addressLine2", line2);
-            attr(mv, "city", address.getCity());
-            attr(mv, "state", address.getState());
-            attr(mv, "zip", address.getZipCode());
-            attr(mv, "county", address.getCounty());
+            attr(mv, contact.getAddress());
         }
 
         String[] phone = BinderUtils.splitPhone(contact.getPhoneNumber());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -255,14 +255,6 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
 
         OrganizationApplicantType org = XMLUtility.nsGetOrganization(enrollment);
-        AlternateAddressesType alternateAddresses = enrollment.getProviderInformation().getAlternateAddresses();
-
-        boolean switchAddressLineFields = false;
-        ContactInformationType contact = XMLUtility.nsGetContactInformation(org);
-        AddressType addressType = contact.getAddress();
-        if (addressType == null || Util.isBlank(addressType.getAddressLine1())) {
-            switchAddressLineFields = true;
-        }
 
         synchronized (ruleErrors) {
             for (StatusMessageType ruleError : ruleErrors) {
@@ -289,9 +281,9 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/Name")) {
                     errors.add(createError("name", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address/AddressLine1")) {
-                    errors.add(createError(switchAddressLineFields? "addressLine2" : "addressLine1", ruleError.getMessage()));
+                    errors.add(createError("addressLine1", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address/AddressLine2")) {
-                    errors.add(createError(switchAddressLineFields? "addressLine1" : "addressLine2", ruleError.getMessage()));
+                    errors.add(createError("addressLine2", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address/City")) {
                     errors.add(createError("city", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/Address/State")) {
@@ -315,12 +307,12 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
                     if (addressIndex != null) {
                         if (org.getTen99AddressIndex() != null) {
                             if (org.getTen99AddressIndex() - 1 == addressIndex) {
-                                errors.add(resolveAddressFieldError(alternateAddresses.getAddress().get(addressIndex), "ten99", path, ruleError));
+                                errors.add(resolveAddressFieldError("ten99", path, ruleError));
                             }
                         }
                         if (org.getBillingAddressIndex() != null) {
                             if (org.getBillingAddressIndex() - 1 == addressIndex) {
-                                errors.add(resolveAddressFieldError(alternateAddresses.getAddress().get(addressIndex), "billing", path, ruleError));
+                                errors.add(resolveAddressFieldError("billing", path, ruleError));
                             }
                         }
                     }
@@ -338,15 +330,15 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
         return errors.isEmpty() ? NO_ERRORS : errors;
     }
 
-    private FormError resolveAddressFieldError(AddressType addressType, String prefix, String path, StatusMessageType ruleError) {
-        boolean switchAddressLineFields = false;
-        if (addressType == null || Util.isBlank(addressType.getAddressLine1())) {
-            switchAddressLineFields = true;
-        }
+    private FormError resolveAddressFieldError(
+            String prefix,
+            String path,
+            StatusMessageType ruleError
+    ) {
         if (path.endsWith("/AddressLine1")) {
-            return createError(switchAddressLineFields ? prefix + "AddressLine2" : prefix + "AddressLine1", ruleError.getMessage());
+            return createError(prefix + "AddressLine1", ruleError.getMessage());
         } else if (path.endsWith("/AddressLine2")) {
-            return createError(switchAddressLineFields ? prefix + "AddressLine1" : prefix + "AddressLine2", ruleError.getMessage());
+            return createError(prefix + "AddressLine2", ruleError.getMessage());
         } else if (path.endsWith("/City")) {
             return createError(prefix + "City", ruleError.getMessage());
         } else if (path.endsWith("/State")) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -646,21 +646,7 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
      * @return the bound address
      */
     private AddressType readBillingAddress(HttpServletRequest request) {
-        AddressType address = new AddressType();
-        String line1 = param(request, "billingAddressLine1");
-        String line2 = param(request, "billingAddressLine2");
-        if (Util.isBlank(line2)) { // prioritize line 2 usage
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
-        address.setAttentionTo(param(request, "billingAttention"));
-        address.setCity(param(request, "billingCity"));
-        address.setState(param(request, "billingState"));
-        address.setZipCode(param(request, "billingZip"));
-        address.setCounty(param(request, "billingCounty"));
-        return address;
+        return readPrefixedAddress(request, "billing");
     }
 
     /**
@@ -670,21 +656,6 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
      * @return the bound address
      */
     private AddressType readTen99Address(HttpServletRequest request) {
-        AddressType address = new AddressType();
-        String line1 = param(request, "ten99AddressLine1");
-        String line2 = param(request, "ten99AddressLine2");
-        if (Util.isBlank(line2)) { // prioritize line 2 usage
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
-        address.setAttentionTo(param(request, "ten99Attention"));
-        address.setCity(param(request, "ten99City"));
-        address.setState(param(request, "ten99State"));
-        address.setZipCode(param(request, "ten99Zip"));
-        address.setCounty(param(request, "ten99County"));
-        return address;
+        return readPrefixedAddress(request, "ten99");
     }
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -204,19 +204,7 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
                 if (org.getBillingAddressIndex() != null) {
                     if (alternateAddresses.getAddress().size() >= org.getBillingAddressIndex()) {
                         AddressType billingAddress = alternateAddresses.getAddress().get(org.getBillingAddressIndex() - 1);
-                        String line1 = billingAddress.getAddressLine1();
-                        String line2 = billingAddress.getAddressLine2();
-                        if (Util.isBlank(line1)) {
-                            line1 = line2;
-                            line2 = null;
-                        }
-                        attr(mv, "billingAttention", billingAddress.getAttentionTo());
-                        attr(mv, "billingAddressLine1", line1);
-                        attr(mv, "billingAddressLine2", line2);
-                        attr(mv, "billingCity", billingAddress.getCity());
-                        attr(mv, "billingState", billingAddress.getState());
-                        attr(mv, "billingZip", billingAddress.getZipCode());
-                        attr(mv, "billingCounty", billingAddress.getCounty());
+                        attr(mv, "billing", billingAddress);
                     }
                 }
             }
@@ -227,19 +215,7 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
                 if (org.getTen99AddressIndex() != null) {
                     if (alternateAddresses.getAddress().size() >= org.getTen99AddressIndex()) {
                         AddressType ten99Address = alternateAddresses.getAddress().get(org.getTen99AddressIndex() - 1);
-                        String line1 = ten99Address.getAddressLine1();
-                        String line2 = ten99Address.getAddressLine2();
-                        if (Util.isBlank(line1)) {
-                            line1 = line2;
-                            line2 = null;
-                        }
-                        attr(mv, "ten99Attention", ten99Address.getAttentionTo());
-                        attr(mv, "ten99AddressLine1", line1);
-                        attr(mv, "ten99AddressLine2", line2);
-                        attr(mv, "ten99City", ten99Address.getCity());
-                        attr(mv, "ten99State", ten99Address.getState());
-                        attr(mv, "ten99Zip", ten99Address.getZipCode());
-                        attr(mv, "ten99County", ten99Address.getCounty());
+                        attr(mv, "ten99", ten99Address);
                     }
                 }
             }
@@ -710,4 +686,5 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
         address.setCounty(param(request, "ten99County"));
         return address;
     }
+
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -230,18 +230,7 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
                     if (personInformation.getContactInformation() != null) {
                         AddressType homeAddress = personInformation.getContactInformation().getAddress();
                         if (homeAddress != null) {
-                            String line1 = homeAddress.getAddressLine1();
-                            String line2 = homeAddress.getAddressLine2();
-                            if (Util.isBlank(line1)) {
-                                line1 = line2;
-                                line2 = null;
-                            }
-                            attr(mv, "iboAddressLine1", personIndex, line1);
-                            attr(mv, "iboAddressLine2", personIndex, line2);
-                            attr(mv, "iboCity", personIndex, homeAddress.getCity());
-                            attr(mv, "iboState", personIndex, homeAddress.getState());
-                            attr(mv, "iboZip", personIndex, homeAddress.getZipCode());
-                            attr(mv, "iboCounty", personIndex, homeAddress.getCounty());
+                            attr(mv, "ibo", personIndex, homeAddress);
                         }
                     }
                 }
@@ -256,18 +245,7 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
 
                 AddressType otherAddress = bo.getOtherInterestAddress();
                 if (otherAddress != null) {
-                    String line1 = otherAddress.getAddressLine1();
-                    String line2 = otherAddress.getAddressLine2();
-                    if (Util.isBlank(line1)) {
-                        line1 = line2;
-                        line2 = null;
-                    }
-                    attr(mv, "iboOtherAddressLine1", personIndex, line1);
-                    attr(mv, "iboOtherAddressLine2", personIndex, line2);
-                    attr(mv, "iboOtherCity", personIndex, otherAddress.getCity());
-                    attr(mv, "iboOtherState", personIndex, otherAddress.getState());
-                    attr(mv, "iboOtherZip", personIndex, otherAddress.getZipCode());
-                    attr(mv, "iboOtherCounty", personIndex, otherAddress.getCounty());
+                    attr(mv, "iboOther", personIndex, otherAddress);
                 }
 
                 personIndex++;
@@ -287,18 +265,7 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
                     if (orgInformation.getContactInformation() != null) {
                         AddressType homeAddress = orgInformation.getContactInformation().getAddress();
                         if (homeAddress != null) {
-                            String line1 = homeAddress.getAddressLine1();
-                            String line2 = homeAddress.getAddressLine2();
-                            if (Util.isBlank(line1)) {
-                                line1 = line2;
-                                line2 = null;
-                            }
-                            attr(mv, "cboAddressLine1", corpIndex, line1);
-                            attr(mv, "cboAddressLine2", corpIndex, line2);
-                            attr(mv, "cboCity", corpIndex, homeAddress.getCity());
-                            attr(mv, "cboState", corpIndex, homeAddress.getState());
-                            attr(mv, "cboZip", corpIndex, homeAddress.getZipCode());
-                            attr(mv, "cboCounty", corpIndex, homeAddress.getCounty());
+                            attr(mv, "cbo", corpIndex, homeAddress);
                         }
                     }
                 }
@@ -311,18 +278,7 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
 
                 AddressType otherAddress = bo.getOtherInterestAddress();
                 if (otherAddress != null) {
-                    String line1 = otherAddress.getAddressLine1();
-                    String line2 = otherAddress.getAddressLine2();
-                    if (Util.isBlank(line1)) {
-                        line1 = line2;
-                        line2 = null;
-                    }
-                    attr(mv, "cboOtherAddressLine1", personIndex, line1);
-                    attr(mv, "cboOtherAddressLine2", personIndex, line2);
-                    attr(mv, "cboOtherCity", corpIndex, otherAddress.getCity());
-                    attr(mv, "cboOtherState", corpIndex, otherAddress.getState());
-                    attr(mv, "cboOtherZip", corpIndex, otherAddress.getZipCode());
-                    attr(mv, "cboOtherCounty", corpIndex, otherAddress.getCounty());
+                    attr(mv, "cboOther", personIndex, otherAddress);
                 }
 
                 corpIndex++;
@@ -340,6 +296,26 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
             mv.put("entityStructureTypes", getLookupService().findAllLookups(EntityStructureType.class));
             mv.put("relationshipTypes", getLookupService().findAllLookups(RelationshipType.class));
         }
+    }
+
+    private void attr(
+            Map<String, Object> mv,
+            String prefix,
+            int index,
+            AddressType address
+    ) {
+        String line1 = address.getAddressLine1();
+        String line2 = address.getAddressLine2();
+        if (Util.isBlank(line1)) {
+            line1 = line2;
+            line2 = null;
+        }
+        attr(mv, prefix + "AddressLine1", index, line1);
+        attr(mv, prefix + "AddressLine2", index, line2);
+        attr(mv, prefix + "City", index, address.getCity());
+        attr(mv, prefix + "State", index, address.getState());
+        attr(mv, prefix + "Zip", index, address.getZipCode());
+        attr(mv, prefix + "County", index, address.getCounty());
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -178,7 +178,7 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
         AddressType address = new AddressType();
         String line1 = param(request, prefix + "AddressLine1", i);
         String line2 = param(request, prefix +  "AddressLine2", i);
-        
+
         if (Util.isBlank(line2)) { // prioritize line 2 usage
             line2 = line1;
             line1 = null;
@@ -354,7 +354,7 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
 
         List<StatusMessageType> ruleErrors = messages.getStatusMessage();
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
-        
+
         OwnershipInformationType ownershipInformation = XMLUtility.nsGetOwnershipInformation(enrollment);
         synchronized (ruleErrors) {
             for (StatusMessageType ruleError : ruleErrors) {
@@ -396,7 +396,7 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
 
     /**
      * Resolves the specific license that is causing the error from the license list.
-     * @param ownershipInformation 
+     * @param ownershipInformation
      * @param ruleError the error to resolve
      * @param entityIndex
      * @return the resolved error
@@ -405,17 +405,17 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
         String path = ruleError.getRelatedElementPath();
         Integer index = resolveIndex(path);
         boolean entity = false;
-        
+
         boolean switch1 = false;
         boolean switch2 = false;
         if (index != null) {
             BeneficialOwnerType owner = ownershipInformation.getBeneficialOwner().get(index);
-            
+
             if (index >= entityIndex) {
                 index = index - entityIndex;
                 entity = true;
             }
-            
+
             if (entity) {
                 if (owner.getEntityInformation() != null) {
                     ContactInformationType contact = owner.getEntityInformation().getContactInformation();
@@ -667,7 +667,5 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
     @Override
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model)
         throws DocumentException {
-        
-        
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
         if (billingContact != null) {
             provider.getDesignatedContactInformation().getDesignatedContact().remove(billingContact);
         }
-        
+
         billingContact = new gov.medicaid.domain.model.DesignatedContactType();
         billingContact.setFullName(param(request, "billingContactName"));
         billingContact.setPrefix(param(request, "billingContactTitle"));
@@ -88,7 +88,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
             e.setAttribute(name("billingContactDOB"), param(request, "billingContactDOB"));
             exceptions.add(e);
         }
-        
+
         if (provider.getDesignatedContactInformation() == null) {
             provider.setDesignatedContactInformation(new DesignatedContactInformationType());
         }
@@ -110,7 +110,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
         if (contacts == null) {
             return null;
         }
-        
+
         gov.medicaid.domain.model.DesignatedContactType billingContact = null;
         for (gov.medicaid.domain.model.DesignatedContactType designatedContactType : contacts) {
             String type = designatedContactType.getDesignationType();
@@ -229,7 +229,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
             }
 
             gov.medicaid.domain.model.DesignatedContactType billingContact = findPCABillingContact(providerInfo);
-            
+
             DesignatedContact hbContact = null;
             for (Iterator<DesignatedContact> iter = designatedContacts.iterator(); iter.hasNext();) {
                 DesignatedContact designatedContact = iter.next();
@@ -237,7 +237,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
                     hbContact = designatedContact;
                 }
             }
-            
+
             if (hbContact != null) {
                 designatedContacts.remove(hbContact);
             }
@@ -247,7 +247,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
                 designatedContact.setType(DesignatedContactType.PCA_BILLING);
                 Person person = new Person();
                 designatedContact.setPerson(person);
-                
+
                 designatedContact.setHireDate(BinderUtils.toDate(billingContact.getHireDate()));
                 person.setName(billingContact.getFullName());
                 person.setPrefix(billingContact.getPrefix());
@@ -267,7 +267,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
     public void bindFromHibernate(Enrollment ticket, EnrollmentType enrollment) {
         ProviderProfile profile = ticket.getDetails();
         if (profile != null) {
-            
+
             DesignatedContact hbContact = null;
             List<DesignatedContact> designatedContacts = profile.getDesignatedContacts();
             if (designatedContacts != null) {
@@ -277,7 +277,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
                         hbContact = designatedContact;
                     }
                 }
-                
+
                 if (hbContact != null) {
                     ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
                     gov.medicaid.domain.model.DesignatedContactType billingContact = findPCABillingContact(provider);
@@ -288,7 +288,7 @@ public class PCABillingContactFormBinder extends BaseFormBinder implements FormB
                     if (provider.getDesignatedContactInformation() == null) {
                         provider.setDesignatedContactInformation(new DesignatedContactInformationType());
                     }
-                    
+
                     billingContact = new gov.medicaid.domain.model.DesignatedContactType();
                     billingContact.setFullName(hbContact.getPerson().getName());
                     billingContact.setPrefix(hbContact.getPerson().getPrefix());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -69,17 +69,17 @@ public class PCPOInsuranceFormBinder extends BaseFormBinder {
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.CERTIFICATE_OF_LIABILITY_INSURANCE.value());
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "compensationInsuranceId");
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.WORKERS_COMPENSATION_INSURANCE.value());
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "fidelityBondId");
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.FIDELITY_BOND.value());
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "suretyBondId");
         if (attachmentId != null) {
             replaceDocument(attachments, attachmentId, DocumentNames.SURETY_BOND.value());
@@ -97,7 +97,7 @@ public class PCPOInsuranceFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -124,7 +124,7 @@ public class PCPOInsuranceFormBinder extends BaseFormBinder {
             }
         }
     }
-    
+
     /**
      * Captures the error messages related to the form.
      * @param enrollment the enrollment that was validated

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     @SuppressWarnings("unchecked")
@@ -80,7 +80,7 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
             if (attachmentId != null) {
                 replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, CONTRACT_WITH_COUNTY);
             }
-            
+
             AttachedDocumentsType attachments = XMLUtility.nsGetAttachments(provider);
             List<DocumentType> attachment = attachments.getAttachment();
             for (DocumentType doc : attachment) {
@@ -121,7 +121,7 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -146,7 +146,7 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
                 if (path == null) {
                     continue;
                 }
-                
+
                 if (path.equals("/ProviderInformation/FacilityCredentials/ContractWithCounty")) {
                     errors.add(createError("countyIndicator", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/FacilityCredentials/ContractWithCounty/ContractAttachmentObjectId")) {
@@ -177,16 +177,16 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
      */
     public void bindToHibernate(EnrollmentType enrollment, Enrollment ticket) {
         ProviderProfile profile = ticket.getDetails();
-        
+
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         CountyContractType contract = credentials.getContractWithCounty();
-        
+
         if (contract == null || !"Y".equals(contract.getCountyInd())) {
             profile.setCounty(null);
         } else {
             profile.setCounty(contract.getCountyName());
         }
-        
+
         if (contract == null || "Y".equals(contract.getCountyInd())) {
             deleteAttachment(profile, CONTRACT_WITH_COUNTY);
         } else {
@@ -216,7 +216,7 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
     public void bindFromHibernate(Enrollment ticket, EnrollmentType enrollment) {
         ProviderProfile profile = ticket.getDetails();
         String county = profile.getCounty();
-        
+
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         CountyContractType countyInfo = new CountyContractType();
         credentials.setContractWithCounty(countyInfo);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class PHNFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
@@ -144,7 +144,7 @@ public class PHNFormBinder extends BaseFormBinder {
                 }
             }
         }
-        
+
         return exceptions;
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -375,10 +375,10 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
             }
         }
     }
-    
+
     /**
      * Renders this form as a PDF.
-     * 
+     *
      * @param enrollment the enrollment to be rendered
      * @param document the PDF document to render on
      * @param model the view model
@@ -389,7 +389,7 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
         if (!"Y".equals(PDFHelper.value(model, ns, "bound"))) {
             return;
         }
-        
+
         // Personal Info Section
         PdfPTable personalInfo = new PdfPTable(2);
         PDFHelper.setTableAsFullPage(personalInfo);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -52,12 +52,12 @@ public class PhysicianClinicFacilityQualificationFormBinder extends BaseFormBind
      * The namespace for this form.
      */
     public static final String NAMESPACE = "_40_";
-    
+
     /**
      * Ambulance service selection.
      */
     private final List<ServiceCategory> categories = new ArrayList<ServiceCategory>();
-    
+
     /**
      * License path.
      */
@@ -68,7 +68,7 @@ public class PhysicianClinicFacilityQualificationFormBinder extends BaseFormBind
      */
     public PhysicianClinicFacilityQualificationFormBinder() {
         super(NAMESPACE);
-        
+
         ServiceCategory cat = new ServiceCategory();
         cat.setCode("designationApproval");
         cat.setDescription("Hospital Based Clinic Designation:  approval letter from CMS");
@@ -88,7 +88,7 @@ public class PhysicianClinicFacilityQualificationFormBinder extends BaseFormBind
         FacilityCredentialsType creds = XMLUtility.nsGetFacilityCredentials(enrollment);
         AttachedDocumentsType attachments = XMLUtility.nsGetAttachments(provider);
         List<FacilityQualificationType> facilityQualification = creds.getFacilityQualification();
-        
+
         for (ServiceCategory category : categories) {
             String type1Indicator = param(request, category.getCode() + "Indicator");
             if ("Y".equals(type1Indicator)) {
@@ -104,7 +104,7 @@ public class PhysicianClinicFacilityQualificationFormBinder extends BaseFormBind
         }
         return Collections.EMPTY_LIST;
     }
-    
+
     /**
      * Finds the service with the given name
      * @param facilityQualification the service list
@@ -117,7 +117,7 @@ public class PhysicianClinicFacilityQualificationFormBinder extends BaseFormBind
                 return FacilityQualificationType;
             }
         }
-        
+
         FacilityQualificationType qualification = new FacilityQualificationType();
         qualification.setServiceType(serviceName);
         facilityQualification.add(qualification);
@@ -197,7 +197,7 @@ public class PhysicianClinicFacilityQualificationFormBinder extends BaseFormBind
 
         return errors.isEmpty() ? NO_ERRORS : errors;
     }
-    
+
     /**
      * Resolves the specific license that is causing the error from the license list.
      * @param services the services entered

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class PracticeTypeFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      */
     @SuppressWarnings("unchecked")
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
@@ -163,8 +163,8 @@ public class PracticeTypeFormBinder extends BaseFormBinder {
             pInfo.setEmployedOrContractedByGroup(profile.getEmployedOrContractedByGroup());
         }
     }
-    
-    
+
+
     @Override
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model)
         throws DocumentException {
@@ -177,7 +177,7 @@ public class PracticeTypeFormBinder extends BaseFormBinder {
             PDFHelper.addLabelValueCell(practiceInfo, "Are you employed and/or independently contracted by a group practice?",
                 PDFHelper.formatBoolean(PDFHelper.value(model, ns, "employedOrContractedByGroup")));
         }
-        
-        document.add(practiceInfo);        
+
+        document.add(practiceInfo);
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
@@ -64,7 +64,7 @@ public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
     /**
      * Binds the request to the model.
      * @param user
-     * 	          the requesting user, for user based data view control
+     *            the requesting user, for user based data view control
      * @param enrollment
      *            the model to bind to
      * @param request
@@ -74,9 +74,9 @@ public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
      *             if the format of the fields could not be bound properly
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
-    	if (!canModifyExistingPractice(user, enrollment)) {
-    		return new ArrayList<BinderException>();
-    	}
+        if (!canModifyExistingPractice(user, enrollment)) {
+            return new ArrayList<BinderException>();
+        }
         List<BinderException> exceptions = super.bindFromPage(user, enrollment, request);
         PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
@@ -114,18 +114,18 @@ public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
     /**
      * Binds the model to the request attributes.
      * @param user
-     * 	          the requesting user, for user based data update control
-	 * @param enrollment
+     *            the requesting user, for user based data update control
+     * @param enrollment
      *            the model to bind from
-	 * @param mv
+     * @param mv
      *            the model and view to bind to
-	 * @param readOnly
+     * @param readOnly
      *            true if the binding is for a read only view
      */
     public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
-    	if (!canModifyExistingPractice(user, enrollment)) {
-    		return;
-    	}
+        if (!canModifyExistingPractice(user, enrollment)) {
+            return;
+        }
         super.bindToPage(user, enrollment, mv, readOnly);
         PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
@@ -157,8 +157,6 @@ public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
         List<StatusMessageType> ruleErrors = messages.getStatusMessage();
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
 
-        PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
-
         synchronized (ruleErrors) {
             for (StatusMessageType ruleError : ruleErrors) {
                 int count = errors.size();
@@ -168,23 +166,15 @@ public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
                     continue;
                 }
 
-                boolean switchAddressLines = false;
-                if (practice.getReimbursementAddress() == null
-                        || Util.isBlank(practice.getReimbursementAddress().getAddressLine1())) {
-                    switchAddressLines = true;
-                }
-
                 if (path.equals(PRACTICE_INFO + "ReimbursementAddress")) {
                     errors.add(createError(new String[] { "reimbursementAddressLine1", "reimbursementAddressLine2" },
                             ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "EffectiveDate")) {
                     errors.add(createError("effectiveDate", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ReimbursementAddress/AddressLine1")) {
-                    errors.add(createError(switchAddressLines ? "reimbursementAddressLine2"
-                            : "reimbursementAddressLine1", ruleError.getMessage()));
+                    errors.add(createError("reimbursementAddressLine1", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ReimbursementAddress/AddressLine2")) {
-                    errors.add(createError(switchAddressLines ? "reimbursementAddressLine1"
-                            : "reimbursementAddressLine2", ruleError.getMessage()));
+                    errors.add(createError("reimbursementAddressLine2", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ReimbursementAddress/City")) {
                     errors.add(createError("reimbursementCity", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "ReimbursementAddress/State")) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
@@ -305,20 +305,6 @@ public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
      * @return the bound address
      */
     private AddressType readReimbursementAddress(HttpServletRequest request) {
-        AddressType address = new AddressType();
-        String line1 = param(request, "reimbursementAddressLine1");
-        String line2 = param(request, "reimbursementAddressLine2");
-        if (Util.isBlank(line2)) { // prioritize line 2 usage
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
-        address.setCity(param(request, "reimbursementCity"));
-        address.setState(param(request, "reimbursementState"));
-        address.setZipCode(param(request, "reimbursementZip"));
-        address.setCounty(param(request, "reimbursementCounty"));
-        return address;
+        return readPrefixedAddress(request, "reimbursement");
     }
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
@@ -135,18 +135,7 @@ public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
         if (!"Y".equals(practice.getReimbursementSameAsPrimary())) {
             AddressType reimbursementAddress = practice.getReimbursementAddress();
             if (reimbursementAddress != null) {
-                String line1 = reimbursementAddress.getAddressLine1();
-                String line2 = reimbursementAddress.getAddressLine2();
-                if (Util.isBlank(line1)) {
-                    line1 = line2;
-                    line2 = null;
-                }
-                attr(mv, "reimbursementAddressLine1", line1);
-                attr(mv, "reimbursementAddressLine2", line2);
-                attr(mv, "reimbursementCity", reimbursementAddress.getCity());
-                attr(mv, "reimbursementState", reimbursementAddress.getState());
-                attr(mv, "reimbursementZip", reimbursementAddress.getZipCode());
-                attr(mv, "reimbursementCounty", reimbursementAddress.getCounty());
+                attr(mv, "reimbursement", reimbursementAddress);
             }
         }
         attr(mv, "effectiveDate", practice.getEffectiveDate());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -162,8 +162,6 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
         List<StatusMessageType> ruleErrors = messages.getStatusMessage();
         List<StatusMessageType> caughtMessages = new ArrayList<StatusMessageType>();
 
-        PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
-
         synchronized (ruleErrors) {
             for (StatusMessageType ruleError : ruleErrors) {
                 int count = errors.size();
@@ -173,19 +171,14 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
                     continue;
                 }
 
-                boolean switchBillingAddressLines = false;
-                if (practice.getBillingAddress() == null || Util.isBlank(practice.getBillingAddress().getAddressLine1())) {
-                    switchBillingAddressLines = true;
-                }
-
                 if (path.equals(PRACTICE_INFO + "EffectiveDate")) {
                     errors.add(createError("effectiveDate", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "BillingAddress")) {
                     errors.add(createError(new String[]{"billingAddressLine1", "billingAddressLine2"}, ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "BillingAddress/AddressLine1")) {
-                    errors.add(createError(switchBillingAddressLines ? "billingAddressLine2" : "billingAddressLine1", ruleError.getMessage()));
+                    errors.add(createError("billingAddressLine1", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "BillingAddress/AddressLine2")) {
-                    errors.add(createError(switchBillingAddressLines ? "billingAddressLine1" :"billingAddressLine2", ruleError.getMessage()));
+                    errors.add(createError("billingAddressLine2", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "BillingAddress/City")) {
                     errors.add(createError("billingCity", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "BillingAddress/State")) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -330,19 +330,6 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
      * @return the bound address
      */
     private AddressType readBillingAddress(HttpServletRequest request) {
-        AddressType address = new AddressType();
-        String line1 = param(request, "billingAddressLine1");
-        String line2 = param(request, "billingAddressLine2");
-        if (Util.isBlank(line2)) { // prioritize line 2 usage
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
-        address.setCity(param(request, "billingCity"));
-        address.setState(param(request, "billingState"));
-        address.setZipCode(param(request, "billingZip"));
-        address.setCounty(param(request, "billingCounty"));
-        return address;
+        return readPrefixedAddress(request, "billing");
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -136,18 +136,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
 
             AddressType billingAddress = practice.getBillingAddress();
             if (billingAddress != null && !"Y".equals(practice.getBillingSameAsPrimary())) {
-                String line1 = billingAddress.getAddressLine1();
-                String line2 = billingAddress.getAddressLine2();
-                if (Util.isBlank(line1)) {
-                    line1 = line2;
-                    line2 = null;
-                }
-                attr(mv, "billingAddressLine1", line1);
-                attr(mv, "billingAddressLine2", line2);
-                attr(mv, "billingCity", billingAddress.getCity());
-                attr(mv, "billingState", billingAddress.getState());
-                attr(mv, "billingZip", billingAddress.getZipCode());
-                attr(mv, "billingCounty", billingAddress.getCounty());
+                attr(mv, "billing", billingAddress);
             }
 
             attr(mv, "fein", practice.getFEIN());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -70,9 +70,9 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
      * @throws BinderException if the format of the fields could not be bound properly
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
-    	if (!canModifyExistingPractice(user, enrollment)) {
-    		return new ArrayList<BinderException>();
-    	}
+        if (!canModifyExistingPractice(user, enrollment)) {
+            return new ArrayList<BinderException>();
+        }
         List<BinderException> exceptions = new ArrayList<BinderException>(super.bindFromPage(user, enrollment, request));
 
         ProviderInformationType provider = enrollment.getProviderInformation();
@@ -85,7 +85,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
                 e.setAttribute(name("effectiveDate"), param(request, "effectiveDate"));
                 exceptions.add(e);
             }
-            
+
             if (param(request, "billingSameAsPrimary") != null) {
                 practice.setBillingSameAsPrimary("Y");
                 AddressType billingAddress = readPrimaryAddress(request);
@@ -95,7 +95,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
                 AddressType billingAddress = readBillingAddress(request);
                 practice.setBillingAddress(billingAddress);
             }
-            
+
             practice.setFEIN(param(request, "fein"));
             practice.setStateTaxId(param(request, "stateTaxId"));
             practice.setFiscalYearEnd(BinderUtils.concatFiscalYearEnd(param(request, "fye1"), param(request, "fye2")));
@@ -111,7 +111,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
             practice.setEFTVendorNumber(null);
             provider.setRemittanceSequenceNumber(null);
         }
-        
+
         return exceptions;
     }
 
@@ -122,18 +122,18 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
      * @param readOnly if the view is read only
      */
     public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
-    	if (!canModifyExistingPractice(user, enrollment)) {
-    		return;
-    	}
+        if (!canModifyExistingPractice(user, enrollment)) {
+            return;
+        }
         super.bindToPage(user, enrollment, mv, readOnly);
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         PracticeInformationType practice = XMLUtility.nsGetPracticeInformation(enrollment);
 
         attr(mv, "effectiveDate", BinderUtils.formatCalendar(practice.getEffectiveDate()));
-        
+
         if (Util.isBlank(practice.getObjectId())) { // do not display private data from linked profile
             attr(mv, "billingSameAsPrimary", practice.getBillingSameAsPrimary());
-            
+
             AddressType billingAddress = practice.getBillingAddress();
             if (billingAddress != null && !"Y".equals(practice.getBillingSameAsPrimary())) {
                 String line1 = billingAddress.getAddressLine1();
@@ -149,7 +149,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
                 attr(mv, "billingZip", billingAddress.getZipCode());
                 attr(mv, "billingCounty", billingAddress.getCounty());
             }
-            
+
             attr(mv, "fein", practice.getFEIN());
             attr(mv, "stateTaxId", practice.getStateTaxId());
             String[] fye = BinderUtils.splitFiscalYear(practice.getFiscalYearEnd());
@@ -183,7 +183,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
                 if (path == null) {
                     continue;
                 }
-                
+
                 boolean switchBillingAddressLines = false;
                 if (practice.getBillingAddress() == null || Util.isBlank(practice.getBillingAddress().getAddressLine1())) {
                     switchBillingAddressLines = true;
@@ -306,12 +306,12 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
 
         practice.setEffectiveDate(BinderUtils.toCalendar(primary.getEffectiveDate()));
     }
-    
+
     @Override
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model)
         throws DocumentException {
         super.renderPDF(enrollment, document, model);
-        
+
         PdfPTable practiceInfo = new PdfPTable(2);
         PDFHelper.setTableAsFullPage(practiceInfo);
 
@@ -333,7 +333,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
 
         document.add(practiceInfo);
     }
-    
+
     /**
      * Reads the billing address from the request.
      *
@@ -356,5 +356,4 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
         address.setCounty(param(request, "billingCounty"));
         return address;
     }
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
@@ -87,7 +87,7 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
             setup.getPayToProvider().add(payTo);
             i++;
         }
-        
+
         return exceptions;
     }
 
@@ -158,7 +158,7 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
 
         return errors.isEmpty() ? NO_ERRORS : errors;
     }
-    
+
     /**
      * Resolves the specific license that is causing the error from the license list.
      * @param ruleError the error to resolve
@@ -185,7 +185,7 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
                 return createError("npi", index, message);
             }
         }
-        
+
         // general location error
         return createError("group", message);
     }
@@ -213,11 +213,11 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
      */
     public void bindToHibernate(EnrollmentType enrollment, Enrollment ticket) throws PortalServiceException {
         ProviderProfile profile = ticket.getDetails();
-        
+
         ProviderSetupInformationType setup = XMLUtility.nsGetProviderSetup(enrollment);
         profile.setPayToProviders(new ArrayList<PayToProvider>());
         List<PayToProvider> providers = profile.getPayToProviders();
-        
+
         for (PayToProviderType payTo : setup.getPayToProvider()) {
             PayToProvider p = new PayToProvider();
             p.setEffectiveDate(BinderUtils.toDate(payTo.getEffectiveDate()));
@@ -230,7 +230,7 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
             providers.add(p);
         }
     }
-    
+
     /**
      * Binds the fields of the persistence model to the front end xml.
      *
@@ -244,7 +244,7 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
             if (payToProviders != null) {
                 ProviderSetupInformationType setup = XMLUtility.nsGetProviderSetup(enrollment);
                 setup.getPayToProvider().clear();
-                
+
                 for (PayToProvider payToProvider : payToProviders) {
                     PayToProviderType payTo = new PayToProviderType();
                     payTo.setObjectId("" + payToProvider.getTargetProfileId());
@@ -257,11 +257,10 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
                     if (payToProvider.getType() != null) {
                         payTo.setType(payToProvider.getType().getDescription());
                     }
-                    
+
                     setup.getPayToProvider().add(payTo);
                 }
             }
         }
     }
-    
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class ProviderTypeFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      */
     @SuppressWarnings("unchecked")
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
@@ -82,7 +82,7 @@ public class ProviderTypeFormBinder extends BaseFormBinder {
                 provider.setApplicantType(ApplicantType.ORGANIZATION);
             }
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -116,7 +116,7 @@ public class ProviderTypeFormBinder extends BaseFormBinder {
             }
         }
     }
-    
+
     /**
      * Sorts the displayed provider types (PESP-252_
      * @param providerTypes the provider types to sort

--- a/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
@@ -130,7 +130,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
                 }
             }
 
-            AddressType address = readQPAddress(request, qpIndex);
+            AddressType address = readIndexedAddress(request, qpIndex);
             ContactInformationType contact = new ContactInformationType();
             qp.setContactInformation(contact);
             qp.getContactInformation().setAddress(address);
@@ -576,29 +576,5 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
             xQPs.getQualifiedProfessional().add(xQP);
         }
-    }
-
-    /**
-     * Reads the primary practice address from the request.
-     *
-     * @param request
-     *            the request to read from
-     * @return the bound address
-     */
-    protected AddressType readQPAddress(HttpServletRequest request, int index) {
-        AddressType address = new AddressType();
-        String line1 = param(request, "addressLine1", index);
-        String line2 = param(request, "addressLine2", index);
-        if (Util.isBlank(line2)) { // prioritize line 2 usage
-            line2 = line1;
-            line1 = null;
-        }
-        address.setAddressLine1(line1);
-        address.setAddressLine2(line2);
-        address.setCity(param(request, "city", index));
-        address.setState(param(request, "state", index));
-        address.setZipCode(param(request, "zip", index));
-        address.setCounty(param(request, "county", index));
-        return address;
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
@@ -231,18 +231,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
             if (qp.getContactInformation() != null) {
                 AddressType address = qp.getContactInformation().getAddress();
                 if (address != null) {
-                    String line1 = address.getAddressLine1();
-                    String line2 = address.getAddressLine2();
-                    if (Util.isBlank(line1)) {
-                        line1 = line2;
-                        line2 = null;
-                    }
-                    attr(mv, "addressLine1", qpIndex, line1);
-                    attr(mv, "addressLine2", qpIndex, line2);
-                    attr(mv, "city", qpIndex, address.getCity());
-                    attr(mv, "state", qpIndex, address.getState());
-                    attr(mv, "zip", qpIndex, address.getZipCode());
-                    attr(mv, "county", qpIndex, address.getCounty());
+                    attr(mv, qpIndex, address);
                 }
             }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * This binder handles the provider type selection form.
- * 
+ *
  * @author TCSASSEMBLER
  * @version 1.0
  */
@@ -79,7 +79,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
      *            the model to bind to
      * @param request
      *            the request containing the form fields
-     * 
+     *
      * @throws BinderException
      *             if the format of the fields could not be bound properly
      */
@@ -284,7 +284,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Retrieves only QP affiliations.
-     * 
+     *
      * @param affiliations
      *            the affiliations to be filtered
      * @return the filtered affiliations
@@ -307,7 +307,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Retrieves the related attachment name.
-     * 
+     *
      * @param enrollment
      *            the enrollment to retrieve from
      * @param attachmentObjectId
@@ -329,12 +329,12 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Captures the error messages related to the form.
-     * 
+     *
      * @param enrollment
      *            the enrollment that was validated
      * @param messages
      *            the messages to select from
-     * 
+     *
      * @return the list of errors related to the form
      */
     protected List<FormError> selectErrors(EnrollmentType enrollment, StatusMessagesType messages) {
@@ -375,7 +375,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Resolves the specific license that is causing the error from the license list.
-     * 
+     *
      * @param ruleError
      *            the error to resolve
      * @return the resolved error
@@ -442,7 +442,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Resolves the index of the field that caused the error.
-     * 
+     *
      * @param path
      *            the field path
      * @return the index of the field, null if cannot be resolved
@@ -457,7 +457,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Binds the fields of the form to the persistence model.
-     * 
+     *
      * @param enrollment
      *            the front end model
      * @param ticket
@@ -520,7 +520,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Binds the fields of the persistence model to the front end xml.
-     * 
+     *
      * @param ticket
      *            the persistent model
      * @param enrollment
@@ -580,7 +580,7 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 
     /**
      * Reads the primary practice address from the request.
-     * 
+     *
      * @param request
      *            the request to read from
      * @return the bound address
@@ -601,5 +601,4 @@ public class QualifiedProfessionalFormBinder extends BaseFormBinder {
         address.setCounty(param(request, "county", index));
         return address;
     }
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class RemittanceSequenceFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     @SuppressWarnings("unchecked")

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class SlidingFeeScheduleFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     @SuppressWarnings("unchecked")
@@ -69,7 +69,7 @@ public class SlidingFeeScheduleFormBinder extends BaseFormBinder {
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         CountyContractType countyInfo = new CountyContractType();
         credentials.setContractWithCounty(countyInfo);
-        
+
         String attachmentId = (String) request.getAttribute(NAMESPACE + "slidingFeeSchedule");
         if (attachmentId != null) {
             replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, DocumentNames.SLIDING_FEE_SCHEDULE.value());
@@ -107,7 +107,7 @@ public class SlidingFeeScheduleFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 
@@ -132,7 +132,7 @@ public class SlidingFeeScheduleFormBinder extends BaseFormBinder {
                 if (path == null) {
                     continue;
                 }
-                
+
                 if (path.equals("/ProviderInformation/AttachedDocuments/Document[name=\"Sliding Fee Schedule\"]")) {
                     errors.add(createError("slidingFeeSchedule", ruleError.getMessage()));
                 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class SpecialtyInformationFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     public List<BinderException> bindFromPage(CMSUser user, EnrollmentType enrollment, HttpServletRequest request) {
@@ -140,7 +140,7 @@ public class SpecialtyInformationFormBinder extends BaseFormBinder {
                 }
             }
         }
-        
+
         return exceptions;
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class TCMContractFormBinder extends BaseFormBinder {
      * @param enrollment the model to bind to
      * @param request the request containing the form fields
      *
-     * @return 
+     * @return
      * @throws BinderException if the format of the fields could not be bound properly
      */
     @SuppressWarnings("unchecked")
@@ -69,7 +69,7 @@ public class TCMContractFormBinder extends BaseFormBinder {
         FacilityCredentialsType credentials = XMLUtility.nsGetFacilityCredentials(enrollment);
         CountyContractType countyInfo = new CountyContractType();
         credentials.setContractWithCounty(countyInfo);
-        
+
         String attachmentId = (String) request.getAttribute(NAMESPACE + "contractAttachment");
         if (attachmentId != null) {
             replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, CONTRACT_WITH_COUNTY);
@@ -81,19 +81,19 @@ public class TCMContractFormBinder extends BaseFormBinder {
             countyInfo.setContractAttachmentObjectId(attachmentId);
             replaceDocument(attachments, attachmentId, "DHS-5638");
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "coverSheet2");
         if (attachmentId != null) {
             countyInfo.setContractAttachmentObjectId(attachmentId);
             replaceDocument(attachments, attachmentId, "DHS-5639");
         }
-        
+
         attachmentId = (String) request.getAttribute(NAMESPACE + "coverSheet3");
         if (attachmentId != null) {
             countyInfo.setContractAttachmentObjectId(attachmentId);
             replaceDocument(attachments, attachmentId, "DHS-5702");
         }
-        
+
         return Collections.EMPTY_LIST;
     }
 
@@ -132,7 +132,7 @@ public class TCMContractFormBinder extends BaseFormBinder {
                 toRemove.add(doc);
             }
         }
-        
+
         attachments.getAttachment().removeAll(toRemove);
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -318,7 +318,7 @@ public class XMLUtility {
         }
         return person.getContactInformation();
     }
-    
+
     /**
      * Null safe get for the contact information.
      *
@@ -491,7 +491,7 @@ public class XMLUtility {
         }
         return provider.getSpecialties();
     }
-    
+
     /**
      * Null safe get for the organization applicant.
      *
@@ -506,7 +506,7 @@ public class XMLUtility {
 
         return applicant.getOrganizationInformation();
     }
-    
+
     /**
      * Null safe get for the contact information.
      *
@@ -533,7 +533,7 @@ public class XMLUtility {
         }
         return provider.getMemberInformation();
     }
-    
+
     /**
      * Null safe get for the ownership information.
      *


### PR DESCRIPTION
Short version: when the individual owner home address form is not filled in, put the error highlight on the first address line field rather than the second line.

Long version:
There was a Drools validation rule that required address line 2 to be present if either line 1 or 2 were present. That's not how we usually think of addresses working, and that mismatch was previously being "fixed" (or perhaps, more accurately, worked around) by testing (in Java code) if the first line was empty, and if so switch lines 1 and 2. This pattern was repeated in every place along the boundry between JSPs and controllers that dealt with addresses.

One of the places, dealing with the home residence address of the individual ownership interest, did not properly switch the two address lines, leading to the second address line being marked as in error when neither are filled, rather than the first address line.

I found the logic around switching the address lines very confusing, and so rather than fix the symptom, fix the underlying problem: update the Drools rule to prioritize address line one rather than address line two, and remove all the complexity around switching address lines everywhere else.

To do that, I did a bunch of refactoring. First, I [cleaned up the whitespace in the rules file](https://github.com/OpenTechStrategies/psm/commit/dc1285d706e5d43fd51298fbd23085c62eb6b3fc?w=1); next, I extracted a bunch of helper methods, as most of the code that dealt with addresses was copy-pasted for each form; then, I fixed the rule and deleted the code working around the previously broken rule.

---

To test this, I went through all the places I could think of that dealt with and validated addresses:
- Individual provider private practice ![screenshot 2017-09-26 16 42 20](https://user-images.githubusercontent.com/1494855/30883311-bfea8c5e-a2d9-11e7-850c-284f379b5227.png)
- Individual provider primary practice 
![screenshot 2017-09-26 15 53 53](https://user-images.githubusercontent.com/1494855/30883348-d6acacd8-a2d9-11e7-9b84-dbe33431b0a2.png)
- Individual provider additional practice 
![screenshot 2017-09-26 16 07 38](https://user-images.githubusercontent.com/1494855/30883375-e9ca965e-a2d9-11e7-90f5-9749fff7deca.png)
- Organization provider practice ![screenshot 2017-09-26 16 10 06](https://user-images.githubusercontent.com/1494855/30883384-f11488fc-a2d9-11e7-90d6-66689aa08f05.png)
- Individual person ownership or control interest - home residence address 
![screenshot 2017-09-26 16 12 14](https://user-images.githubusercontent.com/1494855/30883411-06ad5798-a2da-11e7-9f1f-771fc5593e4f.png)
- Business ownership or control interest- business address 
![screenshot 2017-09-26 16 13 00](https://user-images.githubusercontent.com/1494855/30883417-0dd616ae-a2da-11e7-9dec-3e9d707b5581.png)
- Individual personal care assistant residential address 
![screenshot 2017-09-26 16 16 10 - personal care assistant](https://user-images.githubusercontent.com/1494855/30883423-128dd77c-a2da-11e7-9126-6190d1a9ac36.png)

---

Issue #8 Reduce code duplication
Issue #292 Label all required fields