### PR TITLE
Restrict agents and system administrators

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -77,6 +77,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -106,10 +107,8 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     /**
      * List of roles with full access to all profiles and tickets.
      */
-    private static final List<String> FULL_ACCESS = Arrays.asList(
-            ViewStatics.ROLE_SERVICE_AGENT,
-            ViewStatics.ROLE_SERVICE_ADMINISTRATOR,
-            ViewStatics.ROLE_SYSTEM_ADMINISTRATOR
+    private static final List<String> FULL_ACCESS = Collections.singletonList(
+            ViewStatics.ROLE_SERVICE_ADMINISTRATOR
     );
 
     /**

--- a/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
@@ -15,10 +15,10 @@
 
   <s:http entry-point-ref="authenticationProcessingFilterEntryPoint">
     <s:intercept-url pattern="/system/**" access="ROLE_SYSTEM_ADMINISTRATOR"/>
-    <s:intercept-url pattern="/admin/**" access="ROLE_SERVICE_ADMINISTRATOR,ROLE_SERVICE_AGENT,ROLE_SYSTEM_ADMINISTRATOR"/>
-    <s:intercept-url pattern="/agent/**" access="ROLE_SERVICE_ADMINISTRATOR,ROLE_SERVICE_AGENT,ROLE_SYSTEM_ADMINISTRATOR"/>
-    <s:intercept-url pattern="/provider/profile/edit" access="ROLE_PROVIDER,ROLE_SERVICE_AGENT,ROLE_SERVICE_ADMINISTRATOR"/>
-    <s:intercept-url pattern="/provider/profile/renew" access="ROLE_PROVIDER,ROLE_SERVICE_AGENT,ROLE_SERVICE_ADMINISTRATOR"/>
+    <s:intercept-url pattern="/admin/**" access="ROLE_SERVICE_ADMINISTRATOR"/>
+    <s:intercept-url pattern="/agent/**" access="ROLE_SERVICE_ADMINISTRATOR"/>
+    <s:intercept-url pattern="/provider/profile/edit" access="ROLE_PROVIDER,ROLE_SERVICE_ADMINISTRATOR"/>
+    <s:intercept-url pattern="/provider/profile/renew" access="ROLE_PROVIDER,ROLE_SERVICE_ADMINISTRATOR"/>
     <s:intercept-url pattern="/provider/profile/**" access="ROLE_PROVIDER"/>
     <s:intercept-url pattern="/provider/**" access="IS_AUTHENTICATED_REMEMBERED"/>
     <s:intercept-url pattern="/landing" access="IS_AUTHENTICATED_REMEMBERED"/>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
@@ -56,7 +56,7 @@ public class LandingController extends BaseController {
         if (ViewStatics.ROLE_PROVIDER.equals(role)) {
             return "redirect:/provider/dashboard/";
         } else if (ViewStatics.ROLE_SERVICE_AGENT.equals(role)) {
-            return "redirect:/ops/viewDashboard";
+            return "redirect:/provider/dashboard/";
         } else if (ViewStatics.ROLE_SERVICE_ADMINISTRATOR.equals(role)) {
             return "redirect:/ops/viewDashboard";
         } else if (ViewStatics.ROLE_SYSTEM_ADMINISTRATOR.equals(role)) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -31,6 +31,7 @@ import gov.medicaid.services.util.Util;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.UUID;
 
 import javax.annotation.PostConstruct;
@@ -117,12 +118,17 @@ public class ProviderDashboardController extends BaseController {
 
     /**
      * Is operations user.
-     * @return true if the user is an agent or admin
+     *
+     * @return true if the user is an admin
      */
     private boolean isOperations() {
+        final Collection<String> operationsRoles = Arrays.asList(
+                ViewStatics.ROLE_SERVICE_ADMINISTRATOR,
+                ViewStatics.ROLE_SYSTEM_ADMINISTRATOR
+        );
         CMSUser user = ControllerHelper.getCurrentUser();
         String role = user.getRole().getDescription();
-        return !ViewStatics.ROLE_PROVIDER.equals(role);
+        return operationsRoles.contains(role);
     }
 
     /**


### PR DESCRIPTION
Limit the abilities of service agents to what providers can do, and limit the abilities of system administrators to be creating, editing, and deleting users.

To test this, I logged in as `admin` (a service administrator), copied several links to a text file, and then logged in as a service agent and as a system administrator, and verified that I could not see those pages.

Note that the ops dashboard is *not* protected, and should be - that is separate from this, and I've opened #523 to track it.

Issue #10 Limit sys admins', service agents' ability to view, edit enrollments