### PR TITLE
Add script to create user and developer documentation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ risk scoring, credentialing validation, identity authentication, and
 sanction checks, that lowered the burden on providers and reduced
 administrative and infrastructure expenses for states and federal
 programs.
- 
+
 The application was built using NASA's contract with Harvard Business
 School in association with the Institute of Quantitative Social
 Sciences and their subcontract with TopCoder.  The Application
@@ -76,7 +76,7 @@ Development Challenge was sponsored by CMS as part of the Partnership
 for Program Integrity Innovation program with the specific intent of
 developing an application to improve capabilities for streamlining
 operations and screening providers to reduce fraud and abuse.
- 
+
 The challenge was comprised of an omnibus of 120 contests launched
 between June 2012 and April 2013, to cover all phases of the software
 development life cycle.  The code and documentation resulting from
@@ -132,8 +132,12 @@ As of 21 June 2017, the PSM offers the following functionality:
 * Record logs in `standalone/log/`
 * Record changes for auditing in database tables `audit_details` and `audit_records`
 
-_[Note: As the developer team conducts initial improvement work on the PSM in June 2017, we anticipate recovering many of the features listed in the [original
-repository](https://github.com/NASA-Tournament-Lab/coeci-cms-mpsp/blob/master/README.md), such as identity verification, building provider profiles, and MITA integration.]_
+_[Note: As the developer team conducts initial improvement work on the
+PSM in June 2017, we anticipate recovering many of the features listed
+in the [original
+repository](https://github.com/NASA-Tournament-Lab/coeci-cms-mpsp/blob/master/README.md),
+such as identity verification, building provider profiles, and MITA
+integration.]_
 
 ---------------------------------------------------------------------
 SECTION 4: Project Resources and Repository Organization

--- a/scripts/1_TOC.md
+++ b/scripts/1_TOC.md
@@ -1,0 +1,46 @@
+# Provider Screening Module documentation
+
+This bundle contains several user, administrator, and developer guides
+for the Provider Screening Module.
+
+Here's a guide to the files.
+
+Understand
+----------
+
+Read [the general guide to the PSM's codebase
+(**2_readme.pdf**)](2_readme.pdf).
+
+Use
+---
+
+The [user manual for providers, service agents, state Medicaid staff,
+and system administrators, **3_usermanual.pdf**](3_usermanual.pdf), covers:
+
+-   Creating and submitting enrollments
+-   Verifying, approving and rejecting enrollments
+-   Creating an account and logging in
+-   Managing users
+
+Install and Run
+---------------
+
+Learn to [install the application
+(**4_install-instructions.pdf**)](4_install-instructions.pdf), and
+understand its [external technical dependencies
+(**5_dependencies-list.pdf**)](5_dependencies-list.pdf) and [technical
+architecture and design
+(**6_architecture-design.pdf**)](6_architecture-design.pdf).
+
+Learn to [extract, transform, and load (ETL) verification data from
+the List of Excluded Individuals/Entities (LEIE) on the command line
+(**7_leie_API.pdf**)](7_leie_API.pdf) for use in your PSM instance.
+
+Develop
+-------
+
+Learn to [test
+(**8_testing-instructions.pdf**)](8_testing-instructions.pdf) and
+[contribute to the PSM as a developer
+(**9_developer-contribution-instructions.pdf**)](9_developer-contribution-instructions.pdf),
+or [use its web API (**api-docs/index.html)**](api-docs/index.html).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,3 +10,7 @@ administrators or our build systems.
 * `drools-microservice.sh` sets up a copy of jbpm and Guvnor on a
   standalone server, which the core application can then be configured
   to communicate with.
+* `make-zip-of-documents.sh` builds PDFs of our prose documents for
+  users, administrators, and developers, builds the HTML
+  documentation for our API, and puts together a ZIP file with a
+  table of contents.

--- a/scripts/make-zip-of-documents.sh
+++ b/scripts/make-zip-of-documents.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -ex
+
+# Bundle user & developer docs into a zipped archive; issue # 458
+# For this to work you'll need several Python & Debian packages installed
+# See docs/userhelp/README.mdwn
+
+mkdir documentation-bundle
+
+# Use Pandoc to turn various Markdown documents into PDFs
+
+pandoc -V colorlinks -t latex -o documentation-bundle/2_readme.pdf ../README.md
+pandoc -V colorlinks -t latex -o documentation-bundle/4_install-instructions.pdf \
+       ../INSTALL.md
+pandoc -V colorlinks -t latex -o \
+       documentation-bundle/9_developer-contribution-instructions.pdf \
+       ../CONTRIBUTING.md
+pandoc -V colorlinks -t latex -o documentation-bundle/6_architecture-design.pdf \
+       ../docs/DESIGN.md
+pandoc -V colorlinks -t latex -o documentation-bundle/5_dependencies-list.pdf \
+       ../docs/DEPENDENCIES.md
+pandoc  -V colorlinks -t latex -o documentation-bundle/8_testing-instructions.pdf \
+       ../docs/TESTING.md
+pandoc -V colorlinks -t latex -o documentation-bundle/7_leie_API.pdf \
+       ../etl/leie/README.mdwn
+
+# Use Pandoc to turn index page into a PDF
+
+pandoc -V colorlinks -t latex -o documentation-bundle/1_table_of_contents.pdf \
+       1_TOC.md
+
+# Use Sphinx and LaTeX to turn user manual into a PDF
+
+cd ../docs/userhelp/
+make clean
+make latexpdf
+mv build/latex/ProviderScreeningModuleusermanual.pdf \
+   ../../scripts/documentation-bundle/3_usermanual.pdf
+
+# Build API docs
+
+cd ../../psm-app
+./gradlew cms-web:apiDocs
+cp -r cms-web/build/reports/api-docs ../scripts/documentation-bundle/
+
+# Move PDFs, API doc directory, logo, and HTML index file to ZIP file
+# Syntax: zip options archive inpath inpath
+
+cd ../scripts/documentation-bundle/
+zip -mr documentation-bundle.zip ./*.pdf \
+    api-docs
+
+# Resulting file: documentation-bundle/documentation-bundle.zip
+
+echo -e "Created archive file: documentation-bundle/documentation-bundle.zip\n"


### PR DESCRIPTION
To help us inform our stakeholders better, it's nice to have a ZIPped
archive of our user manual, developer documentation, and so on. This
script builds PDFs of our prose documents for users, administrators,
and developers, builds the HTML documentation for our API, and puts
together a ZIP file with an HTML index page to aid browsing.

~~~
$ cd scripts
$ ./make-zip-of-documents.sh
~~~

To run this successfully, you'll need several Python & Debian packages
installed; see `docs/userhelp/README.mdwn`.

Fixes #458.