### PR TITLE
Make header menu display correctly for admins: #499

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -135,7 +135,7 @@ public class ControllerHelper {
             model.addObject("principalUser", principalUser);
 
             // <c:if test="${requestPrincipal.user.role.description eq 'Service Administrator'}">
-            if (principalUser.getRole().getDescription() == "Service Administrator") {
+            if (principalUser.getRole().getDescription().equals("Service Administrator")) {
                 model.addObject("isServiceAdministrator", true);
             }
 


### PR DESCRIPTION
Fix comparison so service admins see the Functions tab, as they should.

One line change to fix #499.

See [this StackOverflow answer](https://stackoverflow.com/a/513839/6005068) about how to compare strings in Java -- TIL!