### PR TITLE
Remove some instances of TopCoder logging

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/NPILookupHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/NPILookupHandler.java
@@ -3,6 +3,8 @@
  */
 package gov.medicaid.process.enrollment;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.ApplicantInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -13,17 +15,12 @@ import gov.medicaid.domain.model.ScreeningResultsType;
 import gov.medicaid.domain.model.VerificationStatusType;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.NPILookupClient;
-
-import java.io.IOException;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.TransformerException;
-
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
 
 /**
  * This verifies that the NPI provided is avaliable on lookup site.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/NPILookupHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/NPILookupHandler.java
@@ -3,8 +3,6 @@
  */
 package gov.medicaid.process.enrollment;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.ApplicantInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -13,7 +11,6 @@ import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.domain.model.ScreeningResultType;
 import gov.medicaid.domain.model.ScreeningResultsType;
 import gov.medicaid.domain.model.VerificationStatusType;
-import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.NPILookupClient;
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
@@ -21,6 +18,7 @@ import org.drools.runtime.process.WorkItemManager;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * This verifies that the NPI provided is avaliable on lookup site.
@@ -29,11 +27,8 @@ import java.io.IOException;
  * @version 1.0
  */
 public class NPILookupHandler extends GenericHandler {
-
-    /**
-     * Class logger.
-     */
-    private Log log = LogUtil.getLog("NPILookupHandler");
+    private static final Logger LOGGER =
+            Logger.getLogger(NPILookupHandler.class.getName());
 
     /**
      * Checks the NPI Lookup Service.
@@ -44,7 +39,7 @@ public class NPILookupHandler extends GenericHandler {
      *            the work item manager
      */
     public void executeWorkItem(WorkItem item, WorkItemManager manager) {
-        log.log(Level.INFO, "Verifying NPI...");
+        LOGGER.info("Verifying NPI...");
         EnrollmentProcess processModel = (EnrollmentProcess) item.getParameter("model");
         ProviderInformationType provider = XMLUtility.nsGetProvider(processModel);
         ApplicantInformationType applicant = provider.getApplicantInformation();
@@ -73,15 +68,15 @@ public class NPILookupHandler extends GenericHandler {
             }
             screeningResultType.setSearchResult(results.getSearchResults());
         } catch (JAXBException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (IOException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (TransformerException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/SAMExcludedProvidersScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/SAMExcludedProvidersScreeningHandler.java
@@ -3,8 +3,6 @@
  */
 package gov.medicaid.process.enrollment;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.EnrollmentProcess;
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;
@@ -13,7 +11,6 @@ import gov.medicaid.domain.model.ScreeningResultType;
 import gov.medicaid.domain.model.ScreeningResultsType;
 import gov.medicaid.domain.model.VerificationStatusType;
 import gov.medicaid.domain.rules.inference.MatchStatus;
-import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.SAMExclusionSearchClient;
 import gov.medicaid.verification.SAMExclusionServiceMatcher;
 import org.drools.runtime.process.WorkItem;
@@ -22,6 +19,7 @@ import org.drools.runtime.process.WorkItemManager;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * This checks the excluded providers from the SAM website.
@@ -30,11 +28,8 @@ import java.io.IOException;
  * @version 1.0
  */
 public class SAMExcludedProvidersScreeningHandler extends GenericHandler {
-
-    /**
-     * Class logger.
-     */
-    private Log log = LogUtil.getLog("SAMExcludedProvidersScreeningHandler");
+    private static final Logger LOGGER =
+            Logger.getLogger(SAMExcludedProvidersScreeningHandler.class.getName());
 
     /**
      * SAM exclusion screening.
@@ -45,7 +40,7 @@ public class SAMExcludedProvidersScreeningHandler extends GenericHandler {
      *            the work item manager
      */
     public void executeWorkItem(WorkItem item, WorkItemManager manager) {
-        log.log(Level.INFO, "Checking SAM provider exclusion.");
+        LOGGER.info("Checking SAM provider exclusion.");
         EnrollmentProcess processModel = (EnrollmentProcess) item.getParameter("model");
 
         ProviderInformationType provider = XMLUtility.nsGetProvider(processModel);
@@ -74,15 +69,15 @@ public class SAMExcludedProvidersScreeningHandler extends GenericHandler {
             screeningResultType.setStatus(XMLUtility.newStatus("SUCCESS"));
             screeningResultType.setSAMExclusionVerificationResult(results.getSearchResults());
         } catch (TransformerException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (JAXBException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (IOException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/SAMExcludedProvidersScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/SAMExcludedProvidersScreeningHandler.java
@@ -3,6 +3,8 @@
  */
 package gov.medicaid.process.enrollment;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.EnrollmentProcess;
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;
@@ -14,17 +16,12 @@ import gov.medicaid.domain.rules.inference.MatchStatus;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.SAMExclusionSearchClient;
 import gov.medicaid.verification.SAMExclusionServiceMatcher;
-
-import java.io.IOException;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.TransformerException;
-
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
 
 /**
  * This checks the excluded providers from the SAM website.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyBackgroundStudyHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyBackgroundStudyHandler.java
@@ -15,6 +15,8 @@
  */
 package gov.medicaid.process.enrollment;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.AgencyInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -29,18 +31,13 @@ import gov.medicaid.domain.model.VerificationStatusType;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.services.util.Util;
 import gov.medicaid.verification.BackgroundStudyClient;
-
-import java.io.IOException;
-import java.util.List;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.TransformerException;
-
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
+import java.util.List;
 
 /**
  * This verifies that the background study ID is valid and that it is not denied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyBackgroundStudyHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyBackgroundStudyHandler.java
@@ -15,8 +15,6 @@
  */
 package gov.medicaid.process.enrollment;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.AgencyInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -28,7 +26,6 @@ import gov.medicaid.domain.model.ScreeningResultsType;
 import gov.medicaid.domain.model.SearchResultItemType;
 import gov.medicaid.domain.model.SearchResultType;
 import gov.medicaid.domain.model.VerificationStatusType;
-import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.services.util.Util;
 import gov.medicaid.verification.BackgroundStudyClient;
 import org.drools.runtime.process.WorkItem;
@@ -38,6 +35,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * This verifies that the background study ID is valid and that it is not denied.
@@ -47,11 +45,8 @@ import java.util.List;
  * @since External Sources Integration Assembly II
  */
 public class VerifyBackgroundStudyHandler extends GenericHandler {
-
-    /**
-     * Class logger.
-     */
-    private Log log = LogUtil.getLog("VerifyBackgroundStudyHandler");
+    private static final Logger LOGGER =
+            Logger.getLogger(VerifyBackgroundStudyHandler.class.getName());
 
     /**
      * Checks the NETStudy service for the background study id entered for agencies.
@@ -60,7 +55,7 @@ public class VerifyBackgroundStudyHandler extends GenericHandler {
      * @param manager the work item manager
      */
     public void executeWorkItem(WorkItem item, WorkItemManager manager) {
-        log.log(Level.INFO, "Verifying Background study results...");
+        LOGGER.info("Verifying Background study results...");
         EnrollmentProcess processModel = (EnrollmentProcess) item.getParameter("model");
         ProviderInformationType provider = XMLUtility.nsGetProvider(processModel);
         AgencyInformationType agency = provider.getAgencyInformation();
@@ -96,15 +91,15 @@ public class VerifyBackgroundStudyHandler extends GenericHandler {
             }
             screeningResultType.setSearchResult(matchResults);
         } catch (JAXBException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (IOException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (TransformerException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyLicenseHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyLicenseHandler.java
@@ -15,6 +15,8 @@
  */
 package gov.medicaid.process.enrollment;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.EnrollmentProcess;
 import gov.medicaid.domain.model.FacilityCredentialsType;
@@ -35,22 +37,17 @@ import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.services.util.Util;
 import gov.medicaid.verification.LicenseVerificationClient;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.drools.runtime.process.WorkItem;
+import org.drools.runtime.process.WorkItemManager;
 
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.TransformerException;
-
-import org.drools.runtime.StatefulKnowledgeSession;
-import org.drools.runtime.process.WorkItem;
-import org.drools.runtime.process.WorkItemManager;
-
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 
 /**
  * This handler is used to verify facility and individual licenses.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyPECOSRecordHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyPECOSRecordHandler.java
@@ -15,8 +15,6 @@
  */
 package gov.medicaid.process.enrollment;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.ApplicantInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -28,7 +26,6 @@ import gov.medicaid.domain.model.SearchResultType;
 import gov.medicaid.domain.model.VerificationStatusType;
 import gov.medicaid.domain.rules.inference.MatchStatus;
 import gov.medicaid.domain.rules.inference.ProviderNameMatcher;
-import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.PECOSSearchClient;
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
@@ -36,6 +33,7 @@ import org.drools.runtime.process.WorkItemManager;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * This verifies that the NPI is present in the PECOS records.
@@ -45,11 +43,8 @@ import java.io.IOException;
  * @since External Sources Integration Assembly II
  */
 public class VerifyPECOSRecordHandler extends GenericHandler {
-
-    /**
-     * Class logger.
-     */
-    private Log log = LogUtil.getLog("VerifySSNHandler");
+    private static final Logger LOGGER =
+            Logger.getLogger(VerifyPECOSRecordHandler.class.getName());
 
     /**
      * Checks the PECOS service for the NPI of the provider.
@@ -58,7 +53,7 @@ public class VerifyPECOSRecordHandler extends GenericHandler {
      * @param manager the work item manager
      */
     public void executeWorkItem(WorkItem item, WorkItemManager manager) {
-        log.log(Level.INFO, "Verifying NPI in PECOS...");
+        LOGGER.info("Verifying NPI in PECOS...");
         EnrollmentProcess processModel = (EnrollmentProcess) item.getParameter("model");
         ProviderInformationType provider = XMLUtility.nsGetProvider(processModel);
         ApplicantInformationType applicant = provider.getApplicantInformation();
@@ -91,15 +86,15 @@ public class VerifyPECOSRecordHandler extends GenericHandler {
             }
             screeningResultType.setSearchResult(matchResults);
         } catch (JAXBException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (IOException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (TransformerException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyPECOSRecordHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifyPECOSRecordHandler.java
@@ -15,6 +15,8 @@
  */
 package gov.medicaid.process.enrollment;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.ApplicantInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -28,17 +30,12 @@ import gov.medicaid.domain.rules.inference.MatchStatus;
 import gov.medicaid.domain.rules.inference.ProviderNameMatcher;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.PECOSSearchClient;
-
-import java.io.IOException;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.TransformerException;
-
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
 
 /**
  * This verifies that the NPI is present in the PECOS records.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifySSNHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifySSNHandler.java
@@ -15,6 +15,8 @@
  */
 package gov.medicaid.process.enrollment;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.ApplicantInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -25,17 +27,12 @@ import gov.medicaid.domain.model.ScreeningResultsType;
 import gov.medicaid.domain.model.VerificationStatusType;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.DMFSearchClient;
-
-import java.io.IOException;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.TransformerException;
-
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
 
 /**
  * This verifies that the SSN is not present in the DMF records.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifySSNHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/VerifySSNHandler.java
@@ -15,8 +15,6 @@
  */
 package gov.medicaid.process.enrollment;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.ApplicantInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -25,7 +23,6 @@ import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.domain.model.ScreeningResultType;
 import gov.medicaid.domain.model.ScreeningResultsType;
 import gov.medicaid.domain.model.VerificationStatusType;
-import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.verification.DMFSearchClient;
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
@@ -33,6 +30,7 @@ import org.drools.runtime.process.WorkItemManager;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * This verifies that the SSN is not present in the DMF records.
@@ -42,11 +40,8 @@ import java.io.IOException;
  * @since External Sources Integration Assembly II
  */
 public class VerifySSNHandler extends GenericHandler {
-
-    /**
-     * Class logger.
-     */
-    private Log log = LogUtil.getLog("VerifySSNHandler");
+    private static final Logger LOGGER =
+            Logger.getLogger(VerifySSNHandler.class.getName());
 
     /**
      * Checks the DMF service for the SSN of the provider.
@@ -55,7 +50,7 @@ public class VerifySSNHandler extends GenericHandler {
      * @param manager the work item manager
      */
     public void executeWorkItem(WorkItem item, WorkItemManager manager) {
-        log.log(Level.INFO, "Verifying SSN...");
+        LOGGER.info("Verifying SSN...");
         EnrollmentProcess processModel = (EnrollmentProcess) item.getParameter("model");
         ProviderInformationType provider = XMLUtility.nsGetProvider(processModel);
         ApplicantInformationType applicant = provider.getApplicantInformation();
@@ -81,15 +76,15 @@ public class VerifySSNHandler extends GenericHandler {
             }
             screeningResultType.setSearchResult(results.getSearchResults());
         } catch (JAXBException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (IOException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         } catch (TransformerException e) {
-            log.log(Level.ERROR, e);
+            LOGGER.severe(e.toString());
             results = new ExternalSourcesScreeningResultType();
             results.setStatus(XMLUtility.newStatus("ERROR"));
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -15,7 +15,6 @@
  */
 package gov.medicaid.services.impl;
 
-import com.topcoder.util.log.Level;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.EditHistoryType;
 import gov.medicaid.domain.model.EnrollmentProcess;
@@ -84,11 +83,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.SEVERE;
 
 @Stateless
 @Local(BusinessProcessService.class)
 @TransactionManagement(TransactionManagementType.BEAN)
 public class BusinessProcessServiceBean extends BaseService implements BusinessProcessService {
+    private static final Logger LOGGER =
+            Logger.getLogger(BusinessProcessServiceBean.class.getName());
 
     /**
      * See https://issues.jboss.org/browse/JBPM-3791
@@ -196,7 +200,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
                 try {
                     ksession.dispose();
                 } catch (Throwable t) {
-                    getLog().log(Level.ERROR, t, "Could not close session.");
+                    LOGGER.log(SEVERE, "Could not close session.", t);
                 }
             }
         }
@@ -233,7 +237,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
             try {
                 ksession.dispose();
             } catch (Throwable t) {
-                getLog().log(Level.ERROR, t, "Could not close session.");
+                LOGGER.log(SEVERE, "Could not close session.", t);
             }
         }
     }
@@ -365,7 +369,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
             try {
                 ksession.dispose();
             } catch (Throwable t) {
-                getLog().log(Level.ERROR, t, "Could not close session.");
+                LOGGER.log(SEVERE, "Could not close session.", t);
             }
             client.dispose();
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BackgroundStudyClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BackgroundStudyClient.java
@@ -15,8 +15,6 @@
  */
 package gov.medicaid.verification;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;
 import gov.medicaid.domain.model.NETStudyVerificationRequest;
 import gov.medicaid.domain.model.NETStudyVerificationResponse;
@@ -25,7 +23,6 @@ import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.domain.model.SearchResultItemType;
 import gov.medicaid.domain.model.SearchResultType;
 import gov.medicaid.services.CMSConfigurator;
-import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.services.util.Util;
 
 import javax.xml.bind.JAXBContext;
@@ -36,6 +33,9 @@ import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.INFO;
 
 /**
  * Used to verify SSN against the Death Master file records.
@@ -44,11 +44,8 @@ import java.io.StringWriter;
  * @version 1.0
  */
 public class BackgroundStudyClient extends BaseSOAPClient {
-
-    /**
-     * Class logger.
-     */
-    private Log log = LogUtil.getLog("BackgroundStudyClient");
+    private static final Logger LOGGER =
+            Logger.getLogger(BackgroundStudyClient.class.getName());
 
     /**
      * Assigns the given values to the field with the same name.
@@ -103,10 +100,11 @@ public class BackgroundStudyClient extends BaseSOAPClient {
             r1.getColumnData().getNameValuePair().addAll(r2.getColumnData().getNameValuePair());
             result.setRawResponse(null); // not needed now that we have transformed it
 
-            if (log.isEnabled(Level.INFO)) {
+
+            if (LOGGER.isLoggable(INFO)) {
                 sw = new StringWriter();
                 m.marshal(result, sw);
-                log.log(Level.INFO, sw.toString()); // finally! an XML we can actually process!
+                LOGGER.info(sw.toString()); // finally! an XML we can actually process!
             }
         }
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BackgroundStudyClient.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/BackgroundStudyClient.java
@@ -15,6 +15,8 @@
  */
 package gov.medicaid.verification;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;
 import gov.medicaid.domain.model.NETStudyVerificationRequest;
 import gov.medicaid.domain.model.NETStudyVerificationResponse;
@@ -26,18 +28,14 @@ import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.util.LogUtil;
 import gov.medicaid.services.util.Util;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.TransformerException;
-
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * Used to verify SSN against the Death Master file records.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionServiceMatcher.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionServiceMatcher.java
@@ -3,8 +3,6 @@
  */
 package gov.medicaid.verification;
 
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;
 import gov.medicaid.domain.model.NameValuePairType;
 import gov.medicaid.domain.model.ObjectFactory;
@@ -14,7 +12,6 @@ import gov.medicaid.domain.model.SearchResultItemType;
 import gov.medicaid.domain.rules.inference.MatchStatus;
 import gov.medicaid.domain.rules.inference.ResultMatchResolver;
 import gov.medicaid.services.CMSConfigurator;
-import gov.medicaid.services.util.LogUtil;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -23,6 +20,7 @@ import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Uses a web service call to filter multiple search results into an exact match.
@@ -31,11 +29,8 @@ import java.util.List;
  * @version 1.0
  */
 public class SAMExclusionServiceMatcher extends BaseSOAPClient implements ResultMatchResolver {
-
-    /**
-     * Class logger.
-     */
-    private Log log = LogUtil.getLog("SAMExclusionServiceMatcher");
+    private static final Logger LOGGER =
+            Logger.getLogger(SAMExclusionServiceMatcher.class.getName());
 
     /**
      * Assigns the given values to the field with the same name.
@@ -112,11 +107,11 @@ public class SAMExclusionServiceMatcher extends BaseSOAPClient implements Result
                             exactMatch = searchResultItemType;
                         }
                     } catch (JAXBException e) {
-                        log.log(Level.ERROR, e);
+                        LOGGER.severe(e.toString());
                     } catch (IOException e) {
-                        log.log(Level.ERROR, e);
+                        LOGGER.severe(e.toString());
                     } catch (TransformerException e) {
-                        log.log(Level.ERROR, e);
+                        LOGGER.severe(e.toString());
                     }
                     break;
                 }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionServiceMatcher.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/verification/SAMExclusionServiceMatcher.java
@@ -3,6 +3,8 @@
  */
 package gov.medicaid.verification;
 
+import com.topcoder.util.log.Level;
+import com.topcoder.util.log.Log;
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;
 import gov.medicaid.domain.model.NameValuePairType;
 import gov.medicaid.domain.model.ObjectFactory;
@@ -14,17 +16,13 @@ import gov.medicaid.domain.rules.inference.ResultMatchResolver;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.util.LogUtil;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.List;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.transform.TransformerException;
-
-import com.topcoder.util.log.Level;
-import com.topcoder.util.log.Log;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
 
 /**
  * Uses a web service call to filter multiple search results into an exact match.


### PR DESCRIPTION
Some of the logging in our app is done through a TopCoder utility library, which we have checked in as a jar in our repo. Replace a few instances of this logging with standard Java logging, as used elsewhere in the app, to get us closer to no longer depending on the TopCoder utility library.

Issue #214 Remove TopCoder-specific jarfiles