### PR TITLE
Add whitespace rules to checkstyle (and fix existing violations)

### DIFF
--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -3,5 +3,8 @@
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
+  <module name="SuppressionFilter">
+    <property name="file" value="checkstyle_suppressions.xml"/>
+  </module>
   <module name="FileTabCharacter"/>
 </module>

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -7,4 +7,14 @@
     <property name="file" value="checkstyle_suppressions.xml"/>
   </module>
   <module name="FileTabCharacter"/>
+  <module name="TreeWalker">
+    <module name="EmptyForInitializerPad"/>
+    <module name="EmptyForIteratorPad"/>
+    <module name="GenericWhitespace"/>
+    <module name="MethodParamPad"/>
+    <module name="NoLineWrap"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+  </module>
 </module>

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -16,5 +16,10 @@
     <module name="NoWhitespaceBefore"/>
     <module name="ParenPad"/>
     <module name="TypecastParenPad"/>
+    <module name="EmptyLineSeparator">
+      <property name="allowMultipleEmptyLines" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF"/>
+    </module>
   </module>
 </module>

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -3,4 +3,5 @@
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
+  <module name="FileTabCharacter"/>
 </module>

--- a/psm-app/checkstyle_suppressions.xml
+++ b/psm-app/checkstyle_suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+  <suppress files="[\\/]generated[\\/]" checks="[a-zA-Z0-9]*"/>
+</suppressions>

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AdditionalCategory.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AdditionalCategory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AddressEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AddressEntry.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/CertificateException.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/CertificateException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ClassificationMatcher.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ClassificationMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ErrorReporter.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ErrorReporter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.OperationStatusType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsIndividual.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsIndividual.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ProviderInformationType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsOrganization.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsOrganization.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ProviderInformationType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LicenseLookupConfiguration.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LicenseLookupConfiguration.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LicenseNumberMatcher.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LicenseNumberMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LicenseTypeMatcher.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LicenseTypeMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LookupEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LookupEntry.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/MatchStatus.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/MatchStatus.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NPIEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NPIEntry.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NameAndNumberMatcher.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NameAndNumberMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NameAndTypeMatcher.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NameAndTypeMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NullMatcher.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NullMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/PhoneNumberEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/PhoneNumberEntry.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderNameMatcher.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderNameMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderSpecialty.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderSpecialty.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderTypeException.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderTypeException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 /**

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ResultMatchResolver.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ResultMatchResolver.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules.inference;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/CMSKnowledgeUtility.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/CMSKnowledgeUtility.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules;
 
 import javax.persistence.EntityManagerFactory;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DSLTester.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DSLTester.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules;
 
 import gov.medicaid.domain.model.ApplicantType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules;
 
 import gov.medicaid.services.CMSConfigurator;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -71,16 +71,16 @@ public class DroolsKnowledgeDelegate implements KnowledgeDelegate {
      * Flag indicating if guvnor should be used.
      */
     private final boolean useGuvnor;
-    
+
     /**
      * Private constructor.
      */
     DroolsKnowledgeDelegate() {
-    	CMSConfigurator config = new CMSConfigurator();
-    	useGuvnor = "N".equalsIgnoreCase(config.getUseEmbeddedRules());
-    	validationKnowledgeBase = readValidationKnowledgeBase();
-    	screeningKnowledgeBase = readScreeningKnowledgeBase();
-    	externalSourcesKnowledgeBase = readExternalSourcesKnowledgeBase();
+        CMSConfigurator config = new CMSConfigurator();
+        useGuvnor = "N".equalsIgnoreCase(config.getUseEmbeddedRules());
+        validationKnowledgeBase = readValidationKnowledgeBase();
+        screeningKnowledgeBase = readScreeningKnowledgeBase();
+        externalSourcesKnowledgeBase = readExternalSourcesKnowledgeBase();
     }
 
     /* (non-Javadoc)
@@ -96,7 +96,7 @@ public class DroolsKnowledgeDelegate implements KnowledgeDelegate {
             new LocalHumanTaskHandler(ksession, client));
         return ksession;
     }
-    
+
     @Override
     public StatefulKnowledgeSession reloadWorkflowSession(int sessionId, EntityManagerFactory factory, UserTransaction utx) {
         StatefulKnowledgeSession ksession = JPAKnowledgeService.loadStatefulKnowledgeSession(sessionId, processKnowledgeBase, null,
@@ -119,13 +119,13 @@ public class DroolsKnowledgeDelegate implements KnowledgeDelegate {
      * Creates a rule environment.
      *
      * @param emf the persistence factory
-     * @param utx 
+     * @param utx
      * @return a new environment
      */
     private Environment createEnvironment(EntityManagerFactory emf, UserTransaction utx) {
         Environment env = EnvironmentFactory.newEnvironment();
-		env.set(EnvironmentName.ENTITY_MANAGER_FACTORY, emf);
-		env.set(EnvironmentName.APP_SCOPED_ENTITY_MANAGER, emf.createEntityManager());
+        env.set(EnvironmentName.ENTITY_MANAGER_FACTORY, emf);
+        env.set(EnvironmentName.APP_SCOPED_ENTITY_MANAGER, emf.createEntityManager());
         return env;
     }
 
@@ -145,7 +145,7 @@ public class DroolsKnowledgeDelegate implements KnowledgeDelegate {
     private KnowledgeBase readScreeningKnowledgeBase() {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         if (useGuvnor) {
-        	kbuilder.add(ResourceFactory.newClassPathResource("ScreeningRules.xml"), ResourceType.CHANGE_SET);
+            kbuilder.add(ResourceFactory.newClassPathResource("ScreeningRules.xml"), ResourceType.CHANGE_SET);
         } else {
             kbuilder.add(ResourceFactory.newClassPathResource("cms.screening.drl"), ResourceType.DRL);
         }
@@ -170,7 +170,7 @@ public class DroolsKnowledgeDelegate implements KnowledgeDelegate {
     private KnowledgeBase readExternalSourcesKnowledgeBase() {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         if (useGuvnor) {
-        	kbuilder.add(ResourceFactory.newClassPathResource("ExternalSourcesRules.xml"), ResourceType.CHANGE_SET);
+            kbuilder.add(ResourceFactory.newClassPathResource("ExternalSourcesRules.xml"), ResourceType.CHANGE_SET);
         } else {
             kbuilder.add(ResourceFactory.newClassPathResource("cms.externalsources.drl"), ResourceType.DRL);
         }
@@ -195,13 +195,13 @@ public class DroolsKnowledgeDelegate implements KnowledgeDelegate {
     private KnowledgeBase readValidationKnowledgeBase() {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         if (useGuvnor) {
-        	kbuilder.add(ResourceFactory.newClassPathResource("ValidationRules.xml"), ResourceType.CHANGE_SET);
+            kbuilder.add(ResourceFactory.newClassPathResource("ValidationRules.xml"), ResourceType.CHANGE_SET);
         } else {
-        	kbuilder.add(ResourceFactory.newClassPathResource("cms.dsl"), ResourceType.DSL);
-        	kbuilder.add(ResourceFactory.newClassPathResource("cms.validation.dslr"), ResourceType.DSLR);
-        	kbuilder.add(ResourceFactory.newClassPathResource("cms.validation.drl"), ResourceType.DRL);
+            kbuilder.add(ResourceFactory.newClassPathResource("cms.dsl"), ResourceType.DSL);
+            kbuilder.add(ResourceFactory.newClassPathResource("cms.validation.dslr"), ResourceType.DSLR);
+            kbuilder.add(ResourceFactory.newClassPathResource("cms.validation.drl"), ResourceType.DRL);
         }
-        
+
         KnowledgeBuilderErrors errors = kbuilder.getErrors();
         if (errors.size() > 0) {
             for (KnowledgeBuilderError error : errors) {

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules;
 
 import gov.medicaid.domain.model.ReservationNames;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.domain.rules;
 
 import javax.persistence.EntityManagerFactory;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import java.util.Date;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/DisqualificationHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/DisqualificationHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentHistoryHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentHistoryHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentMonitor.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentMonitor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ExcludedProvidersScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ExcludedProvidersScreeningHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import ca.uhn.fhir.context.FhirContext;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/GenericHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/GenericHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import org.drools.runtime.process.WorkItem;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/NPILookupHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/NPILookupHandler.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/PreProcessHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/PreProcessHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import java.util.Date;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/SAMExcludedProvidersScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/SAMExcludedProvidersScreeningHandler.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class ScreeningHandler extends GenericHandler {
         this.entityManager = config.getPortalEntityManager();
         systemUser = config.getSystemUser();
     }
-    
+
     /**
      * Runs the screening rules.
      *
@@ -90,7 +90,7 @@ public class ScreeningHandler extends GenericHandler {
         // known facts for screening
         ksession.insert(processModel.getPostSubmissionInformation());
         EnrollmentType enrollment = processModel.getEnrollment();
-		ksession.insert(enrollment);
+        ksession.insert(enrollment);
         ksession.insert(enrollment.getProviderInformation());
         ksession.insert(enrollment.getProviderInformation().getVerificationStatus());
         ksession.insert(processModel.getProcessResults().getScreeningResults());
@@ -105,12 +105,12 @@ public class ScreeningHandler extends GenericHandler {
         // merge rule changes to the model
         try {
             providerService.saveEnrollmentDetails(XMLAdapter.fromXML(systemUser, enrollment));
-			long ticketId = Long.parseLong(enrollment.getObjectId());
-			ProviderInformationType providerInformation = enrollment.getProviderInformation();
-			String reviewer = providerInformation.getReviewedBy(); // transient field (should really add to DB)
-			ProviderInformationType updatedInfo = XMLAdapter.toXML(providerService.getTicketDetails(systemUser, ticketId)).getProviderInformation();
-			updatedInfo.setReviewedBy(reviewer);
-			enrollment.setProviderInformation(updatedInfo);
+            long ticketId = Long.parseLong(enrollment.getObjectId());
+            ProviderInformationType providerInformation = enrollment.getProviderInformation();
+            String reviewer = providerInformation.getReviewedBy(); // transient field (should really add to DB)
+            ProviderInformationType updatedInfo = XMLAdapter.toXML(providerService.getTicketDetails(systemUser, ticketId)).getProviderInformation();
+            updatedInfo.setReviewedBy(reviewer);
+            enrollment.setProviderInformation(updatedInfo);
         } catch (PortalServiceException e) {
             logger.log(java.util.logging.Level.SEVERE, e.getMessage(), e);
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ValidationHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ValidationHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyBackgroundStudyHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyBackgroundStudyHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyLicenseHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyLicenseHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyPECOSRecordHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyPECOSRecordHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifySSNHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifySSNHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.process.enrollment;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BaseService.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BaseService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import com.topcoder.util.log.Level;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.dao.IdentityProviderDAO;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.BinderUtils;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -228,7 +228,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
      *
      * @param username the username
      * @param systemId the system authenticator
-     * @param string 
+     * @param string
      * @return the user matched
      * @throws PortalServiceException for any errors encountered
      */
@@ -238,15 +238,15 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
         if (system != SystemId.CMS_ONLINE) {
             user = registrationService.findByExternalUsername(system, username);
             if (Util.isNotBlank(npi)) { // proxy user
-            	user.setProxyForNPI(npi);
-            	if (username.equals(npi)) {
-            		user.setExternalRoleView(RoleView.SELF);
-            	} else {
-            		user.setExternalRoleView(RoleView.EMPLOYER);
-            	}
-				ExternalAccountLink link = registrationService.findAccountLink(
-						user.getUserId(), system, username);
-            	user.setExternalAccountLink(link);
+                user.setProxyForNPI(npi);
+                if (username.equals(npi)) {
+                    user.setExternalRoleView(RoleView.SELF);
+                } else {
+                    user.setExternalRoleView(RoleView.EMPLOYER);
+                }
+                ExternalAccountLink link = registrationService.findAccountLink(
+                        user.getUserId(), system, username);
+                user.setExternalAccountLink(link);
             }
         } else {
             user = registrationService.findByUsername(username);
@@ -283,7 +283,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
         } else {
             ticket = XMLAdapter.fromXML(user, enrollment);
         }
-        
+
         if (resetToDraft) {
             ticketId = providerEnrollmentService.saveAsDraft(user, ticket);
         } else {
@@ -303,31 +303,31 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
     @Override
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED) // allow SAVE even if SUBMIT fails
     public SubmitTicketResponse submitEnrollment(SubmitTicketRequest request) throws PortalServiceException {
-    	try {
-	        EnrollmentType enrollment = request.getEnrollment();
-	        CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());
-	        // transaction #1
-	        long ticketId = saveTicket(user, enrollment, true);
-	
-	        long profileId = BinderUtils.getAsLong(enrollment.getProviderInformation().getObjectId());
-	        Validity validity = providerEnrollmentService.getSubmissionValidity(ticketId, profileId);
-	
-	        SubmitTicketResponse response = new SubmitTicketResponse();
-	        response.setTicketNumber(ticketId);
-	        if (validity == Validity.VALID) {
-	        	
-	        	// transaction #2
-	            businessProcessService.submitTicket(user, ticketId);
-	            
-	            response.setStatus("SUCCESS");
-	            return response;
-	        } else {
-	            response.setStatus(validity.name());
-	            return response;
-	        }
-    	} catch (Throwable t) {
-    		throw new PortalServiceException("error during submit.", t);
-    	}
+        try {
+            EnrollmentType enrollment = request.getEnrollment();
+            CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());
+            // transaction #1
+            long ticketId = saveTicket(user, enrollment, true);
+
+            long profileId = BinderUtils.getAsLong(enrollment.getProviderInformation().getObjectId());
+            Validity validity = providerEnrollmentService.getSubmissionValidity(ticketId, profileId);
+
+            SubmitTicketResponse response = new SubmitTicketResponse();
+            response.setTicketNumber(ticketId);
+            if (validity == Validity.VALID) {
+
+                // transaction #2
+                businessProcessService.submitTicket(user, ticketId);
+
+                response.setStatus("SUCCESS");
+                return response;
+            } else {
+                response.setStatus(validity.name());
+                return response;
+            }
+        } catch (Throwable t) {
+            throw new PortalServiceException("error during submit.", t);
+        }
     }
 
     /**
@@ -352,7 +352,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
     public ResubmitTicketResponse resubmitEnrollment(ResubmitTicketRequest request) throws PortalServiceException {
         EnrollmentType enrollment = request.getEnrollment();
         CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());
-        
+
         long ticketId = BinderUtils.getAsLong(request.getTicketId());
         long profileId = BinderUtils.getAsLong(enrollment.getProviderInformation().getObjectId());
         Validity validity = providerEnrollmentService.getSubmissionValidity(ticketId, profileId);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExportServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExportServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.BinderUtils;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HelpServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HelpServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.entities.HelpItem;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.rules.GlobalLookups;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateEventServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateEventServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.entities.Event;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
@@ -44,9 +44,9 @@ import java.util.logging.Logger;
 
 /**
  * This is a port of org.jbpm.process.workitem.wsht.CommandBasedWSHumanTaskHandler to use local connections.
- * 
+ *
  * See https://community.jboss.org/thread/201834
- * 
+ *
  * @author TCSASSEMBLER
  * @version 1.0
  */
@@ -74,7 +74,7 @@ public class LocalHumanTaskHandler extends GenericHandler {
 
     /**
      * Creates a new instance using the given session and service.
-     * 
+     *
      * @param session the knowledge session
      * @param service the task service
      */
@@ -99,7 +99,7 @@ public class LocalHumanTaskHandler extends GenericHandler {
 
     /**
      * Executes the human task. Maps the work item to the Task table and persists it.
-     * 
+     *
      * @param workItem the task work item
      * @param manager the work item manager.
      */
@@ -111,7 +111,7 @@ public class LocalHumanTaskHandler extends GenericHandler {
             names.add(new I18NText(LOCALE_DEFAULT, taskName));
             task.setNames(names);
         }
-        
+
         // set default values
         List<I18NText> empty = new ArrayList<I18NText>();
         empty.add(new I18NText(LOCALE_DEFAULT, ""));
@@ -159,7 +159,7 @@ public class LocalHumanTaskHandler extends GenericHandler {
     /**
      * Saves the task content data.
      * @param workItem the current work item
-     * @return the content data 
+     * @return the content data
      */
     private ContentData saveContent(WorkItem workItem) {
         ContentData content = null;
@@ -205,7 +205,7 @@ public class LocalHumanTaskHandler extends GenericHandler {
 
     /**
      * Callback for completed human task.
-     * 
+     *
      * @author TCSASSEMBLER
      * @version 1.0
      */
@@ -213,7 +213,7 @@ public class LocalHumanTaskHandler extends GenericHandler {
 
         /**
          * Executes the callback logic.
-         * 
+         *
          * @param payload the work parameters
          */
         @SuppressWarnings("rawtypes")
@@ -245,11 +245,11 @@ public class LocalHumanTaskHandler extends GenericHandler {
                                 }
                             }
                         }
-                        
+
                         if ("Y".equals(results.get("isAbort"))) {
                             session.getWorkItemManager().abortWorkItem(workItemId);
                         } else {
-                        	session.getWorkItemManager().completeWorkItem(task.getTaskData().getWorkItemId(), results);
+                            session.getWorkItemManager().completeWorkItem(task.getTaskData().getWorkItemId(), results);
                         }
                     } catch (IOException e) {
                         logger.log(Level.SEVERE, e.getMessage(), e);
@@ -266,7 +266,7 @@ public class LocalHumanTaskHandler extends GenericHandler {
 
         /**
          * Return false.
-         * 
+         *
          * @return false
          */
         public boolean isRemove() {

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.process.enrollment.GenericHandler;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.model.ApplicantType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -32,87 +32,87 @@ import com.topcoder.util.log.Level;
 
 /**
  * Implementation of a partner service.
- * 
+ *
  * @author TCSASSEMBLER
  * @version 1.0
  */
 @Stateless
 @Local(PartnerSystemService.class)
 public class MockMNITSPartnerServiceBean extends BaseService implements
-		PartnerSystemService {
+        PartnerSystemService {
 
-	@EJB
-	private ProviderEnrollmentService enrollmentService;
-	
-	/**
-	 * The domain that is acceptable.
-	 */
-	private String internalSecurityDomain;
-	
-	/**
-	 * The token for verification.
-	 */
-	private String internalSecurityToken;
-	
-	/**
-	 * Empty constructor.
-	 */
-	public MockMNITSPartnerServiceBean() {
-		CMSConfigurator config = new CMSConfigurator();
-		internalSecurityDomain = config.getInternalSecurityDomain();
-		internalSecurityToken = config.getInternalSecurityToken();
-	}
+    @EJB
+    private ProviderEnrollmentService enrollmentService;
 
-	/**
-	 * Retrieves the profiles of users from the given link.
-	 * 
-	 * @param externalUserId
-	 *            the external account link user id
-	 * @return the list of matched profiles
-	 * @throws PortalServiceException
-	 *             for any errors encountered
-	 */
-	@SuppressWarnings("unchecked")
-	public List<ProviderProfile> findProfiles(String externalUserId)
-			throws PortalServiceException {
-		return Collections.EMPTY_LIST;
-	}
+    /**
+     * The domain that is acceptable.
+     */
+    private String internalSecurityDomain;
 
-	/**
-	 * Authenticates the given credentials.
-	 * 
-	 * 1. Confirm the domain from #4 is allowable, else show access error
-	 * (domain is configurable)
-	 * 
-	 * 2. Confirm #3, else show access error
-	 * 
-	 * 3. Confirm that 1 and 2 are identical, or, that #2 works for #1, else
-	 * show access error
-	 * @throws PortalServiceException for any errors encountered 
-	 */
-	public boolean authenticate(String externalUserId, String password,
-			String profileNPI, String referrer) throws PortalServiceException {
-		
-		if (!internalSecurityDomain.equals(referrer)) {
-			getLog().log(Level.WARN, "Rejecting external login due to invalid domain: " + referrer);
-			return false;
-		} if (!internalSecurityToken.equals(password)) {
-			getLog().log(Level.WARN, "Rejecting external login due to invalid token: " + password);
-			return false;
-		}
+    /**
+     * The token for verification.
+     */
+    private String internalSecurityToken;
 
-		if (!enrollmentService.existsProfile(profileNPI)) {
-			getLog().log(Level.WARN, "Rejecting external login because provider NPI is not found.");
-			return false;
-		}
+    /**
+     * Empty constructor.
+     */
+    public MockMNITSPartnerServiceBean() {
+        CMSConfigurator config = new CMSConfigurator();
+        internalSecurityDomain = config.getInternalSecurityDomain();
+        internalSecurityToken = config.getInternalSecurityToken();
+    }
 
-		if (!externalUserId.equals(profileNPI)) {
-			if (!enrollmentService.hasGroupAffiliation(externalUserId, profileNPI)) {
-				getLog().log(Level.WARN, "Rejecting external login because affiliation is not found.");
-				return false;
-			}
-		}
-		
-		return true;
-	}
+    /**
+     * Retrieves the profiles of users from the given link.
+     *
+     * @param externalUserId
+     *            the external account link user id
+     * @return the list of matched profiles
+     * @throws PortalServiceException
+     *             for any errors encountered
+     */
+    @SuppressWarnings("unchecked")
+    public List<ProviderProfile> findProfiles(String externalUserId)
+            throws PortalServiceException {
+        return Collections.EMPTY_LIST;
+    }
+
+    /**
+     * Authenticates the given credentials.
+     *
+     * 1. Confirm the domain from #4 is allowable, else show access error
+     * (domain is configurable)
+     *
+     * 2. Confirm #3, else show access error
+     *
+     * 3. Confirm that 1 and 2 are identical, or, that #2 works for #1, else
+     * show access error
+     * @throws PortalServiceException for any errors encountered
+     */
+    public boolean authenticate(String externalUserId, String password,
+            String profileNPI, String referrer) throws PortalServiceException {
+
+        if (!internalSecurityDomain.equals(referrer)) {
+            getLog().log(Level.WARN, "Rejecting external login due to invalid domain: " + referrer);
+            return false;
+        } if (!internalSecurityToken.equals(password)) {
+            getLog().log(Level.WARN, "Rejecting external login due to invalid token: " + password);
+            return false;
+        }
+
+        if (!enrollmentService.existsProfile(profileNPI)) {
+            getLog().log(Level.WARN, "Rejecting external login because provider NPI is not found.");
+            return false;
+        }
+
+        if (!externalUserId.equals(profileNPI)) {
+            if (!enrollmentService.hasGroupAffiliation(externalUserId, profileNPI)) {
+                getLog().log(Level.WARN, "Rejecting external login because affiliation is not found.");
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.entities.ProviderProfile;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
@@ -487,7 +487,7 @@ public class PresentationServiceBean extends BaseService implements Presentation
                     personalInfoFormSettings.addSetting("requireNPI", false);
                 }
                 if (ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value().equals(type)) {
-                	personalInfoFormSettings.addSetting("hideRenewalDate", true);
+                    personalInfoFormSettings.addSetting("hideRenewalDate", true);
                     personalInfoFormSettings.addSetting("hideLicenseNumber", true);
                 }
                 page.addForm(ViewStatics.PERSONAL_INFO_FORM, personalInfoFormSettings);
@@ -565,11 +565,11 @@ public class PresentationServiceBean extends BaseService implements Presentation
             }
 
             if (ProviderType.DAY_TRAINING_AND_HABILITATION_DAY_ACTIVITY_CENTER.value().equals(type)) {
-            	settings.addSetting("requireNPI", false);
+                settings.addSetting("requireNPI", false);
             }
 
             if (ProviderType.HOME_AND_COMMUNITY_BASED_SERVICES_WAIVERED_SERVICES.value().equals(type)) {
-            	settings.addSetting("askUMPI", true);
+                settings.addSetting("askUMPI", true);
             }
             if (ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value().equals(type)) {
                 // custom form settings
@@ -675,8 +675,8 @@ public class PresentationServiceBean extends BaseService implements Presentation
                 FormSettings formSettings = new FormSettings();
                 formSettings.addSetting("askBGSInfo", false);
                 if (ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value().equals(type)) {
-                	formSettings.addSetting("askBGSInfo", true);
-                	formSettings.addSetting("askUMPIorNPI", true);
+                    formSettings.addSetting("askBGSInfo", true);
+                    formSettings.addSetting("askUMPIorNPI", true);
                 }
                 page.addForm(ViewStatics.MEMBER_INFO_FORM, formSettings);
                 viewModel.addTabModel(ViewStatics.MEMBER_INFO, page);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.BinderUtils;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.entities.ProviderType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.BinderUtils;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.impl;
 
 import java.util.Date;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.model.EnrollmentProcess;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BackgroundStudyClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BackgroundStudyClient.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.verification;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BaseSOAPClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BaseSOAPClient.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.verification;
 
 import java.io.IOException;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/DMFSearchClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/DMFSearchClient.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.verification;
 
 import gov.medicaid.domain.model.DMFVerificationRequest;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/LicenseVerificationClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/LicenseVerificationClient.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.verification;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/NPILookupClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/NPILookupClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.verification;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/PECOSSearchClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/PECOSSearchClient.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.verification;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionSearchClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionSearchClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.verification;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionServiceMatcher.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionServiceMatcher.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.verification;
 
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;

--- a/psm-app/cms-web/WebContent/js/jwysiwyg/plugins/spellchecker/SpellcheckController.java
+++ b/psm-app/cms-web/WebContent/js/jwysiwyg/plugins/spellchecker/SpellcheckController.java
@@ -28,43 +28,43 @@ import com.swabunga.spell.event.StringWordTokenizer;
 @Controller
 @RequestMapping("/spellcheck.html")
 public class SpellcheckController {
-	
-	protected static final Log log = LogFactory.getLog(SpellcheckController.class);
 
-	/** All the dictionaries in the world */
-	@Autowired private List<SpellDictionary> dictionaries;
+    protected static final Log log = LogFactory.getLog(SpellcheckController.class);
 
-	/**
-	 * Embedded implementation of {@link com.swabunga.spell.event.SpellCheckListener} 
-	 * responsible for recording potential errors from a list of words.
-	 *
-	 */
+    /** All the dictionaries in the world */
+    @Autowired private List<SpellDictionary> dictionaries;
+
+    /**
+     * Embedded implementation of {@link com.swabunga.spell.event.SpellCheckListener}
+     * responsible for recording potential errors from a list of words.
+     *
+     */
     private static class Checker implements SpellCheckListener {
         private JSONObject result;
         private JSONArray words;
-        
+
         public void init(JSONObject result) {
             this.result = result;
             words = new JSONArray();
             try {
-				this.result.put("result", words);
-			} catch (JSONException e) {
-				e.printStackTrace();
-				throw new RuntimeException(e);
-			}
+                this.result.put("result", words);
+            } catch (JSONException e) {
+                e.printStackTrace();
+                throw new RuntimeException(e);
+            }
         }
 
-		public void spellingError(SpellCheckEvent event) {
+        public void spellingError(SpellCheckEvent event) {
 
-        	String badWord = event.getInvalidWord();
-			words.put(badWord);
+            String badWord = event.getInvalidWord();
+            words.put(badWord);
 
         }
     }
-    
+
     /**
-	 * Embedded implementation of {@link com.swabunga.spell.event.SpellCheckListener} 
-	 * responsible for recording potential replacements for a mis-spelled word.
+     * Embedded implementation of {@link com.swabunga.spell.event.SpellCheckListener}
+     * responsible for recording potential replacements for a mis-spelled word.
      *
      */
     private static class Suggester implements SpellCheckListener {
@@ -75,29 +75,29 @@ public class SpellcheckController {
         }
 
         @SuppressWarnings("unchecked")
-		public void spellingError(SpellCheckEvent event) {
+        public void spellingError(SpellCheckEvent event) {
 
-        	JSONArray suggs = new JSONArray();
-            
+            JSONArray suggs = new JSONArray();
+
             List<Word> suggestions = event.getSuggestions();
             if (!suggestions.isEmpty()) {
-            	for(Word word : suggestions){
-            		suggs.put(word.getWord());
-            	}
+                for(Word word : suggestions){
+                    suggs.put(word.getWord());
+                }
             }
-            
+
             try {
-				result.put("result", suggs);
-			} catch (JSONException e) {
-				try {
-					result.put("error", e.getMessage());
-				} catch (JSONException argh) {
-					throw new RuntimeException(argh);
-				}
-			}
+                result.put("result", suggs);
+            } catch (JSONException e) {
+                try {
+                    result.put("error", e.getMessage());
+                } catch (JSONException argh) {
+                    throw new RuntimeException(argh);
+                }
+            }
         }
     }
-    
+
     /**
      * Request mapping that accepts a list of space-separated words (as a single String)
      * and returns a JSON response with a list of potential errors (case insensitive) in the following format:
@@ -112,28 +112,28 @@ public class SpellcheckController {
     @RequestMapping(params="words", method = RequestMethod.POST)
     public ResponseEntity<String> checkWordList(@RequestParam("words") String words){
 
-		JSONObject response = new JSONObject();
+        JSONObject response = new JSONObject();
 
-		SpellChecker spellChecker = new SpellChecker();
+        SpellChecker spellChecker = new SpellChecker();
         Configuration cfg = spellChecker.getConfiguration();
         cfg.setBoolean(Configuration.SPELL_IGNOREUPPERCASE, false);
-        
+
         Checker chk = new Checker();
         spellChecker.addSpellCheckListener(chk);
         for (SpellDictionary dictionary : dictionaries) {
             spellChecker.addDictionary(dictionary);
         }
-		
+
         chk.init(response);
-        spellChecker.checkSpelling(new StringWordTokenizer(words.trim()));		
-        		
+        spellChecker.checkSpelling(new StringWordTokenizer(words.trim()));
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         return new ResponseEntity<String>(response.toString(), headers, HttpStatus.OK);
     }
-    
+
     /**
-     * Request mapping that accepts a single word and returns a JSON response with a list of 
+     * Request mapping that accepts a single word and returns a JSON response with a list of
      * potential replacements in the following format:
      * <pre>
      * {
@@ -142,25 +142,25 @@ public class SpellcheckController {
      * </pre>
      * @param word
      * @return A list of potential corrections for a mis-spelled word.
-     */    
+     */
     @RequestMapping(params="word", method = RequestMethod.POST)
     public ResponseEntity<String> suggestForWord(@RequestParam("word") String word){
 
-		JSONObject response = new JSONObject();
-		
-		SpellChecker spellChecker = new SpellChecker();
+        JSONObject response = new JSONObject();
+
+        SpellChecker spellChecker = new SpellChecker();
         Configuration cfg = spellChecker.getConfiguration();
         cfg.setBoolean(Configuration.SPELL_IGNOREUPPERCASE, false);
-        
+
         Suggester sug = new Suggester();
         spellChecker.addSpellCheckListener(sug);
         for (SpellDictionary dictionary : dictionaries) {
             spellChecker.addDictionary(dictionary);
         }
-		
+
         sug.init(response);
-        spellChecker.checkSpelling(new StringWordTokenizer(word));			
-        		
+        spellChecker.checkSpelling(new StringWordTokenizer(word));
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         return new ResponseEntity<String>(response.toString(), headers, HttpStatus.OK);

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.controllers.validators.StrictCustomDateEditor;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import java.text.SimpleDateFormat;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import com.topcoder.util.log.Level;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FlashMessageInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FlashMessageInterceptor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import javax.servlet.http.HttpServletRequest;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.controllers.forms.ForgotPasswordForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.controllers.forms.UpdatePasswordForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.controllers.forms.AccountLinkForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.controllers.forms.RegistrationForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/TruncateTextTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/TruncateTextTag.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
  */
+
 package gov.medicaid.controllers;
 
 import java.io.IOException;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.entities.AgreementDocument;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -167,7 +167,7 @@ public class AgreementDocumentController extends BaseServiceAdminController {
             throw e;
         }
     }
- 
+
     /**
      * This action will get the entity with the given ID.
      *
@@ -196,7 +196,7 @@ public class AgreementDocumentController extends BaseServiceAdminController {
             throw e;
         }
     }
-    
+
     /**
      * This action will get the entity with the given ID.
      *
@@ -256,7 +256,7 @@ public class AgreementDocumentController extends BaseServiceAdminController {
         LogUtil.traceEntry(getLog(), signature, new String[] {"agreementDocument"}, new Object[] {agreementDocument});
 
         try {
-        	agreementDocument.setCreatedBy(principal.getName());
+            agreementDocument.setCreatedBy(principal.getName());
             agreementDocumentService.create(agreementDocument);
             ModelAndView model = new ModelAndView("admin/service_admin_view_agreement_document");
             model.addObject("agreementDocument", agreementDocument);
@@ -289,7 +289,7 @@ public class AgreementDocumentController extends BaseServiceAdminController {
 
         try {
             agreementDocumentService.update(agreementDocument);
-            
+
             ModelAndView model = new ModelAndView("admin/service_admin_view_agreement_document");
             model.addObject("agreementDocument", agreementDocument);
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseServiceAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseServiceAdminController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.ControllerHelper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.services.LookupService;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/DashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/DashboardController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.ControllerHelper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.binders.XMLUtility;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/HelpController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/HelpController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.entities.HelpItem;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -258,12 +258,12 @@ public class ProviderTypeController extends BaseServiceAdminController {
             List<AgreementDocument> selectedAgreements = providerType.getAgreementDocuments();
 
             for (AgreementDocument agreement: agreements) {
-            	for (AgreementDocument selectedAgreement: selectedAgreements) {
-            		if (selectedAgreement.getId() == agreement.getId()) {
-            			remainingAgreements.remove(agreement);
-            			break;
-            		}
-            	}
+                for (AgreementDocument selectedAgreement: selectedAgreements) {
+                    if (selectedAgreement.getId() == agreement.getId()) {
+                        remainingAgreements.remove(agreement);
+                        break;
+                    }
+                }
             }
             ModelAndView model = new ModelAndView("admin/service_admin_edit_provider_type");
             model.addObject("providerType", providerType);
@@ -298,15 +298,15 @@ public class ProviderTypeController extends BaseServiceAdminController {
             boolean exists = getLookupService().findLookupByDescription(ProviderType.class, providerType.getDescription()) != null;
             if (!blank && !exists) {
                 providerTypeService.create(providerType);
-                
+
                 // Retrieve
                 providerType = providerTypeService.get(providerType.getCode());
-                
+
                 ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
                 model.addObject("providerType", providerType);
                 return LogUtil.traceExit(getLog(), signature, model);
             } else {
-                
+
                 ModelAndView mv = beginCreate();
                 if (blank) {
                     ControllerHelper.addError("Please specify a provider type.");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.ControllerHelper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeValidator.java
@@ -87,6 +87,4 @@ public class ProviderTypeValidator implements Validator {
             // empty
         }
     }
-
-
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeValidator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class ProviderTypeValidator implements Validator {
     @Override
     public void validate(Object target, Errors errors) {
         if (target != null) {
-        	// empty
+            // empty
         }
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeValidator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.entities.ProviderType;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.entities.ScreeningSchedule;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ServiceAgentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ServiceAgentController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import java.util.Arrays;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.ControllerHelper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
@@ -87,6 +87,7 @@ public class SystemAdminUserSearchController extends BaseSystemAdminController {
         mv.addObject("roles", getRolesStr(criteria.getRoles()));
         return LogUtil.traceExit(getLog(), signature, mv);
     }
+
     /**
      * Gets all roles string.
      *
@@ -105,6 +106,7 @@ public class SystemAdminUserSearchController extends BaseSystemAdminController {
         }
         return Arrays.toString(roles);
     }
+
     /**
      * This action will delete the entities with the given IDs.
      *

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.ControllerHelper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.ControllerHelper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.validators.BaseValidator;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ApprovalDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ApprovalDTO.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.dto;
 
 import java.util.List;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/CMSUserDetailsWrapper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/CMSUserDetailsWrapper.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.dto;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/StatusDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/StatusDTO.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.dto;
 
 /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/AccountLinkForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/AccountLinkForm.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.forms;
 
 import java.io.Serializable;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/ForgotPasswordForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/ForgotPasswordForm.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.forms;
 
 /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/RegistrationForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/RegistrationForm.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.forms;
 
 import java.io.Serializable;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/UpdatePasswordForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/UpdatePasswordForm.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.forms;
 
 /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.AccountLinkForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/BaseValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/BaseValidator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.validators;
 
 import org.springframework.validation.Errors;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.UpdatePasswordForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.RegistrationForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/StrictCustomDateEditor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/StrictCustomDateEditor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.validators;
 
 import java.text.SimpleDateFormat;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.UpdatePasswordForm;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import gov.medicaid.controllers.dto.CMSUserDetailsWrapper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSPrincipal.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSPrincipal.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import java.security.Principal;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import gov.medicaid.controllers.dto.CMSUserDetailsWrapper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -55,19 +55,19 @@ public class CustomAuthenticationProcessingFilter extends UsernamePasswordAuthen
         if (password == null) {
             password = "";
         }
-        
+
         username = username.trim();
 
         DomainAuthenticationToken authRequest;
         if (domain == null || "MN_ITS".equalsIgnoreCase(domain)) {
-        	domain = "MN_ITS";
-        	String token = request.getParameter("token");
-        	String userNPI  = request.getParameter("userNPI");
-        	String profileNPI  = request.getParameter("profileNPI");
-        	String referrer  = request.getParameter("referrer");
-        	authRequest = new DomainAuthenticationToken(userNPI, profileNPI, token, referrer, domain);
+            domain = "MN_ITS";
+            String token = request.getParameter("token");
+            String userNPI  = request.getParameter("userNPI");
+            String profileNPI  = request.getParameter("profileNPI");
+            String referrer  = request.getParameter("referrer");
+            authRequest = new DomainAuthenticationToken(userNPI, profileNPI, token, referrer, domain);
         } else {
-			authRequest = new DomainAuthenticationToken(username, password, domain);
+            authRequest = new DomainAuthenticationToken(username, password, domain);
         }
 
         // Place the last username attempted into HttpSession for views

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import javax.servlet.http.HttpServletRequest;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -109,11 +109,11 @@ public class DefaultExternalAuthenticationProvider implements AuthenticationProv
             if (Util.isBlank(username)) {
                 throw new BadCredentialsException("Username is required.");
             } else if (Util.isBlank(password)) {
-            	throw new BadCredentialsException("Token is required.");
+                throw new BadCredentialsException("Token is required.");
             } else if (Util.isBlank(profileNPI)) {
-            	throw new BadCredentialsException("Provider NPI is required.");
+                throw new BadCredentialsException("Provider NPI is required.");
             } else if (Util.isBlank(referrer)) {
-            	throw new BadCredentialsException("Referrer is required.");
+                throw new BadCredentialsException("Referrer is required.");
             }
 
             try {
@@ -133,30 +133,30 @@ public class DefaultExternalAuthenticationProvider implements AuthenticationProv
      * Loads the user information by the external user. Auto provisions a CMS user for this record.
      *
      * @param userNPI the username used to login
-     * @param profileNPI 
+     * @param profileNPI
      * @return the mapped details
      */
     private UserDetails loadProxyUser(String userNPI, String profileNPI) {
         try {
-        	CMSUser cmsUser = registrationService.findByExternalUsername(system, userNPI);
-        	if (cmsUser == null) {
-        		cmsUser = new CMSUser();
-        		// set defaults
-        		cmsUser.setLastName(userNPI);
-        		registrationService.registerExternalUser(system, userNPI, cmsUser);
-        	}
+            CMSUser cmsUser = registrationService.findByExternalUsername(system, userNPI);
+            if (cmsUser == null) {
+                cmsUser = new CMSUser();
+                // set defaults
+                cmsUser.setLastName(userNPI);
+                registrationService.registerExternalUser(system, userNPI, cmsUser);
+            }
 
-        	// set session based fields
-        	if (userNPI.equals(profileNPI)) {
-        		cmsUser.setExternalRoleView(RoleView.SELF);
-        	} else {
-        		cmsUser.setExternalRoleView(RoleView.EMPLOYER);
-        	}
-        	cmsUser.setProxyForNPI(profileNPI);
-			ExternalAccountLink link = registrationService.findAccountLink(
-					cmsUser.getUserId(), system, userNPI);
+            // set session based fields
+            if (userNPI.equals(profileNPI)) {
+                cmsUser.setExternalRoleView(RoleView.SELF);
+            } else {
+                cmsUser.setExternalRoleView(RoleView.EMPLOYER);
+            }
+            cmsUser.setProxyForNPI(profileNPI);
+            ExternalAccountLink link = registrationService.findAccountLink(
+                    cmsUser.getUserId(), system, userNPI);
             cmsUser.setExternalAccountLink(link);
-            
+
             User springUserObject = new User(userNPI, "", true, true, true, true, EMPTY_AUTH);
             return new CMSUserDetailsWrapper(springUserObject, cmsUser, system);
         } catch (PortalServiceException e) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import gov.medicaid.controllers.dto.CMSUserDetailsWrapper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -29,16 +29,16 @@ public class DomainAuthenticationToken extends UsernamePasswordAuthenticationTok
      * The domain.
      */
     private final String domain;
-    
+
     /**
      * Profile NPI.
      */
-	private String profileNPI;
-	
-	/**
-	 * Referrer URL.
-	 */
-	private String referrer;
+    private String profileNPI;
+
+    /**
+     * Referrer URL.
+     */
+    private String referrer;
 
     /**
      * Creates a new instance from the given properties.
@@ -53,7 +53,7 @@ public class DomainAuthenticationToken extends UsernamePasswordAuthenticationTok
 
     /**
      * Creates a new instance from the given properties.
-     * 
+     *
      * @param userNPI the NPI of the user
      * @param profileNPI the requested profile
      * @param token the token for verification
@@ -61,14 +61,14 @@ public class DomainAuthenticationToken extends UsernamePasswordAuthenticationTok
      * @param domain the domain
      */
     public DomainAuthenticationToken(String userNPI, String profileNPI,
-			String token, String referrer, String domain) {
-    	super(userNPI, token);
-		this.profileNPI = profileNPI;
-		this.referrer = referrer;
-    	this.domain = domain;
-	}
+            String token, String referrer, String domain) {
+        super(userNPI, token);
+        this.profileNPI = profileNPI;
+        this.referrer = referrer;
+        this.domain = domain;
+    }
 
-	/**
+    /**
      * Gets the value of the field <code>domain</code>.
      *
      * @return the domain
@@ -77,35 +77,35 @@ public class DomainAuthenticationToken extends UsernamePasswordAuthenticationTok
         return domain;
     }
 
-	/**
-	 * Gets the value of the field <code>profileNPI</code>.
-	 * @return the profileNPI
-	 */
-	public String getProfileNPI() {
-		return profileNPI;
-	}
+    /**
+     * Gets the value of the field <code>profileNPI</code>.
+     * @return the profileNPI
+     */
+    public String getProfileNPI() {
+        return profileNPI;
+    }
 
-	/**
-	 * Sets the value of the field <code>profileNPI</code>.
-	 * @param profileNPI the profileNPI to set
-	 */
-	public void setProfileNPI(String profileNPI) {
-		this.profileNPI = profileNPI;
-	}
+    /**
+     * Sets the value of the field <code>profileNPI</code>.
+     * @param profileNPI the profileNPI to set
+     */
+    public void setProfileNPI(String profileNPI) {
+        this.profileNPI = profileNPI;
+    }
 
-	/**
-	 * Gets the value of the field <code>referrer</code>.
-	 * @return the referrer
-	 */
-	public String getReferrer() {
-		return referrer;
-	}
+    /**
+     * Gets the value of the field <code>referrer</code>.
+     * @return the referrer
+     */
+    public String getReferrer() {
+        return referrer;
+    }
 
-	/**
-	 * Sets the value of the field <code>referrer</code>.
-	 * @param referrer the referrer to set
-	 */
-	public void setReferrer(String referrer) {
-		this.referrer = referrer;
-	}
+    /**
+     * Sets the value of the field <code>referrer</code>.
+     * @param referrer the referrer to set
+     */
+    public void setReferrer(String referrer) {
+        this.referrer = referrer;
+    }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import gov.medicaid.controllers.dto.CMSUserDetailsWrapper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainLdapAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainLdapAuthenticationProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.security;
 
 import gov.medicaid.entities.SystemId;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -9,7 +9,6 @@ import net.thucydides.core.annotations.Steps;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 @SuppressWarnings("unused")
 public class EnrollmentStepDefinitions {
     @Steps

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -131,7 +131,6 @@ public class EnrollmentSteps {
         organizationInfoPage.setContactPhone("4445556666");
     }
 
-
     public String generateEffectiveDate() {
         GregorianCalendar cal = new GregorianCalendar();
         cal.setTime(new Date());

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 @SuppressWarnings("unused")
 public class ValidationStepDefinitions {
     @Steps

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
@@ -1,11 +1,9 @@
 package gov.medicaid.features.enrollment.ui;
 
-
 import net.serenitybdd.core.annotations.findby.By;
 import net.thucydides.core.pages.PageObject;
 import org.openqa.selenium.WebElement;
 import java.util.List;
-
 
 public class EnrollmentPage extends PageObject {
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
@@ -7,7 +7,6 @@ public class OrganizationInfoPage extends EnrollmentPage {
         $("#fein").typeAndTab(feinValue);
     }
 
-
     public String getFEINValue() {
         return $("#fein").getValue();
     }
@@ -40,7 +39,6 @@ public class OrganizationInfoPage extends EnrollmentPage {
         throw new PendingException("Issue #347 - Capture Medicaid Number for new Enrollments");
     }
 
-
     public boolean isPersonalEnrollment() {
         return this.getTitle().equals("Personal Information");
     }
@@ -56,7 +54,6 @@ public class OrganizationInfoPage extends EnrollmentPage {
     public void setEffectiveDate(String effectiveDate) {
         $("[name='_15_effectiveDate']").type(effectiveDate);
     }
-
 
     public void setDoingBusinessAs(String dba) {
         $("#name").sendKeys(dba);

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
@@ -88,7 +88,6 @@ public class OwnershipInfoPage extends EnrollmentPage {
         $("[name='_17_iboOtherState_0']").selectByVisibleText(state);
     }
 
-
     public void selectControlOwnershipCounty(String county) {
         $("[name='_17_iboOtherCounty0']").selectByVisibleText(county);
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -40,7 +40,6 @@ public class PersonalInfoPage extends PageObject {
         $("[name=_02_ssn]").type(SSN);
     }
 
-
     public void enterEmail(String email) {
         $("#emailAddress").type(email);
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -1,6 +1,5 @@
 package gov.medicaid.features.general.ui;
 
-
 import net.thucydides.core.pages.PageObject;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -1,8 +1,8 @@
 package gov.medicaid.features.general.ui;
 
-
 import net.thucydides.core.pages.PageObject;
 import net.thucydides.core.annotations.DefaultUrl;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DefaultUrl("http://localhost:8080/cms")

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AgencyInformationType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AdditionalPracticeLocationsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AmbulanceServicesType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import com.topcoder.util.errorhandling.BaseCriticalException;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
@@ -80,7 +80,6 @@ public class CLIAFormBinder extends BaseFormBinder {
         List<CLIACertificateType> licenseList = new ArrayList<CLIACertificateType>(licenseInfo.getCLIACertificate());
         licenseInfo.getCLIACertificate().clear();
 
-
         // bind licenses
         int i = 0;
         Set<String> linkedAttachments = new HashSet<String>();

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
@@ -81,7 +81,6 @@ public class FacilityTypeFormBinder extends BaseFormBinder {
                 replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, CONTRACT_WITH_COUNTY);
             }
 
-
             List<DocumentType> attachment = attachments.getAttachment();
             for (DocumentType doc : attachment) {
                 if (CONTRACT_WITH_COUNTY.equals(doc.getName())) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
@@ -126,7 +126,6 @@ public class FederalQualificationFormBinder extends BaseFormBinder {
         }
     }
 
-
     private void replaceDocument(AttachedDocumentsType attachments, String id, String value) {
         List<DocumentType> toRemove = new ArrayList<DocumentType>();
         List<DocumentType> attachment = attachments.getAttachment();

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.ApplicantInformationType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AgencyInformationType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AcceptedAgreementsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
@@ -379,7 +379,6 @@ public class LicenseInformationFormBinder extends BaseFormBinder {
         }
     }
 
-
     @Override
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model)
         throws DocumentException {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.ApplicantType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -585,7 +585,6 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
         PdfPTable personalInfo = new PdfPTable(2);
         PDFHelper.setTableAsFullPage(personalInfo);
 
-
         if (useEDILayout) {
             PDFHelper.addLabelValueCell(personalInfo, "EDI Type", PDFHelper.value(model, ns, "subType"));
         }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AcceptedAgreementsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -110,7 +110,6 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
             AddressType address = readAddress(request, "ibo", i);
             person.getContactInformation().setAddress(address);
 
-
             try {
                 bo.setHireDate(BinderUtils.getAsCalendar(param(request, "iboHireDate", i)));
             } catch (BinderException e) {
@@ -603,6 +602,5 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
 
     @Override
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model)
-        throws DocumentException {
-    }
+        throws DocumentException {}
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.DesignatedContactInformationType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.ApplicantInformationType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
@@ -164,7 +164,6 @@ public class PracticeTypeFormBinder extends BaseFormBinder {
         }
     }
 
-
     @Override
     public void renderPDF(EnrollmentType enrollment, Document document, Map<String, Object> model)
         throws DocumentException {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.ApplicantType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AddressType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AttachedDocumentsType;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.binders;
 
 import gov.medicaid.domain.model.AcceptedAgreementsType;

--- a/psm-app/services/src/main/java/gov/medicaid/dao/IdentityProviderDAO.java
+++ b/psm-app/services/src/main/java/gov/medicaid/dao/IdentityProviderDAO.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.dao;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/services/src/main/java/gov/medicaid/dao/impl/LDAPIdentityProviderDAOBean.java
+++ b/psm-app/services/src/main/java/gov/medicaid/dao/impl/LDAPIdentityProviderDAOBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.dao.impl;
 
 import gov.medicaid.dao.IdentityProviderDAO;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.*;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
@@ -125,14 +125,14 @@ public class AgreementDocument implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-    	if (obj instanceof AgreementDocument) {
-    		return ((AgreementDocument)obj).getId() == this.getId();
-    	}
-    	return false;
+        if (obj instanceof AgreementDocument) {
+            return ((AgreementDocument)obj).getId() == this.getId();
+        }
+        return false;
     }
 
     @Override
     public int hashCode() {
-    	return (int) this.getId();
+        return (int) this.getId();
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Id;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.io.Serializable;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 import javax.persistence.Column;
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import org.hibernate.annotations.GenericGenerator;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import gov.medicaid.binders.BinderUtils;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -354,51 +354,51 @@ public class CMSUser implements Serializable {
             businessPhoneExt);
     }
 
-	/**
-	 * Gets the value of the field <code>externalRoleView</code>.
-	 * @return the externalRoleView
-	 */
-	public RoleView getExternalRoleView() {
-		return externalRoleView;
-	}
+    /**
+     * Gets the value of the field <code>externalRoleView</code>.
+     * @return the externalRoleView
+     */
+    public RoleView getExternalRoleView() {
+        return externalRoleView;
+    }
 
-	/**
-	 * Sets the value of the field <code>externalRoleView</code>.
-	 * @param externalRoleView the externalRoleView to set
-	 */
-	public void setExternalRoleView(RoleView externalRoleView) {
-		this.externalRoleView = externalRoleView;
-	}
+    /**
+     * Sets the value of the field <code>externalRoleView</code>.
+     * @param externalRoleView the externalRoleView to set
+     */
+    public void setExternalRoleView(RoleView externalRoleView) {
+        this.externalRoleView = externalRoleView;
+    }
 
-	/**
-	 * Gets the value of the field <code>proxyForNPI</code>.
-	 * @return the proxyForNPI
-	 */
-	public String getProxyForNPI() {
-		return proxyForNPI;
-	}
+    /**
+     * Gets the value of the field <code>proxyForNPI</code>.
+     * @return the proxyForNPI
+     */
+    public String getProxyForNPI() {
+        return proxyForNPI;
+    }
 
-	/**
-	 * Sets the value of the field <code>proxyForNPI</code>.
-	 * @param proxyForNPI the proxyForNPI to set
-	 */
-	public void setProxyForNPI(String proxyForNPI) {
-		this.proxyForNPI = proxyForNPI;
-	}
+    /**
+     * Sets the value of the field <code>proxyForNPI</code>.
+     * @param proxyForNPI the proxyForNPI to set
+     */
+    public void setProxyForNPI(String proxyForNPI) {
+        this.proxyForNPI = proxyForNPI;
+    }
 
-	/**
-	 * Gets the value of the field <code>externalAccountLink</code>.
-	 * @return the externalAccountLink
-	 */
-	public ExternalAccountLink getExternalAccountLink() {
-		return externalAccountLink;
-	}
+    /**
+     * Gets the value of the field <code>externalAccountLink</code>.
+     * @return the externalAccountLink
+     */
+    public ExternalAccountLink getExternalAccountLink() {
+        return externalAccountLink;
+    }
 
-	/**
-	 * Sets the value of the field <code>externalAccountLink</code>.
-	 * @param externalAccountLink the externalAccountLink to set
-	 */
-	public void setExternalAccountLink(ExternalAccountLink externalAccountLink) {
-		this.externalAccountLink = externalAccountLink;
-	}
+    /**
+     * Sets the value of the field <code>externalAccountLink</code>.
+     * @param externalAccountLink the externalAccountLink to set
+     */
+    public void setExternalAccountLink(ExternalAccountLink externalAccountLink) {
+        this.externalAccountLink = externalAccountLink;
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactData.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactData.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Degree.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Degree.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContactType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContactType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EmailTemplate.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EmailTemplate.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalProfileLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalProfileLink.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/HelpItem.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/HelpItem.java
@@ -94,6 +94,4 @@ public class HelpItem {
     public void setDescription(String description) {
         this.description = description;
     }
-
-    
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/HelpItem.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/HelpItem.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/HelpSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/HelpSearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.io.Serializable;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -15,7 +15,6 @@
  */
 package gov.medicaid.entities;
 
-
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LicenseType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LicenseType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
@@ -59,7 +59,6 @@ public class Note implements Serializable {
     @Column(name = "created_at")
     private Date createdOn;
 
-
     public long getProfileId() {
         return profileId;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
@@ -41,7 +41,6 @@ public class OrganizationBeneficialOwner extends BeneficialOwner {
     @Column()
     private String fein;
 
-
     public String getLegalName() {
         return legalName;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
@@ -66,7 +66,6 @@ public class OwnershipInformation implements Serializable {
     @JoinColumn(name = "ownership_info_id", referencedColumnName = "ownership_info_id")
     private List<BeneficialOwner> beneficialOwners;
 
-
     public long getId() {
         return id;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.*;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Person.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Person.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
@@ -17,6 +17,7 @@ package gov.medicaid.entities;
 
 import java.util.Date;
 import javax.persistence.*;
+
 /**
  * A person beneficial owner.
  *
@@ -71,7 +72,6 @@ public class PersonBeneficialOwner extends BeneficialOwner {
     @ManyToOne
     @JoinColumn(name = "relationship_type_code")
     private RelationshipType relationship;
-
 
     public String getFirstName() {
         return firstName;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PracticeLookup.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PracticeLookup.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProfileHeader.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProfileHeader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProfileStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProfileStatus.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderLookup.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderLookup.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderProfile.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderProfile.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import gov.medicaid.binders.BinderUtils;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
@@ -110,13 +110,13 @@ public class ProviderType extends LookupEntity {
         this.applicantType = applicantType;
     }
 
-	public boolean isCanDelete() {
-		return canDelete;
-	}
+    public boolean isCanDelete() {
+        return canDelete;
+    }
 
-	public void setCanDelete(boolean canDelete) {
-		this.canDelete = canDelete;
-	}
+    public void setCanDelete(boolean canDelete) {
+        this.canDelete = canDelete;
+    }
 
     public List<AgreementDocument> getAgreementDocuments() {
         return agreementDocuments;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import gov.medicaid.domain.model.ApplicantType;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSetting.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSetting.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RequestType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RequestType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RiskLevel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RiskLevel.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Role.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Role.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RoleView.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RoleView.java
@@ -2,13 +2,13 @@ package gov.medicaid.entities;
 
 public enum RoleView {
 
-	/**
-	 * External user view.
-	 */
-	SELF, 
-	
-	/**
-	 * Employer view for external user.
-	 */
-	EMPLOYER
+    /**
+     * External user view.
+     */
+    SELF,
+
+    /**
+     * Employer view for external user.
+     */
+    EMPLOYER
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningIntervalType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningIntervalType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -49,7 +49,6 @@ public class ScreeningSchedule implements Serializable {
     @Column(name = "interval_type")
     private ScreeningIntervalType intervalType;
 
-
     public Date getUpcomingScreeningDate() {
         return upcomingScreeningDate;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.List;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ServiceCategory.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package gov.medicaid.entities;
+
 import javax.persistence.Table;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SpecialtyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SpecialtyType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/StateType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/StateType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Table;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserRequest.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserRequest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 import java.util.List;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserStatus.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Validity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Validity.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormError.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormError.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities.dto;
 
 /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormSettings.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormSettings.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities.dto;
 
 import java.util.HashMap;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/MinimumLicenseRulesModel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/MinimumLicenseRulesModel.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities.dto;
 
 import java.util.ArrayList;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/UITabModel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/UITabModel.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities.dto;
 
 import java.util.ArrayList;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewModel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewModel.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities.dto;
 
 import java.util.HashMap;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.entities.dto;
 
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.entities.AgreementDocument;

--- a/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.EnrollmentProcess;

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -63,9 +63,9 @@ public class CMSConfigurator {
     /**
      * EMF that uses the XA data source.
      */
-	private EntityManagerFactory emf;
+    private EntityManagerFactory emf;
 
-	private EntityManager portalEntityManager;
+    private EntityManager portalEntityManager;
 
     /**
      * Reads the configuration and stores it.
@@ -299,11 +299,11 @@ public class CMSConfigurator {
      * @return the portal entity manager
      */
     public EntityManager getPortalEntityManager() {
-    	if (emf == null) {
-    		emf = Persistence.createEntityManagerFactory("cms");
-    		portalEntityManager = emf.createEntityManager();
-    	}
-		return portalEntityManager;
+        if (emf == null) {
+            emf = Persistence.createEntityManagerFactory("cms");
+            portalEntityManager = emf.createEntityManager();
+        }
+        return portalEntityManager;
     }
 
     /**
@@ -350,13 +350,13 @@ public class CMSConfigurator {
      * Retrieves the flag setting for using external or embedded rules
      * @return the flag setting for rules
      */
-	public String getUseEmbeddedRules() {
+    public String getUseEmbeddedRules() {
         return globalSettings.getProperty("rules.embedded");
-	}
+    }
 
     /**
      * Gets the configured pdf files folder
-     * 
+     *
      * @return the pdf files folder
      */
     public String getExportPDFFolder() {
@@ -367,15 +367,15 @@ public class CMSConfigurator {
      * The allowed referrer domain for MN logins.
      * @return the configured domain
      */
-	public String getInternalSecurityDomain() {
+    public String getInternalSecurityDomain() {
         return globalSettings.getProperty("internalSecurityDomain");
-	}
-	
-	/**
-	 * The allowed referrer domain for MN logins.
-	 * @return the configured domain
-	 */
-	public String getInternalSecurityToken() {
-		return globalSettings.getProperty("internalSecurityToken");
-	}
+    }
+
+    /**
+     * The allowed referrer domain for MN logins.
+     * @return the configured domain
+     */
+    public String getInternalSecurityToken() {
+        return globalSettings.getProperty("internalSecurityToken");
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.binders.BaseFormBinder;

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.GetLookupGroupsRequest;

--- a/psm-app/services/src/main/java/gov/medicaid/services/EntityNotFoundException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EntityNotFoundException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import javax.ejb.ApplicationException;

--- a/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.entities.Event;

--- a/psm-app/services/src/main/java/gov/medicaid/services/ExportService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ExportService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/services/HelpService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/HelpService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.entities.HelpItem;

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.ApplicantType;

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -130,10 +130,10 @@ public interface LookupService {
     public List<BeneficialOwnerType> findBeneficialOwnerTypes(String entityType);
 
     /**
-	 * Updates the ProviderTypeSettings for agreements.
-	 *
-	 * @param providerType providerType
-	 * @param agreementIds agreement ids
-	 */
-	public void updateProviderTypeAgreementSettings(ProviderType providerType, long[] agreementIds);
+     * Updates the ProviderTypeSettings for agreements.
+     *
+     * @param providerType providerType
+     * @param agreementIds agreement ids
+     */
+    public void updateProviderTypeAgreementSettings(ProviderType providerType, long[] agreementIds);
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.entities.ProviderProfile;

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceConfigurationException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceConfigurationException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import com.topcoder.util.errorhandling.BaseRuntimeException;

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import javax.ejb.ApplicationException;

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceRuntimeException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceRuntimeException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import javax.ejb.ApplicationException;

--- a/psm-app/services/src/main/java/gov/medicaid/services/PresentationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PresentationService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import javax.jws.WebService;

--- a/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import gov.medicaid.entities.CMSUser;

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/LogUtil.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/LogUtil.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.util;
 
 import java.io.IOException;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
@@ -256,6 +256,4 @@ public class PDFHelper {
         sb.append(p4);
         return sb.toString();
     }
-
-
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.util;
 
 import java.util.Map;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.util;
 
 import gov.medicaid.services.PortalServiceConfigurationException;

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package gov.medicaid.services.util;
 
 import gov.medicaid.binders.BinderUtils;


### PR DESCRIPTION
Now that we have checkstyle in our project, add some rules about whitespace to it:
- [no padding spaces in empty `for` initializers](http://checkstyle.sourceforge.net/config_whitespace.html#EmptyForInitializerPad) (good: `for (; i < 5; i++) {}`, bad: `for ( ; i < 5; i++) {}`)
- [no padding spaces in empty `for` iterators](http://checkstyle.sourceforge.net/config_whitespace.html#EmptyForIteratorPad) (good: `for (int i = 1; i < 5;) {i++;}`, bad: `for (int i = 1; i < 5; ) {i++;}`)
- [no padding spaces around generic type specifiers](http://checkstyle.sourceforge.net/config_whitespace.html#GenericWhitespace)
- [no space before or after a method's opening paren, except a newline after](http://checkstyle.sourceforge.net/config_whitespace.html#MethodParamPad)
- [no line wraps on `package`, `import`, or `import static` statements](http://checkstyle.sourceforge.net/config_whitespace.html#NoLineWrap)
- [no whitespace before certain tokens (`,` `;` `...` `++`)](http://checkstyle.sourceforge.net/config_whitespace.html#NoWhitespaceBefore)
- [no spaces after `(` or before `)`](http://checkstyle.sourceforge.net/config_whitespace.html#ParenPad), including [for typecasts](http://checkstyle.sourceforge.net/config_whitespace.html#TypecastParenPad)

The above rules were already being followed in our codebase; additionally, clean up for and then enforce the following rules:
- [no tabs in Java code](http://checkstyle.sourceforge.net/config_whitespace.html#FileTabCharacter) ([whitespace-only commit](https://github.com/OpenTechStrategies/psm/commit/84b44b288a0e22ae45d8ccd48e01c7f1440f98f0?w=1))
- [require exactly one empty line between several statements](http://checkstyle.sourceforge.net/config_whitespace.html#EmptyLineSeparator), except class variables, which may have either zero or one blank line separating them

You can see that the rules are working by `./gradlew checkstyleMain checkstyleTest`, or by looking at the Travis build report, which invokes the same.

Issue #456 Use consistent code style