### PR TITLE
Add handlebars template variables to all requests

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -28,7 +28,7 @@
   <mvc:interceptors>
     <mvc:interceptor>
       <mvc:mapping path="/**"/>
-      <bean class="gov.medicaid.controllers.FlashMessageInterceptor"/>
+      <bean class="gov.medicaid.interceptors.FlashMessageInterceptor"/>
     </mvc:interceptor>
   </mvc:interceptors>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -30,6 +30,10 @@
       <mvc:mapping path="/**"/>
       <bean class="gov.medicaid.interceptors.FlashMessageInterceptor"/>
     </mvc:interceptor>
+    <mvc:interceptor>
+      <mvc:mapping path="/**"/>
+      <bean class="gov.medicaid.interceptors.HandlebarsInterceptor"/>
+    </mvc:interceptor>
   </mvc:interceptors>
 
   <bean id="log4jLogFactory"

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -1,253 +1,311 @@
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:mvc="http://www.springframework.org/schema/mvc" xmlns:context="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+<?xml version="1.0"?>
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:mvc="http://www.springframework.org/schema/mvc"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/mvc
+    http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+    http://www.springframework.org/schema/context
+    http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+  <context:annotation-config/>
 
-	<context:annotation-config />
+  <mvc:resources location="/js/**" mapping="/js/**"/>
+  <mvc:resources location="/css/**" mapping="/css/**"/>
+  <mvc:resources location="/i/**" mapping="/i/**"/>
 
-	<mvc:resources location="/js/**" mapping="/js/**" />
-	<mvc:resources location="/css/**" mapping="/css/**" />
-	<mvc:resources location="/i/**" mapping="/i/**" />
+  <mvc:annotation-driven/>
 
-	<mvc:annotation-driven />
+  <context:property-placeholder location="classpath:cms.properties"/>
 
-	<context:property-placeholder location="classpath:cms.properties"/>
-
-	<bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-	    <property name="maxUploadSize" value="${max.upload.size}"/>
-	</bean>
-
-	<mvc:interceptors>
-	   <mvc:interceptor>
-	       <mvc:mapping path="/**" />
-	       <bean class="gov.medicaid.controllers.FlashMessageInterceptor"></bean>
-	   </mvc:interceptor>
-	</mvc:interceptors>
-
-    <bean id="log4jLogFactory" class="com.topcoder.util.log.log4j.Log4jLogFactory" />
-    <bean id="Log" factory-bean="log4jLogFactory" factory-method="createLog">
-        <constructor-arg type="java.lang.String" value="cms-web" />
-    </bean>
-
-	<bean id="RegistrationService" class="org.springframework.jndi.JndiObjectFactoryBean">
-		<property name="jndiName">
-            <value>${jndi.RegistrationService}</value>
-		</property>
-	</bean>
-	<bean id="ExportService" class="org.springframework.jndi.JndiObjectFactoryBean">
-		<property name="jndiName">
-            <value>${jndi.ExportService}</value>
-		</property>
-	</bean>
-
-	<bean id="LookupService" class="org.springframework.jndi.JndiObjectFactoryBean">
-		<property name="jndiName">
-			<value>${jndi.LookupService}</value>
-		</property>
-	</bean>
-
-    <bean id="BusinessProcessService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.BusinessProcessService}</value>
-        </property>
-    </bean>
-
-	<bean id="ProviderEnrollmentService" class="org.springframework.jndi.JndiObjectFactoryBean">
-		<property name="jndiName">
-			<value>${jndi.ProviderEnrollmentService}</value>
-		</property>
-	</bean>
-
-    <bean id="PresentationService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.PresentationService}</value>
-        </property>
-    </bean>
-
-	<bean id="OnboardingService" class="org.springframework.jndi.JndiObjectFactoryBean">
-		<property name="jndiName">
-			<value>${jndi.OnboardingService}</value>
-		</property>
-	</bean>
-
-    <bean id="EnrollmentWebService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.EnrollmentWebService}</value>
-        </property>
-    </bean>
-
-
-	<bean class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">
-		<property name="mappings">
-			<value>
-				/login=JSPController
-				/mnLogin=JSPController
-				/system/advanced-search-system-admin=JSPController
-			</value>
-		</property>
-	</bean>
-
-	<bean id="BaseController" class="gov.medicaid.controllers.BaseController" abstract="true">
-		<property name="log" ref="Log"></property>
-	</bean>
-
-	<bean id="SelfRegistrationController" class="gov.medicaid.controllers.SelfRegistrationController" parent="BaseController">
-		<property name="registrationService" ref="RegistrationService"></property>
-		<property name="validator" ref="RegistrationFormValidator"></property>
-	</bean>
-
-    <bean id="ForgotPasswordController" class="gov.medicaid.controllers.ForgotPasswordController" parent="BaseController">
-        <property name="registrationService" ref="RegistrationService"></property>
-        <property name="validator" ref="ForgotPasswordFormValidator"></property>
-    </bean>
-
-    <bean id="LandingController" class="gov.medicaid.controllers.LandingController">
-    </bean>
-
-    <bean id="EnrollmentPageFlowController" class="gov.medicaid.controllers.EnrollmentPageFlowController" parent="BaseController">
-		<property name="enrollmentWebService" ref="EnrollmentWebService"></property>
-		<property name="presentationService" ref="PresentationService"></property>
-        <property name="enrollmentService" ref="ProviderEnrollmentService"></property>
-        <property name="exportService" ref="ExportService"></property>
-        <property name="lookupService" ref="LookupService"></property>
-    </bean>
-
-	<bean id="ProviderDashboardController" class="gov.medicaid.controllers.ProviderDashboardController" parent="BaseController">
-		<property name="enrollmentService" ref="ProviderEnrollmentService"></property>
-        <property name="exportService" ref="ExportService"></property>
-	</bean>
-
-    <bean id="OnboardingController" class="gov.medicaid.controllers.OnboardingController" parent="BaseController">
-        <property name="onboardingService" ref="OnboardingService"></property>
-        <property name="registrationService" ref="RegistrationService"></property>
-        <property name="validator" ref="AccountLinkFormValidator"></property>
-    </bean>
-
-	<bean id="MyProfileController" class="gov.medicaid.controllers.MyProfileController" parent="BaseController">
-		<property name="enrollmentService" ref="ProviderEnrollmentService"></property>
-		<property name="registrationService" ref="RegistrationService"></property>
-		<property name="validator" ref="UpdatePasswordFormValidator"></property>
-	</bean>
-
-	<bean id="RegistrationFormValidator" class="gov.medicaid.controllers.validators.RegistrationFormValidator">
-		<property name="registrationService" ref="RegistrationService"></property>
-	</bean>
-
-	<bean id="AccountLinkFormValidator" class="gov.medicaid.controllers.validators.AccountLinkFormValidator">
-	</bean>
-	<bean id="ForgotPasswordFormValidator" class="gov.medicaid.controllers.validators.ForgotPasswordFormValidator">
-	</bean>
-	<bean id="UpdatePasswordFormValidator" class="gov.medicaid.controllers.validators.UpdatePasswordFormValidator">
-	</bean>
-
-	<bean class="org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter" />
-
-	<bean id="JSPController" class="org.springframework.web.servlet.mvc.UrlFilenameViewController">
-	</bean>
-
-	<bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
-		<property name="prefix">
-			<value>/WEB-INF/pages/</value>
-		</property>
-		<property name="suffix">
-			<value>.jsp</value>
-		</property>
-	</bean>
-
-  <bean id="viewResolver" class="com.github.jknack.handlebars.springmvc.HandlebarsViewResolver">
-    <property name="order" value="1" />
-    <property name="prefix" value="/templates/" />
-    <property name="suffix" value=".template.html" />
-    <property name="failOnMissingFile" value="false" />
+  <bean id="multipartResolver"
+        class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
+    <property name="maxUploadSize" value="${max.upload.size}"/>
   </bean>
 
-	<bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
-		<property name="basename">
-			<value>messages</value>
-		</property>
-	</bean>
+  <mvc:interceptors>
+    <mvc:interceptor>
+      <mvc:mapping path="/**"/>
+      <bean class="gov.medicaid.controllers.FlashMessageInterceptor"/>
+    </mvc:interceptor>
+  </mvc:interceptors>
 
-	<!-- Merged Service Admin Assembly -->
-    <bean id="AgreementDocumentService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.AgreementDocumentService}</value>
-        </property>
-    </bean>
-    <bean id="HelpService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.HelpService}</value>
-        </property>
-    </bean>
-    <bean id="EventService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.EventService}</value>
-        </property>
-    </bean>
-    <bean id="ScreeningService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.ScreeningService}</value>
-        </property>
-    </bean>
-    <bean id="ProviderTypeService" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <property name="jndiName">
-            <value>${jndi.ProviderTypeService}</value>
-        </property>
-    </bean>
+  <bean id="log4jLogFactory"
+        class="com.topcoder.util.log.log4j.Log4jLogFactory"/>
+  <bean id="Log" factory-bean="log4jLogFactory" factory-method="createLog">
+    <constructor-arg type="java.lang.String" value="cms-web"/>
+  </bean>
 
-    <bean id="BaseServiceAdminController" class="gov.medicaid.controllers.admin.BaseServiceAdminController" abstract="true">
-        <property name="log" ref="Log" />
-    </bean>
-    <bean id="AgreementDocumentController" class="gov.medicaid.controllers.admin.AgreementDocumentController" parent="BaseServiceAdminController">
-        <property name="agreementDocumentService" ref="AgreementDocumentService" />
-    </bean>
-    <bean id="DashboardController" class="gov.medicaid.controllers.admin.DashboardController" parent="BaseServiceAdminController">
-        <property name="providerProfileService" ref="ProviderEnrollmentService" />
-        <property name="helpService" ref="HelpService" />
-        <property name="eventService" ref="EventService" />
-    </bean>
-    <bean id="HelpController" class="gov.medicaid.controllers.admin.HelpController" parent="BaseServiceAdminController">
-        <property name="helpService" ref="HelpService" />
-    </bean>
-    <bean id="ProviderTypeController" class="gov.medicaid.controllers.admin.ProviderTypeController" parent="BaseServiceAdminController">
-        <property name="agreementDocumentService" ref="AgreementDocumentService" />
-        <property name="providerTypeService" ref="ProviderTypeService" />
-        <property name="lookupService" ref="LookupService" />
-    </bean>
-    <bean id="ScreeningScheduleController" class="gov.medicaid.controllers.admin.ScreeningScheduleController" parent="BaseServiceAdminController">
-        <property name="screeningService" ref="ScreeningService" />
-    </bean>
-    <bean id="ServiceAgentController" class="gov.medicaid.controllers.admin.ServiceAgentController" parent="BaseServiceAdminController">
-        <property name="registrationService" ref="RegistrationService" />
-    </bean>
-    <bean id="UserController" class="gov.medicaid.controllers.admin.UserController" parent="BaseServiceAdminController">
-        <property name="registrationService" ref="RegistrationService" />
-    </bean>
+  <bean id="RegistrationService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.RegistrationService}</value>
+    </property>
+  </bean>
+  <bean id="ExportService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.ExportService}</value>
+    </property>
+  </bean>
 
-    <bean id="EnrollmentController" class="gov.medicaid.controllers.admin.EnrollmentController" parent="BaseController">
-        <property name="businessProcessService" ref="BusinessProcessService" />
-        <property name="enrollmentService" ref="ProviderEnrollmentService" />
-        <property name="screeningService" ref="ScreeningService" />
-        <property name="helpService" ref="HelpService" />
-        <property name="eventService" ref="EventService" />
-        <property name="lookupService" ref="LookupService" />
-        <property name="providerTypeService" ref="ProviderTypeService" />
-        <property name="exportService" ref="ExportService" />
-    </bean>
+  <bean id="LookupService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.LookupService}</value>
+    </property>
+  </bean>
 
-    <bean id="BaseSystemAdminController" class="gov.medicaid.controllers.admin.BaseController" abstract="true">
-        <property name="log" ref="Log"></property>
-        <property name="registrationService" ref="RegistrationService"></property>
-        <property name="lookupService" ref="LookupService"></property>
-    </bean>
+  <bean id="BusinessProcessService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.BusinessProcessService}</value>
+    </property>
+  </bean>
 
-    <bean id="SystemAdminUserSearchController" class="gov.medicaid.controllers.admin.SystemAdminUserSearchController" parent="BaseSystemAdminController" >
-    </bean>
+  <bean id="ProviderEnrollmentService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.ProviderEnrollmentService}</value>
+    </property>
+  </bean>
 
-    <bean id="UserValidator" class="gov.medicaid.controllers.admin.UserValidator">
-        <property name="registrationService" ref="RegistrationService"></property>
-    </bean>
+  <bean id="PresentationService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.PresentationService}</value>
+    </property>
+  </bean>
 
-    <bean id="SystemAdminUserController" class="gov.medicaid.controllers.admin.SystemAdminUserController" parent="BaseSystemAdminController" >
-        <property name="userValidator" ref="UserValidator"></property>
-    </bean>
+  <bean id="OnboardingService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.OnboardingService}</value>
+    </property>
+  </bean>
+
+  <bean id="EnrollmentWebService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.EnrollmentWebService}</value>
+    </property>
+  </bean>
+
+  <bean class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">
+    <property name="mappings">
+      <value>
+        /login=JSPController
+        /mnLogin=JSPController
+        /system/advanced-search-system-admin=JSPController
+      </value>
+    </property>
+  </bean>
+
+  <bean id="BaseController"
+        class="gov.medicaid.controllers.BaseController"
+        abstract="true">
+    <property name="log" ref="Log"/>
+  </bean>
+
+  <bean id="SelfRegistrationController"
+        class="gov.medicaid.controllers.SelfRegistrationController"
+        parent="BaseController">
+    <property name="registrationService" ref="RegistrationService"/>
+    <property name="validator" ref="RegistrationFormValidator"/>
+  </bean>
+
+  <bean id="ForgotPasswordController"
+        class="gov.medicaid.controllers.ForgotPasswordController"
+        parent="BaseController">
+    <property name="registrationService" ref="RegistrationService"/>
+    <property name="validator" ref="ForgotPasswordFormValidator"/>
+  </bean>
+
+  <bean id="LandingController"
+        class="gov.medicaid.controllers.LandingController"/>
+
+  <bean id="EnrollmentPageFlowController"
+        class="gov.medicaid.controllers.EnrollmentPageFlowController"
+        parent="BaseController">
+    <property name="enrollmentWebService" ref="EnrollmentWebService"/>
+    <property name="presentationService" ref="PresentationService"/>
+    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
+    <property name="exportService" ref="ExportService"/>
+    <property name="lookupService" ref="LookupService"/>
+  </bean>
+
+  <bean id="ProviderDashboardController"
+        class="gov.medicaid.controllers.ProviderDashboardController"
+        parent="BaseController">
+    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
+    <property name="exportService" ref="ExportService"/>
+  </bean>
+
+  <bean id="OnboardingController"
+        class="gov.medicaid.controllers.OnboardingController"
+        parent="BaseController">
+    <property name="onboardingService" ref="OnboardingService"/>
+    <property name="registrationService" ref="RegistrationService"/>
+    <property name="validator" ref="AccountLinkFormValidator"/>
+  </bean>
+
+  <bean id="MyProfileController"
+        class="gov.medicaid.controllers.MyProfileController"
+        parent="BaseController">
+    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
+    <property name="registrationService" ref="RegistrationService"/>
+    <property name="validator" ref="UpdatePasswordFormValidator"/>
+  </bean>
+
+  <bean id="RegistrationFormValidator" class="gov.medicaid.controllers.validators.RegistrationFormValidator">
+    <property name="registrationService" ref="RegistrationService"/>
+  </bean>
+
+  <bean id="AccountLinkFormValidator"
+        class="gov.medicaid.controllers.validators.AccountLinkFormValidator"/>
+  <bean id="ForgotPasswordFormValidator"
+        class="gov.medicaid.controllers.validators.ForgotPasswordFormValidator"/>
+  <bean id="UpdatePasswordFormValidator"
+        class="gov.medicaid.controllers.validators.UpdatePasswordFormValidator"/>
+
+  <bean class="org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter"/>
+
+  <bean id="JSPController"
+        class="org.springframework.web.servlet.mvc.UrlFilenameViewController"/>
+  <bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
+    <property name="prefix">
+      <value>/WEB-INF/pages/</value>
+    </property>
+    <property name="suffix">
+      <value>.jsp</value>
+    </property>
+  </bean>
+
+  <bean id="viewResolver"
+        class="com.github.jknack.handlebars.springmvc.HandlebarsViewResolver">
+    <property name="order" value="1"/>
+    <property name="prefix" value="/templates/"/>
+    <property name="suffix" value=".template.html"/>
+    <property name="failOnMissingFile" value="false"/>
+  </bean>
+
+  <bean id="messageSource"
+        class="org.springframework.context.support.ResourceBundleMessageSource">
+    <property name="basename">
+      <value>messages</value>
+    </property>
+  </bean>
+
+  <!-- Merged Service Admin Assembly -->
+  <bean id="AgreementDocumentService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.AgreementDocumentService}</value>
+    </property>
+  </bean>
+  <bean id="HelpService" class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.HelpService}</value>
+    </property>
+  </bean>
+  <bean id="EventService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.EventService}</value>
+    </property>
+  </bean>
+  <bean id="ScreeningService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.ScreeningService}</value>
+    </property>
+  </bean>
+  <bean id="ProviderTypeService"
+        class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="jndiName">
+      <value>${jndi.ProviderTypeService}</value>
+    </property>
+  </bean>
+
+  <bean id="BaseServiceAdminController"
+        class="gov.medicaid.controllers.admin.BaseServiceAdminController"
+        abstract="true">
+    <property name="log" ref="Log"/>
+  </bean>
+  <bean id="AgreementDocumentController"
+        class="gov.medicaid.controllers.admin.AgreementDocumentController"
+        parent="BaseServiceAdminController">
+    <property name="agreementDocumentService" ref="AgreementDocumentService"/>
+  </bean>
+  <bean id="DashboardController"
+        class="gov.medicaid.controllers.admin.DashboardController"
+        parent="BaseServiceAdminController">
+    <property name="providerProfileService" ref="ProviderEnrollmentService"/>
+    <property name="helpService" ref="HelpService"/>
+    <property name="eventService" ref="EventService"/>
+  </bean>
+  <bean id="HelpController"
+        class="gov.medicaid.controllers.admin.HelpController"
+        parent="BaseServiceAdminController">
+    <property name="helpService" ref="HelpService"/>
+  </bean>
+  <bean id="ProviderTypeController"
+        class="gov.medicaid.controllers.admin.ProviderTypeController"
+        parent="BaseServiceAdminController">
+    <property name="agreementDocumentService" ref="AgreementDocumentService"/>
+    <property name="providerTypeService" ref="ProviderTypeService"/>
+    <property name="lookupService" ref="LookupService"/>
+  </bean>
+  <bean id="ScreeningScheduleController"
+        class="gov.medicaid.controllers.admin.ScreeningScheduleController"
+        parent="BaseServiceAdminController">
+    <property name="screeningService" ref="ScreeningService"/>
+  </bean>
+  <bean id="ServiceAgentController"
+        class="gov.medicaid.controllers.admin.ServiceAgentController"
+        parent="BaseServiceAdminController">
+    <property name="registrationService" ref="RegistrationService"/>
+  </bean>
+  <bean id="UserController"
+        class="gov.medicaid.controllers.admin.UserController"
+        parent="BaseServiceAdminController">
+    <property name="registrationService" ref="RegistrationService"/>
+  </bean>
+
+  <bean id="EnrollmentController"
+        class="gov.medicaid.controllers.admin.EnrollmentController"
+        parent="BaseController">
+    <property name="businessProcessService" ref="BusinessProcessService"/>
+    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
+    <property name="screeningService" ref="ScreeningService"/>
+    <property name="helpService" ref="HelpService"/>
+    <property name="eventService" ref="EventService"/>
+    <property name="lookupService" ref="LookupService"/>
+    <property name="providerTypeService" ref="ProviderTypeService"/>
+    <property name="exportService" ref="ExportService"/>
+  </bean>
+
+  <bean id="BaseSystemAdminController"
+        class="gov.medicaid.controllers.admin.BaseController"
+        abstract="true">
+    <property name="log" ref="Log"/>
+    <property name="registrationService" ref="RegistrationService"/>
+    <property name="lookupService" ref="LookupService"/>
+  </bean>
+
+  <bean id="SystemAdminUserSearchController"
+        class="gov.medicaid.controllers.admin.SystemAdminUserSearchController"
+        parent="BaseSystemAdminController"/>
+
+  <bean id="UserValidator" class="gov.medicaid.controllers.admin.UserValidator">
+    <property name="registrationService" ref="RegistrationService"/>
+  </bean>
+
+  <bean id="SystemAdminUserController"
+        class="gov.medicaid.controllers.admin.SystemAdminUserController"
+        parent="BaseSystemAdminController">
+    <property name="userValidator" ref="UserValidator"/>
+  </bean>
 </beans>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Register"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Registration Complete"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
@@ -66,10 +66,7 @@
           </div>
           <!-- /.userSection -->
           <div class="mastHead">
-            <sec:authentication property="principal.loginDate" var="loginDate"/>
-            Last login:
-            <fmt:formatDate value="${loginDate}"
-                            pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/>
+            Last login: <c:out value="${loginDate}" />
           </div>
           <!-- /.mastHead -->
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
@@ -10,75 +10,104 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" lang="en" />
-        <title>${title}</title>
-        <link rel="stylesheet" href="<c:url value='/css/reset.css' />" type="text/css" media="all"/>
-        <link rel="stylesheet" href="<c:url value='/css/style.css' />" type="text/css" media="all"/>
-        <link rel="stylesheet" href="<c:url value='/css/jquery.ui.css' />" type="text/css" media="all"/>
-		<link rel="stylesheet" href="<c:url value='/js/chosen/chosen.css' />" type="text/css" media="all"/>
-		
-        <!--[if IE 7]>
-        <link rel="stylesheet" href="<c:url value='/css/style-ie7.css' />" type="text/css" />
-        <![endif]-->
-        <script src="<c:url value='/js/jquery-1.7.1.min.js' />" type="text/javascript"></script>
-        <script src="<c:url value='/js/jquery.tablesorter.min.js' />" type="text/javascript"></script>
-        <script src="<c:url value='/js/jquery.tablesorter.widgets.js' />" type="text/javascript"></script>
-        <script src="<c:url value='/js/jquery.ui.core.js' />" type="text/javascript"></script>
-        <script src="<c:url value='/js/jquery.ui.widget.js' />" type="text/javascript"></script>
-        <script src="<c:url value='/js/jquery.ui.datepicker.js' />" type="text/javascript"></script>
-        <script src="<c:url value='/js/chosen/chosen.jquery.min.js' />" type="text/javascript"></script>
-        <script src="<c:url value='/js/system/script.js' />" type="text/javascript"></script>
-    </head>
-    <body>
-        <div id="wrapper">
-            <div id="header">
-			    <div class="contentWidth">
-			        <div class="userSection">
-			            Welcome, <strong><sec:authentication property="principal.username" /></strong> | <a href="<c:url value='/system/help-system-admin' />">Help</a> | <a href="<spring:url value="/j_spring_security_logout" />">Logout</a>
-			        </div>
-			        <!-- /.userSection -->
-			        <div class="mastHead">
-			            <sec:authentication property="principal.loginDate" var="loginDate"/>
-			            Last login: <fmt:formatDate value="${loginDate}" pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/> 
-			        </div>
-			        <!-- /.mastHead -->
-			    </div>
-            </div>
-            <!-- /#header -->
+  <head>
+    <meta http-equiv="Content-Type"
+          content="text/html; charset=UTF-8"
+          lang="en" />
+    <title>${title}</title>
+    <link rel="stylesheet"
+          href="<c:url value='/css/reset.css' />"
+          type="text/css"
+          media="all"/>
+    <link rel="stylesheet"
+          href="<c:url value='/css/style.css' />"
+          type="text/css"
+          media="all"/>
+    <link rel="stylesheet"
+          href="<c:url value='/css/jquery.ui.css' />"
+          type="text/css"
+          media="all"/>
+    <link rel="stylesheet"
+          href="<c:url value='/js/chosen/chosen.css' />"
+          type="text/css"
+          media="all"/>
 
-            <div id="mainContent" <c:if test='${isUpdateUser}'>class="detailPage"</c:if>>
-                <div class="contentWidth">
-                    <div class="mainNav">
-                        <%@include file="/WEB-INF/pages/includes/logo.jsp" %>
-                        <div class="nav">
-                            <div class="navR">
-                                <div class="navM">
-                                    <ul>
-                                        <li class="active">
-                                            <a href="<c:url value='/system/user/list' />">USER ACCOUNTS</a>
-                                            <c:if test="${hasArrow}"><span class="arrow"></span></c:if>
-                                            
-                                        </li>
-                                    </ul>
-                                    <div class="searchWidget">
-                                        <a href="<c:url value='/system/advanced-search-system-admin' />">Advanced Search</a>
-                                        <form id="searchBoxForm" class="inputContainer" action="<c:url value='/system/user/search?role=Provider' />"  method="post">
-                                            <a href="javascript:;" class="search searchBox"></a>
-                                            <input type="text" class="hint" value="Search Keyword" title="Search Keyword" name="firstName" id="searchBoxFirstName"/>
-                                            <input type="hidden" name="lastName" id="searchBoxLastName" />
-                                            <input type="hidden" name="and" value="false" />
-                                            <input type="hidden" name="searchBox" value="true" />
-                                            <input type="hidden" name="initSearchBox" value="true" />
-                                            <input type="hidden" name="roles" value="Provider"/>
-                                            <input type="hidden" name="roles" value="Service Agent"/>
-                                            <input type="hidden" name="roles" value="Service Administrator"/>
-                                            <input type="hidden" name="roles" value="System Administrator"/>
-                                        </form>
-                                    </div>
-                                    <!-- /.searchWidget -->
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.mainNav -->
+    <!--[if IE 7]>
+      <link rel="stylesheet"
+            href="<c:url value='/css/style-ie7.css' />"
+            type="text/css" />
+    <![endif]-->
+    <script src="<c:url value='/js/jquery-1.7.1.min.js' />"
+            type="text/javascript"></script>
+    <script src="<c:url value='/js/jquery.tablesorter.min.js' />"
+            type="text/javascript"></script>
+    <script src="<c:url value='/js/jquery.tablesorter.widgets.js' />"
+            type="text/javascript"></script>
+    <script src="<c:url value='/js/jquery.ui.core.js' />"
+            type="text/javascript"></script>
+    <script src="<c:url value='/js/jquery.ui.widget.js' />"
+            type="text/javascript"></script>
+    <script src="<c:url value='/js/jquery.ui.datepicker.js' />"
+            type="text/javascript"></script>
+    <script src="<c:url value='/js/chosen/chosen.jquery.min.js' />"
+            type="text/javascript"></script>
+    <script src="<c:url value='/js/system/script.js' />"
+            type="text/javascript"></script>
+  </head>
+  <body>
+    <div id="wrapper">
+      <div id="header">
+        <div class="contentWidth">
+          <div class="userSection">
+            Welcome,
+            <strong><sec:authentication property="principal.username" /></strong>
+            | <a href="<c:url value='/system/help-system-admin' />">Help</a>
+            | <a href="<spring:url value="/j_spring_security_logout" />">Logout</a>
+          </div>
+          <!-- /.userSection -->
+          <div class="mastHead">
+            <sec:authentication property="principal.loginDate" var="loginDate"/>
+            Last login:
+            <fmt:formatDate value="${loginDate}"
+                            pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/>
+          </div>
+          <!-- /.mastHead -->
+        </div>
+      </div>
+      <!-- /#header -->
+
+      <div id="mainContent" <c:if test='${isUpdateUser}'>class="detailPage"</c:if>>
+        <div class="contentWidth">
+          <div class="mainNav">
+            <%@include file="/WEB-INF/pages/includes/logo.jsp" %>
+            <div class="nav">
+              <div class="navR">
+                <div class="navM">
+                  <ul>
+                    <li class="active">
+                      <a href="<c:url value='/system/user/list' />">USER ACCOUNTS</a>
+                      <c:if test="${hasArrow}"><span class="arrow"></span></c:if>
+
+                    </li>
+                  </ul>
+                  <div class="searchWidget">
+                    <a href="<c:url value='/system/advanced-search-system-admin' />">Advanced Search</a>
+                    <form id="searchBoxForm" class="inputContainer" action="<c:url value='/system/user/search?role=Provider' />"  method="post">
+                      <a href="javascript:;" class="search searchBox"></a>
+                      <input type="text" class="hint" value="Search Keyword" title="Search Keyword" name="firstName" id="searchBoxFirstName"/>
+                      <input type="hidden" name="lastName" id="searchBoxLastName" />
+                      <input type="hidden" name="and" value="false" />
+                      <input type="hidden" name="searchBox" value="true" />
+                      <input type="hidden" name="initSearchBox" value="true" />
+                      <input type="hidden" name="roles" value="Provider"/>
+                      <input type="hidden" name="roles" value="Service Agent"/>
+                      <input type="hidden" name="roles" value="Service Administrator"/>
+                      <input type="hidden" name="roles" value="System Administrator"/>
+                    </form>
+                  </div>
+                  <!-- /.searchWidget -->
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- /.mainNav -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/taglibs.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/taglibs.jsp
@@ -14,5 +14,4 @@
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<c:set var="ctx" value="${pageContext.request.contextPath}"/>
 <fmt:setLocale value="en_US" scope="session"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -10,7 +10,6 @@
   <c:when test="${principal ne null && principal.enabled}">
     <html xmlns="http://www.w3.org/1999/xhtml">
       <c:set var="title" value="Server Error"/>
-      <c:set var="ctx" value="${pageContext.request.contextPath}"/>
       <h:handlebars template="includes/html_head" context="${pageContext}"/>
       <body>
         <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Forgot Password"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/includes/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/includes/header.jsp
@@ -18,10 +18,7 @@
     </div>
     <!-- /.userSection -->
     <div class="mastHead">
-      <sec:authentication property="principal.loginDate" var="loginDate"/>
-      Last login:
-      <fmt:formatDate value="${loginDate}"
-                      pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/>
+      Last login: <c:out value="${loginDate}" />
     </div>
     <!-- /.mastHead -->
   </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/includes/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/includes/header.jsp
@@ -10,20 +10,27 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 
 <div id="header">
-    <div class="contentWidth">
-        <div class="userSection">
-            Welcome, <strong><sec:authentication property="principal.username" /></strong> | <a href="javascript:;">Help</a> | <a href="<spring:url value="/j_spring_security_logout" />">Logout</a>
-        </div>
-        <!-- /.userSection -->
-        <div class="mastHead">
-            <sec:authentication property="principal.loginDate" var="loginDate"/>
-            Last login: <fmt:formatDate value="${loginDate}" pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/> 
-        </div>
-        <!-- /.mastHead -->
+  <div class="contentWidth">
+    <div class="userSection">
+      Welcome, <strong><sec:authentication property="principal.username" /></strong>
+      | <a href="javascript:;">Help</a>
+      | <a href="<spring:url value="/j_spring_security_logout" />">Logout</a>
     </div>
-    <!-- /.contentWidth -->
-    
-    <sec:authentication property="principal.authenticatedBySystem" var="authenticatedBySystem"/>
-    <sec:authentication property="principal" var="requestPrincipal"/>
-    <spring:eval expression="authenticatedBySystem == T(gov.medicaid.entities.SystemId).CMS_ONLINE" var="isInternalUser" />
+    <!-- /.userSection -->
+    <div class="mastHead">
+      <sec:authentication property="principal.loginDate" var="loginDate"/>
+      Last login:
+      <fmt:formatDate value="${loginDate}"
+                      pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/>
+    </div>
+    <!-- /.mastHead -->
+  </div>
+  <!-- /.contentWidth -->
+
+  <sec:authentication property="principal.authenticatedBySystem"
+                      var="authenticatedBySystem"/>
+  <sec:authentication property="principal"
+                      var="requestPrincipal"/>
+  <spring:eval expression="authenticatedBySystem == T(gov.medicaid.entities.SystemId).CMS_ONLINE"
+               var="isInternalUser" />
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/includes/nav.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/includes/nav.jsp
@@ -5,7 +5,6 @@
     @version 1.0
  --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<c:set var="ctx" value="${pageContext.request.contextPath}"/>
 <div class="nav">
     <div class="navR">
         <div class="navM">
@@ -18,18 +17,18 @@
                     <a href="<c:url value="/provider/dashboard/drafts" />">ENROLLMENTS</a>
                     <c:if test="${activeTab == 2}"><span class="arrow"></span></c:if>
                 </li>
-                <c:if test="${requestPrincipal.user.role.description eq 'Service Administrator'}">
+                <c:if test="${isServiceAdministrator}">
                 <li class="${activeTab == 4 ? 'active' : ''}">
-                    <a href="<c:url value="/admin/viewProviderTypes" />">FUNCTIONS</a> 
+                    <a href="<c:url value="/admin/viewProviderTypes" />">FUNCTIONS</a>
                     <c:if test="${activeTab == 4}"><span class="arrow"></span></c:if>
                 </li>
                 </c:if>
                 <li class="last ${activeTab == 3 ? 'active' : ''}">
-                    <a href="<c:url value="/myprofile" />">MY PROFILE</a> 
+                    <a href="<c:url value="/myprofile" />">MY PROFILE</a>
                     <c:if test="${activeTab == 3}"><span class="arrow"></span></c:if>
                 </li>
             </ul>
-            
+
                 <div class="searchWidget">
                     <a href="${ctx}/provider/search/advanced">Advanced Search</a>
                     <div class="inputContainer">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -4,7 +4,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Login"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
@@ -4,7 +4,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Login"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Welcome"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Welcome"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -6,7 +6,6 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Dashboard"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -6,7 +6,6 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Dashboard"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="${pageTitle}"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="${pageTitle}"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="${pageTitle}"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="${pageTitle}"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="${pageTitle}"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Import Profiles"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Confirm Action"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Import Profiles"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -5,7 +5,6 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <c:set var="title" value="Link Account"/>
-  <c:set var="ctx" value="${pageContext.request.contextPath}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/tags/handlebars.tag
+++ b/psm-app/cms-web/WebContent/WEB-INF/tags/handlebars.tag
@@ -21,16 +21,23 @@ try {
 
   // parent page context, passed via attr
   PageContext parentContext = (PageContext) jspContext.getAttribute("context");
-  Enumeration attrs = parentContext.getAttributeNamesInScope(PageContext.PAGE_SCOPE);
 
-  while(attrs.hasMoreElements()) {
-      String name = attrs.nextElement().toString();
+  int[] scopes = {
+    PageContext.APPLICATION_SCOPE,
+    PageContext.SESSION_SCOPE,
+    PageContext.REQUEST_SCOPE,
+    PageContext.PAGE_SCOPE,
+  };
+  for (int scope : scopes) {
+    Enumeration attrs = parentContext.getAttributeNamesInScope(scope);
 
-      // replicate attrs into current context too
-      map.put(name, parentContext.getAttribute(name));
-      jspContext.setAttribute(name, parentContext.getAttribute(name), PageContext.PAGE_SCOPE);
+    while(attrs.hasMoreElements()) {
+        String name = attrs.nextElement().toString();
+
+        // replicate attrs into current context too
+        map.put(name, parentContext.getAttribute(name, scope));
+    }
   }
-
   Context context = Context.newBuilder(map).build();
 
   %><%= t.apply(context) %><%

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import javax.servlet.http.HttpSession;
 
 import gov.medicaid.entities.CMSUser;
+import gov.medicaid.interceptors.FlashMessageInterceptor;
 import gov.medicaid.security.CMSPrincipal;
 
 import org.springframework.web.servlet.ModelAndView;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -65,8 +65,12 @@ public class ControllerHelper {
     public static CMSPrincipal getPrincipal() {
         SecurityContext context = SecurityContextHolder.getContext();
         Authentication authentication = context.getAuthentication();
-        CMSPrincipal principal = (CMSPrincipal) authentication.getPrincipal();
-        return principal;
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CMSPrincipal) {
+            return (CMSPrincipal) principal;
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -118,39 +122,5 @@ public class ControllerHelper {
     public static void addError(String message) {
         ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         attr.getRequest().setAttribute(FlashMessageInterceptor.FLASH_ERROR, message);
-    }
-
-    /**
-     * Adds request and application context info to model
-     * @param model to add extra information
-     */
-    public static void addContextInfoToModel(ModelAndView model) {
-        ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
-
-        // <c:set var="ctx" value="${pageContext.request.contextPath}"/>
-        model.addObject("ctx", attr.getRequest().getContextPath());
-
-        CMSPrincipal principal = ControllerHelper.getPrincipal();
-        if (principal != null) {
-            CMSUser principalUser = principal.getUser();
-            model.addObject("principalUser", principalUser);
-
-            // <c:if test="${requestPrincipal.user.role.description eq 'Service Administrator'}">
-            if (principalUser.getRole().getDescription().equals("Service Administrator")) {
-                model.addObject("isServiceAdministrator", true);
-            }
-
-            // <sec:authentication property="principal.loginDate" var="loginDate"/>
-            // <fmt:setLocale value="en_US" scope="session"/>
-            // Last login: <fmt:formatDate value="${loginDate}" pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/>
-            SimpleDateFormat dateFormat = new SimpleDateFormat("EEEE, d MMMM yyyy hh:mm:ss a zzz", Locale.US);
-            model.addObject("loginDate", dateFormat.format(principal.getLoginDate()));
-
-            // TODO for provider/profile/list template of MyProfileController
-            // <sec:authentication property="principal.authenticatedBySystem" var="authenticatedBySystem"/>
-            // <sec:authentication property="principal" var="requestPrincipal"/>
-            // <spring:eval expression="authenticatedBySystem == T(gov.medicaid.entities.SystemId).CMS_ONLINE" var="isInternalUser" />
-            // if (principal.authenticatedBySystem == gov.medicaid.entities.SystemId.CMS_ONLINE) model.addObject("isInternalUser", true);
-        }
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
@@ -90,7 +90,6 @@ public class UserController extends BaseServiceAdminController {
             CMSUser user = registrationService.findByUserId(userId);
             ModelAndView model = new ModelAndView("admin/service_admin_view_user_profile");
             model.addObject("user", user);
-            ControllerHelper.addContextInfoToModel(model);
 
             return LogUtil.traceExit(getLog(), signature, model);
         } catch (PortalServiceException e) {
@@ -119,7 +118,6 @@ public class UserController extends BaseServiceAdminController {
             CMSUser user = registrationService.findByUserId(userId);
             ModelAndView model = new ModelAndView("admin/service_admin_edit_user_profile");
             model.addObject("user", user);
-            ControllerHelper.addContextInfoToModel(model);
 
             return LogUtil.traceExit(getLog(), signature, model);
         } catch (PortalServiceException e) {
@@ -156,7 +154,6 @@ public class UserController extends BaseServiceAdminController {
             registrationService.updateUserProfile(currentUser.getUserId(), user);
             ModelAndView model = new ModelAndView("admin/service_admin_view_user_profile");
             model.addObject("user", user);
-            ControllerHelper.addContextInfoToModel(model);
 
             return LogUtil.traceExit(getLog(), signature, model);
         } catch (PortalServiceException e) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gov.medicaid.controllers;
+package gov.medicaid.interceptors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
@@ -1,0 +1,62 @@
+package gov.medicaid.interceptors;
+
+import gov.medicaid.controllers.ControllerHelper;
+import gov.medicaid.entities.CMSUser;
+import gov.medicaid.security.CMSPrincipal;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+public class HandlebarsInterceptor extends HandlerInterceptorAdapter {
+    @Override
+    public void postHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler,
+            ModelAndView modelAndView
+    ) throws Exception {
+        if (modelAndView == null ||
+                modelAndView.getViewName().startsWith("redirect:")) {
+            return;
+        }
+
+        // <c:set var="ctx" value="${pageContext.request.contextPath}"/>
+        modelAndView.addObject("ctx", request.getContextPath());
+
+        CMSPrincipal principal = ControllerHelper.getPrincipal();
+        if (principal != null) {
+            CMSUser principalUser = principal.getUser();
+            modelAndView.addObject("principalUser", principalUser);
+
+            // <c:if test="${requestPrincipal.user.role.description eq 'Service Administrator'}">
+            if ("Service Administrator".equals(principalUser.getRole().getDescription())) {
+                modelAndView.addObject(
+                        "isServiceAdministrator",
+                        true
+                );
+            }
+
+            // <sec:authentication property="principal.loginDate" var="loginDate"/>
+            // <fmt:setLocale value="en_US" scope="session"/>
+            // Last login: <fmt:formatDate value="${loginDate}" pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/>
+            SimpleDateFormat dateFormat = new SimpleDateFormat(
+                    "EEEE, d MMMM yyyy hh:mm:ss a zzz",
+                    Locale.US
+            );
+            modelAndView.addObject(
+                    "loginDate",
+                    dateFormat.format(principal.getLoginDate())
+            );
+
+            // TODO for provider/profile/list template of MyProfileController
+            // <sec:authentication property="principal.authenticatedBySystem" var="authenticatedBySystem"/>
+            // <sec:authentication property="principal" var="requestPrincipal"/>
+            // <spring:eval expression="authenticatedBySystem == T(gov.medicaid.entities.SystemId).CMS_ONLINE" var="isInternalUser" />
+            // if (principal.authenticatedBySystem == gov.medicaid.entities.SystemId.CMS_ONLINE) model.addObject("isInternalUser", true);
+        }
+    }
+}


### PR DESCRIPTION
There are a few common variables that our new templates need, most notably the variable `ctx`. Previously, we were adding those by hand each time we invoked a handlebars template. However, as we add more variables, this will get more and more repetitive. Instead of copy pasta, add an [interceptor](https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/htmlsingle/#mvc-handlermapping-interceptor) that adds the variables, and configure it to run on every request.

This will allow us to add variables more easily (such as the CSRF tokens we need in #219), as well as access the variables already added by the other interceptor (see #494).

I tested this by deploying and force-reloading the login page to ensure that the static assets, which are specified in a handlebars template as being relative to the `ctx` variable, still load. I also updated the admin user's profile, which uses all handlebars templates and no JSPs, to confirm that it still works. Finally, I ran the integration tests, which passed.

Issue #238 Templatize UI