### PR TITLE
Remove hardcoded variable from registration success message

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
@@ -29,13 +29,12 @@
                 <div class="wholeCol">
                   <h3>Welcome
                     <c:out value="${account.username}"/>!</h3>
-                  <p>You have been successfully registered to APPNAME.</p>
+                  <p>You have successfully registered an account.</p>
                   <p>
                     We have sent a confirmation email to
-                    <i><c:out value="${account.email}"/></i>
-                    with your login information. If you do not receive the email within a reasonable amount of time, please
-                    <a href="#">contact us</a>
-                    and we will resend the notification.
+                    <i><c:out value="${account.email}"/></i> with your login information.
+		    If you do not receive the email within a reasonable amount of time, please
+                    <a href="#">contact us</a> and we will resend the notification.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
A partial response to #176.

If we think it's important to use the name "Provider Screening Module", or to make this admin-configurable so that the name of the state can be included, then we can revise this. I'm inclined to merge this to get rid of the unsightly `APPNAME`.