### PR TITLE
Allow 9-digit zip code for personal care assistant

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
@@ -83,7 +83,7 @@
                 <label>ZIP Code<span class="required">*</span> : </label>
                 <c:set var="formName" value="_10_zip"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="6"/>
+                <input type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
                 <label>County : </label>
                 <c:set var="formName" value="_10_county"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>


### PR DESCRIPTION
Update the form presented to the individual provider type "Personal Care Assistant" to allow for 9-digit zip codes (plus the separating dash).

The rest of the infrastructure is already in place for 9-digit zip codes, and it is working elsewhere; only the form needed to be changed.

---

To test this, I created an enrollment, verified that the form allowed a 9-digit zip code:
![screenshot 2017-09-27 11 09 17](https://user-images.githubusercontent.com/1494855/30921804-5ea7edaa-a375-11e7-8a6b-fde9c6fbf10a.png)

verified that the zip code was shown correctly on the summary page before enrollment submission:
![screenshot 2017-09-27 11 10 39](https://user-images.githubusercontent.com/1494855/30921835-75649a98-a375-11e7-8b32-3ff85ab8a163.png)

and verified that the admin user could see the full zip code:
![screenshot 2017-09-27 11 12 54](https://user-images.githubusercontent.com/1494855/30921862-82ea26a6-a375-11e7-92bc-708bcafe24ff.png)

---

Resolves #290 Add 4 extra digits to zipcode field(s)