### PR TITLE
Fix problem with extraneous whitespace breaking links/URLs

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -112,7 +112,7 @@
                 <div class="br"></div>
               </div>
               <div class="buttonBox">
-                <a href="<c:url value=" /login" />" class="greyBtn">
+                <a href="<c:url value="/login" />" class="greyBtn">
                   <span class="btR">
                     <span class="btM">Cancel</span>
                   </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
@@ -47,7 +47,7 @@
               <div class="br"></div>
             </div>
             <div class="buttonBox">
-              <a href="<c:url value=" /login" />" class="purpleBtn">
+              <a href="<c:url value="/login" />" class="purpleBtn">
                 <span class="btR">
                   <span class="btM">Login</span>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -126,7 +126,7 @@
                     <label class="label">&nbsp;</label>
                     <input type="checkbox" id="remember" name="keepUserSignedIn"/>
                     <label for="remember">Remember Me</label>
-                    <a href="<c:url value=" /forgotpassword" />">Forgot Password?</a>
+                    <a href="<c:url value="/forgotpassword" />">Forgot Password?</a>
                   </div>
                   <div class="buttons">
                     <a href="javascript:;" id="btnLogin" class="purpleBtn">
@@ -134,7 +134,7 @@
                         <span class="btM">Login</span>
                       </span>
                     </a>
-                    <a href="<c:url value=" /accounts/new" />" class="">Register New Account</a>
+                    <a href="<c:url value="/accounts/new" />" class="">Register New Account</a>
                   </div>
 
                   <div class="tl"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -76,7 +76,7 @@
                 <div class="br"></div>
               </div>
               <div class="buttonBox">
-                <a href="<c:url value=" /login" />" class="greyBtn">
+                <a href="<c:url value="/login" />" class="greyBtn">
                   <span class="btR">
                     <span class="btM">Cancel</span>
                   </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -54,7 +54,7 @@
                 <label class="label">&nbsp;</label>
                 <input type="checkbox" id="remember" name="keepUserSignedIn"/>
                 <label for="remember">Remember Me</label>
-                <a href="<c:url value=" /forgotpassword" />">Forgot Password?</a>
+                <a href="<c:url value="/forgotpassword" />">Forgot Password?</a>
               </div>
               <div class="buttons">
                 <a href="javascript:;" id="btnLogin" class="purpleBtn">
@@ -62,7 +62,7 @@
                     <span class="btM">Login</span>
                   </span>
                 </a>
-                <a href="<c:url value=" /accounts/new" />" class="">Register New Account</a>
+                <a href="<c:url value="/accounts/new" />" class="">Register New Account</a>
               </div>
 
               <div class="tl"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -34,7 +34,7 @@
                       dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
                     </p>
                     <div class="">
-                      <a href="<c:url value=" /provider/onboarding/list" />" class="purpleBtn">
+                      <a href="<c:url value="/provider/onboarding/list" />" class="purpleBtn">
                         <span class="btR">
                           <span class="btM">Import Profile</span>
                         </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -65,7 +65,7 @@
                       You can link your online account to any existing profiles in partner services.
                     </p>
                     <div class="">
-                      <a href="<c:url value=" /provider/onboarding/link" />" class="purpleBtn">
+                      <a href="<c:url value="/provider/onboarding/link" />" class="purpleBtn">
                         <span class="btR">
                           <span class="btM">Get Profiles</span>
                         </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -31,22 +31,22 @@
             <div class="tabHead">
               <div class="tabR">
                 <div class="tabM">
-                  <a class="tab ${statusFilter eq 'Draft' ? 'active' : ''}" href="<c:url value=" /provider/dashboard/drafts" />">
+                  <a class="tab ${statusFilter eq 'Draft' ? 'active' : ''}" href="<c:url value="/provider/dashboard/drafts" />">
                     <span class="aR">
                       <span class="aM">Draft</span>
                     </span>
                   </a>
-                  <a class="tab ${statusFilter eq 'Pending' ? 'active' : ''}" href="<c:url value=" /provider/dashboard/pending" />">
+                  <a class="tab ${statusFilter eq 'Pending' ? 'active' : ''}" href="<c:url value="/provider/dashboard/pending" />">
                     <span class="aR">
                       <span class="aM">Pending</span>
                     </span>
                   </a>
-                  <a class="tab ${statusFilter eq 'Approved' ? 'active' : ''}" href="<c:url value=" /provider/dashboard/approved" />">
+                  <a class="tab ${statusFilter eq 'Approved' ? 'active' : ''}" href="<c:url value="/provider/dashboard/approved" />">
                     <span class="aR">
                       <span class="aM">Approved</span>
                     </span>
                   </a>
-                  <a class="tab ${statusFilter eq 'Rejected' ? 'active' : ''}" href="<c:url value=" /provider/dashboard/rejected" />">
+                  <a class="tab ${statusFilter eq 'Rejected' ? 'active' : ''}" href="<c:url value="/provider/dashboard/rejected" />">
                     <span class="aR">
                       <span class="aM">Denied</span>
                     </span>
@@ -74,7 +74,7 @@
                   </a>
                   <a href="javascript:submitFormById('paginationForm','${exportResultsURL}')" class="greyBtn">
                     <span class="btR">
-                      <span class="btM"><img src="<c:url value=" /i/icon-pdf.png" />" alt=""/>Export to PDF</span>
+                      <span class="btM"><img src="<c:url value="/i/icon-pdf.png" />" alt=""/>Export to PDF</span>
                     </span>
                   </a>
                 </div>
@@ -200,12 +200,12 @@
           <div class="modal-title">
             <a href="javascript:;" class="greyBtn">
               <span class="btR">
-                <span class="btM"><img src="<c:url value=" /i/icon-x.png" />" alt=""/>Close</span>
+                <span class="btM"><img src="<c:url value="/i/icon-x.png" />" alt=""/>Close</span>
               </span>
             </a>
             <a href="javascript:;" class="purpleBtn printBtn">
               <span class="btR">
-                <span class="btM"><img src="<c:url value=" /i/icon-print2.png" />" alt=""/>Print</span>
+                <span class="btM"><img src="<c:url value="/i/icon-print2.png" />" alt=""/>Print</span>
               </span>
             </a>
             <h3>Print Preview</h3>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -22,7 +22,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value=" /provider/dashboard/drafts" />">Enrollments</a>
+            <a href="<c:url value="/provider/dashboard/drafts" />">Enrollments</a>
             <span>Edit Enrollment</span>
           </div>
           <div class="head">
@@ -31,7 +31,7 @@
 
           <div class="tabSection">
 
-            <form action="<c:url value=" /provider/enrollment/steps/rebind" />" id="changeProviderTypeForm" method="post" enctype="multipart/form-data">
+            <form action="<c:url value="/provider/enrollment/steps/rebind" />" id="changeProviderTypeForm" method="post" enctype="multipart/form-data">
               <c:if test="${isReopened}">
                 <div class="detailPanel" style="width: 940px;">
                   <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
@@ -25,7 +25,7 @@
           <c:choose>
             <c:when test="${isRenewalEnrollment}">
               <div class="breadCrumb">
-                <a href="<c:url value=" /provider/dashboard/drafts" />">Enrollments</a>
+                <a href="<c:url value="/provider/dashboard/drafts" />">Enrollments</a>
                 <span>Enrollment Renewal</span>
               </div>
               <div class="head">
@@ -37,7 +37,7 @@
             </c:when>
             <c:otherwise>
               <div class="breadCrumb">
-                <a href="<c:url value=" /provider/dashboard/drafts" />">Enrollments</a>
+                <a href="<c:url value="/provider/dashboard/drafts" />">Enrollments</a>
                 <span>Register New Enrollment</span>
               </div>
               <div class="head">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -22,24 +22,24 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value=" /provider/dashboard/list" />">Enrollments</a>
+            <a href="<c:url value="/provider/dashboard/list" />">Enrollments</a>
             <span>View Enrollment Details</span>
           </div>
 
           <div class="head">
             <h1>View Enrollment Details</h1>
-            <a class="greyBtn" href="<c:url value=" /provider/enrollment/export" />">
+            <a class="greyBtn" href="<c:url value="/provider/enrollment/export" />">
               <span class="btR">
-                <span class="btM"><img alt="" src="<c:url value=" /i/icon-pdf.png" />"/>Export to PDF</span>
+                <span class="btM"><img alt="" src="<c:url value="/i/icon-pdf.png" />"/>Export to PDF</span>
               </span>
             </a>
             <a class="greyBtn printModalBtn" href="javascript:printThis();">
               <span class="btR">
-                <span class="btM"><img alt="" src="<c:url value=" /i/icon-print.png" />"/>Print</span>
+                <span class="btM"><img alt="" src="<c:url value="/i/icon-print.png" />"/>Print</span>
               </span>
             </a>
             <c:if test="${showReviewLink}">
-              <a class="greyBtn" href="<c:url value=" /agent/enrollment/screeningReview?id=${enrollment.objectId}" />">
+              <a class="greyBtn" href="<c:url value="/agent/enrollment/screeningReview?id=${enrollment.objectId}" />">
                 <span class="btR">
                   <span class="btM">Review</span>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
@@ -22,19 +22,19 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value=" /provider/profile/" />">My Profile</a>
+            <a href="<c:url value="/provider/profile/" />">My Profile</a>
             <span>View Profile Details</span>
           </div>
           <div class="head">
             <h1>View Profile Details</h1>
-            <a class="greyBtn" href="<c:url value=" /provider/enrollment/export" />">
+            <a class="greyBtn" href="<c:url value="/provider/enrollment/export" />">
               <span class="btR">
-                <span class="btM"><img alt="" src="<c:url value=" /i/icon-pdf.png" />"/>Export to PDF</span>
+                <span class="btM"><img alt="" src="<c:url value="/i/icon-pdf.png" />"/>Export to PDF</span>
               </span>
             </a>
             <a class="greyBtn printModalBtn" href="javascript:printThis();">
               <span class="btR">
-                <span class="btM"><img alt="" src="<c:url value=" /i/icon-print.png" />"/>Print</span>
+                <span class="btM"><img alt="" src="<c:url value="/i/icon-print.png" />"/>Print</span>
               </span>
             </a>
           </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -20,7 +20,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value=" /provider/dashboard/setup" />">Account Setup</a>
+            <a href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
             <span class="text">Account Details</span>
           </div>
           <div class="head">
@@ -82,7 +82,7 @@
                     </div>
                   </div>
                   <div class="buttonBox">
-                    <a href="<c:url value=" /provider/dashboard/setup" />" class="greyBtn">
+                    <a href="<c:url value="/provider/dashboard/setup" />" class="greyBtn">
                       <span class="btR">
                         <span class="btM">Cancel</span>
                       </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -20,7 +20,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value=" /provider/dashboard/setup" />">Account Setup</a>
+            <a href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
             <span class="text">Import Profiles</span>
           </div>
           <div class="head">
@@ -32,7 +32,7 @@
 
           <div class="dashboardPanel">
             <div class="tableData">
-              <form id="importProfilesForm" action="<c:url value=" /provider/onboarding/list" />" method="post">
+              <form id="importProfilesForm" action="<c:url value="/provider/onboarding/list" />" method="post">
                 <div class="tableTitle">
                   <h2>Profiles</h2>
                 </div>
@@ -103,7 +103,7 @@
             <!-- /.sideBar -->
 
             <div class="tableDataButtons buttonBox">
-              <a href="<c:url value=" /provider/dashboard/setup" />" class="greyBtn">
+              <a href="<c:url value="/provider/dashboard/setup" />" class="greyBtn">
                 <span class="btR">
                   <span class="btM">Cancel</span>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
@@ -21,7 +21,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value=" /provider/search/approved?statuses=Approved" />">Enrollments</a>
+            <a href="<c:url value="/provider/search/approved?statuses=Approved" />">Enrollments</a>
             <span>Confirm Edit</span>
           </div>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -90,7 +90,7 @@
                   <ul>
                     <li>
                       <p>
-                        <a href="<c:url value=" /provider/dashboard/setup" />">Account Setup</a>
+                        <a href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
                         <br/>
                         Create new or import existing profiles
                       </p>
@@ -98,7 +98,7 @@
                     <c:if test="${isInternalUser}">
                       <li>
                         <p>
-                          <a href="<c:url value=" /provider/profile/reset" />">Change Password</a>
+                          <a href="<c:url value="/provider/profile/reset" />">Change Password</a>
                           <br/>
                           Set a new password for your online account
                         </p>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -21,7 +21,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value=" /provider/profile/" />">My Profile</a>
+            <a href="<c:url value="/provider/profile/" />">My Profile</a>
             <span class="text">Update Password</span>
           </div>
           <div class="head">
@@ -82,7 +82,7 @@
                     </div>
                   </div>
                   <div class="buttonBox">
-                    <a href="<c:url value=" /provider/profile/" />" class="greyBtn">
+                    <a href="<c:url value="/provider/profile/" />" class="greyBtn">
                       <span class="btR">
                         <span class="btM">Cancel</span>
                       </span>


### PR DESCRIPTION
In commit 85b3dd6e0a3fe946609cf8ae6d2c107c2e27750d (in PR #490)
extra spaces were inserted into JSP tags, when automatically
reformatting the JSP files to have two-space indentation.  This
broke links/URLs.  (Apparently auto-formatters are easily confused
by the JSP tags.)  This commit removes the extra spaces, fixing
the links.