### PR TITLE
Display phone number on user profile page

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -18,6 +18,8 @@ package gov.medicaid.entities;
 import gov.medicaid.binders.BinderUtils;
 import org.hibernate.annotations.GenericGenerator;
 
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -56,6 +58,7 @@ public class CMSUser implements Serializable {
     @Column(name = "middle_name")
     private String middleName;
 
+    @Access(AccessType.PROPERTY)
     @Column(name = "phone_number")
     private String phoneNumber;
 


### PR DESCRIPTION
The admin user profile page uses a Hibernate entity to transfer data between the controller and the page. The entity has a complete phone number, dashes included, that it stores in the database; and separate, transient fields for the four parts of the phone number (area code, prefix, line number, and extension). When a user POSTs data, the phone number parts are stored separately in the transient fields, and then the controller calls a helper method on the entity to concatenate the fields together, and Hibernate persists that concatenated phone number to the database.

After editing a user, the controller sends the same entity instance back, and so the transient fields are populated: that's why this bug wasn't always showing.

The entity has some logic in `setPhoneNumber` to break up the string into those transient parts, suitable for displaying on the page. However, on first viewing a user, Hibernate was loading the phone number directly into the field, without using the setter; this can be both faster and safer, and is the default when the `@Id` annotation is placed on the field instead of the getter[1]. This meant that the transient fields were never populated, and so it looked as though changes to the user's phone number were not persisted.

Tell Hibernate to populate the `phoneNumber` field by using the setter instead of reflection, so that the phone number is split up into the transient fields.

[1] https://en.wikibooks.org/wiki/Java_Persistence/Mapping#Access_Type

Resolves #184 data loss: PSM does not save profile phone number