### PR TITLE
Use interceptor-provided current user variable

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
@@ -60,7 +60,7 @@
         <div class="contentWidth">
           <div class="userSection">
             Welcome,
-            <strong><sec:authentication property="principal.username" /></strong>
+            <strong><c:out value="${principalUser.username}" /></strong>
             | <a href="<c:url value='/system/help-system-admin' />">Help</a>
             | <a href="<spring:url value="/j_spring_security_logout" />">Logout</a>
           </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -5,9 +5,8 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<sec:authentication var="principal" property="principal"/>
 <c:choose>
-  <c:when test="${principal ne null && principal.enabled}">
+  <c:when test="${principalUser ne null}">
     <html xmlns="http://www.w3.org/1999/xhtml">
       <c:set var="title" value="Server Error"/>
       <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/includes/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/includes/header.jsp
@@ -12,7 +12,7 @@
 <div id="header">
   <div class="contentWidth">
     <div class="userSection">
-      Welcome, <strong><sec:authentication property="principal.username" /></strong>
+      Welcome, <strong><c:out value="${principalUser.username}" /></strong>
       | <a href="javascript:;">Help</a>
       | <a href="<spring:url value="/j_spring_security_logout" />">Logout</a>
     </div>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -18,13 +18,16 @@ package gov.medicaid.controllers;
 
 import com.topcoder.util.log.Log;
 import gov.medicaid.controllers.validators.StrictCustomDateEditor;
+import gov.medicaid.interceptors.HandlebarsInterceptor;
 import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.util.LogUtil;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.servlet.ModelAndView;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Date;
 
@@ -77,15 +80,22 @@ public abstract class BaseController {
     }
 
     /**
-     * Captures any exception that is thrown from the controllers and sends the user to the
-     * error page.
-     * @param ex the exception thrown
+     * Captures any exception that is thrown from the controllers and renders
+     * the error page.
+     *
+     * @param request the request that resulted in an exception
+     * @param ex      the exception thrown
      * @return the error view
      */
     @ExceptionHandler(Exception.class)
-    public String handleError(Exception ex) {
+    public ModelAndView handleError(
+            HttpServletRequest request,
+            Exception ex
+    ) {
         LogUtil.traceError(getLog(), "BaseController#handleError(Exception ex)", ex);
-        return "error";
+        ModelAndView view = new ModelAndView("error");
+        HandlebarsInterceptor.addCommonVariables(request, view);
+        return view;
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -16,20 +16,17 @@
 
 package gov.medicaid.controllers;
 
+import com.topcoder.util.log.Log;
 import gov.medicaid.controllers.validators.StrictCustomDateEditor;
 import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.util.LogUtil;
-
-import java.util.Date;
-
-import javax.servlet.http.HttpServletResponse;
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.InitBinder;
 
-import com.topcoder.util.log.Log;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
 
 /**
  * A base controller class that other classes will extend that provides logging.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -114,8 +114,8 @@ public abstract class BaseController {
      * @param response the response to add disable cache headers on
      */
     protected void nocache(HttpServletResponse response) {
-        response.addHeader("Cache-Control", "no-cache,no-store,private,must-revalidate,max-stale=0,post-check=0,pre-check=0"); 
-        response.addHeader("Pragma", "no-cache"); 
+        response.addHeader("Cache-Control", "no-cache,no-store,private,must-revalidate,max-stale=0,post-check=0,pre-check=0");
+        response.addHeader("Pragma", "no-cache");
         response.addDateHeader("Expires", 0);
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
@@ -17,6 +17,7 @@
 package gov.medicaid.controllers.admin;
 
 import com.topcoder.util.log.Log;
+import gov.medicaid.interceptors.HandlebarsInterceptor;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.RegistrationService;
@@ -24,6 +25,8 @@ import gov.medicaid.services.util.LogUtil;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * A base controller class that other classes will extend that provides logging, auditing, and additional services.
@@ -65,14 +68,20 @@ public abstract class BaseSystemAdminController {
 
     /**
      * Directs all exceptions encountered by subclasses to a generic error page.
-     * @param ex the exception encountered
+     *
+     * @param request the request that resulted in an exception
+     * @param ex      the exception encountered
      * @return the error view name
      */
     @ExceptionHandler(Exception.class)
-    public ModelAndView handleException(Exception ex) {
+    public ModelAndView handleException(
+            HttpServletRequest request,
+            Exception ex
+    ) {
         LogUtil.traceError(getLog(), "BaseSystemAdminController#handleException(Exception ex)", ex);
         ModelAndView view = new ModelAndView("error");
         view.addObject("exception", ex);
+        HandlebarsInterceptor.addCommonVariables(request, view);
         return view;
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
@@ -16,16 +16,14 @@
 
 package gov.medicaid.controllers.admin;
 
+import com.topcoder.util.log.Log;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.RegistrationService;
 import gov.medicaid.services.util.LogUtil;
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.topcoder.util.log.Log;
 
 /**
  * A base controller class that other classes will extend that provides logging, auditing, and additional services.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
@@ -24,6 +25,13 @@ public class HandlebarsInterceptor extends HandlerInterceptorAdapter {
             return;
         }
 
+        addCommonVariables(request, modelAndView);
+    }
+
+    public static void addCommonVariables(
+            @NotNull HttpServletRequest request,
+            @NotNull ModelAndView modelAndView
+    ) {
         // <c:set var="ctx" value="${pageContext.request.contextPath}"/>
         modelAndView.addObject("ctx", request.getContextPath());
 


### PR DESCRIPTION
Instead of using the Spring Security helper tags, which will be unavailable once we finish our template migration, use the variable provided by the interceptor introduced in #500.

This also fixes an issue with errors on logged-out pages, as the error page was not handling the case where the current user is an anonymous user. This shows up as:

    The class 'java.lang.String' does not have the property 'enabled'.

The helper method used to fetch the current user correctly accounts for anonymous users.

Issue #238 Templatize UI
Resolves #504 Stack trace when mail server unavailable