### PR TITLE
Document logout of inactive users: #414

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -433,6 +433,14 @@ we will set a sane default in `cms.properties` when we do.  See [issue
 263 in GitHub](https://github.com/OpenTechStrategies/psm/issues/263)
 for some discussion of the problem.
 
+## Configuration options
+
+Note: This section will grow as we describe more configurable options.
+
+1. The amount of time before the system logs out an inactive user can be
+set in the `session-timeout` variable in
+`psm-app/cms-web/WebContent/WEB-INF/web.xml`.
+
 ## Continuous Deployment
 
 This project leverages Travis to power Continuous Deployment.  To set

--- a/psm-app/userhelp/source/account-help.rst
+++ b/psm-app/userhelp/source/account-help.rst
@@ -70,3 +70,11 @@ Can I delete my account?
 
 No, you cannot. `A future version of the PSM may let you do
 so. <https://github.com/OpenTechStrategies/psm/issues/327>`__
+
+I stopped using the PSM for a while and when I came back I had to log in again.  Is that normal?
+------------------------------------------------------------------------------------------------
+
+Yes.  For security purposes, the PSM will automatically log you out
+after you haven't interacted with the application for a given amount of
+time.  The default is 30 minutes, but it may be as little as 15 minutes
+depending on the guidelines in your state.


### PR DESCRIPTION
Add user and developer-focused documentation for configuring the amount
of time a user can be inactive on the PSM before being automatically
logged out.

@brainwane, let me know if this follows your user documentation format correctly.