### PR TITLE
Add empty checkstyle config and use with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,12 @@ install: true
 # The build step here also builds our Javadocs.
 script:
   - cd psm-app
-  - ./gradlew --no-daemon --console=plain clean cms-portal-services:build cms-web:apiDocs
+  - ./gradlew --no-daemon --console=plain
+        clean
+        checkstyleMain
+        checkstyleTest
+        cms-portal-services:build
+        cms-web:apiDocs
   - cd ../
 
 # Push the new Javadocs to our GitHub Pages site.

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -61,6 +61,7 @@ List runtime_libs = [
 
 allprojects {
     apply plugin: 'groovy'
+    apply plugin: 'checkstyle'
 
     repositories {
         mavenCentral()
@@ -70,6 +71,11 @@ allprojects {
     dependencies {
         testCompile 'org.codehaus.groovy:groovy-all:2.4.10'
         testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
+    }
+
+    checkstyle {
+        toolVersion = '8.2'
+        configFile = new File(rootDir, 'checkstyle.xml')
     }
 }
 

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+</module>


### PR DESCRIPTION
The first step to adopting a code style is configuring the build.

Include the checkstyle ([checkstyle project on GitHub](https://github.com/checkstyle/checkstyle), [checkstyle web page](http://checkstyle.sourceforge.net/)) [gradle plugin](https://docs.gradle.org/current/userguide/checkstyle_plugin.html), and include an empty configuration file for it to use - we'll add checks later.

Configure Travis to run the newly-defined `checkstyleMain` and `checkstyleTest` tasks as part of the build.

You may also want to install the [CheckStyle-IDEA](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) plugin, and configure it to point to `checkstyle.xml`.

---

Issue #456 Use consistent code style