### PR TITLE
Fix link to Enrollments from admin edit page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -23,7 +23,7 @@
                     </div>
                     <!-- /.mainNav -->
                     <div class="breadCrumb">
-                        <a href="<c:url value="/cms/provider/dashboard/drafts" />">Enrollments</a>
+                        <a href="<c:url value="/provider/dashboard/drafts" />">Enrollments</a>
                         <span>Edit Enrollment</span>
                     </div>
                     <div class="head">


### PR DESCRIPTION
Do not include the default application web root ("/cms") in links. This appears to be the only place were doing that, as verified by:

    git grep 'c:url' | grep 'cms/'

I tested this by deploying, editing a `Pending` enrollment, and then clicking the breadcrumb link back to the enrollments list.

Resolves #455 Bad link on admin view