### PR TITLE
Convert 'EFT Vendor Number' to 'EFT Accepted'

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/Entities.xsd
+++ b/psm-app/cms-business-model/src/main/resources/Entities.xsd
@@ -189,7 +189,7 @@
       <element name="StateTaxId" type="string" maxOccurs="1" minOccurs="0"/>
       <element name="StateMedicaidId" type="string" maxOccurs="1" minOccurs="0"/>
       <element name="FiscalYearEnd" type="string" maxOccurs="1" minOccurs="0"/>
-      <element name="EFTVendorNumber" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="EftAccepted" type="boolean" maxOccurs="1" minOccurs="0"/>
       <element name="AdditionalPracticeLocations" type="tns:AdditionalPracticeLocationsType" maxOccurs="1" minOccurs="0"/>
       <element name="BillingSameAsPrimary" type="string" maxOccurs="1" minOccurs="0"/>
       <element name="ReimbursementSameAsPrimary" type="string" maxOccurs="1" minOccurs="0"/>

--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -5244,51 +5244,19 @@ dialect 'mvel'
 
 end
 
-rule 'EFT Vendor Number Maximum Length Check'
+rule 'EFT Accepted Indicator Must Be Answered'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- * Updated character length check - PEPS-254
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
-        PracticeInformationType(EFTVendorNumber != null, EFTVendorNumber not matches "^.{0,14}$") from $provider.practiceInformation
+        PracticeInformationType(isEftAccepted() == null) from $provider.practiceInformation
         $report: ErrorReporter()
     then
         $report.addError(
-            "/ProviderInformation/PracticeInformation/EFTVendorNumber",
+            "/ProviderInformation/PracticeInformation/EftAccepted",
             "00001",
-            "EFT vendor number length cannot exceed 14 characters."
+            "EFT Accepted question must be answered."
         );
-
-end
-
-rule 'EFT Vendor Number Should Be Left Empty'
-dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
-        $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
-        PracticeInformationType(EFTVendorNumber != null, EFTVendorNumber != "") from $provider.practiceInformation
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/PracticeInformation/EFTVendorNumber",
-            "00001",
-            "EFT vendor number must be left empty if not in private practice."
-        );
-
 end
 
 rule 'Eighteen Years Old And Above Must Be Answered For Specified Provider Types'

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -79,9 +79,9 @@
     </span>
 </div>
 <div class="row">
-    <label>EFT Vendor Number</label>
+    <label>Do you accept <abbr title="Electronic Funds Transfer">EFT</abbr>?</label>
     <span class="floatL"><b>:</b></span>
-    <span id="eftVendorNumber">${requestScope['_05_eftVendorNo']}</span>
+    <span id="eftAccepted">${requestScope['_05_eftAccepted'] ? 'Yes' : 'No'}</span>
 </div>
 <div class="row">
     <label>Remittance Sequence</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -16,28 +16,28 @@
     <c:set var="formName" value="_05_objectId"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
     <input type="hidden" name="${formName}" value="${formValue}"/>
-        
+
     <c:set var="disableLinkedFields" value=""></c:set>
     <c:set var="isLinked" value="${false}"></c:set>
     <c:if test="${not empty formValue}">
         <c:set var="disableLinkedFields" value='disabled="disabled"'></c:set>
         <c:set var="isLinked" value="${true}"></c:set>
     </c:if>
-    
+
     <c:set var="disableBillingAddress" value="${isLinked}" />
     <c:set var="billingAddressMarkup" value="${disableLinkedFields}" />
     <c:set var="formName" value="_05_billingSameAsPrimary"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-    
+
     <c:if test="${formValue eq 'Y'}">
         <c:set var="disableBillingAddress" value="${true}" />
         <c:set var="billingAddressMarkup" value='disabled="disabled"'></c:set>
     </c:if>
-    
+
     <c:set var="formName" value="_05_objectIdHash"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
     <input type="hidden" name="${formName}" value="${formValue}"/>
-    
+
     <div id="privatePractice">
         <div class="tableHeader otherTableHeader">
             <span>Private Practice or Primary Office Location Information</span>
@@ -49,7 +49,7 @@
                 <div class="row">
                     <label>Private Practice Name<span class="required">*</span></label>
                     <span class="floatL"><b>:</b></span>
-                    
+
                     <c:set var="formName" value="_05_name"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
@@ -75,7 +75,7 @@
                 <div class="row addressline1">
                     <label>Practice Address<span class="required">*</span></label>
                     <span class="floatL"><b>:</b></span>
-                    
+
                     <c:set var="formName" value="_05_addressLine1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="28"/>
@@ -161,19 +161,19 @@
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <input ${disableLinkedFields} type="checkbox" class="checkbox" name="${formName}" ${formValue eq 'Y' ? 'checked' : ''}/>Same as Above
                         </div>
-                        
+
                         <div class="row addressline1">
                             <c:set var="formName" value="_05_billingAddressLine1"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <input ${billingAddressMarkup} type="text" class="${disableBillingAddress ? 'disabled' : '' } addressInput normalInput" name="${formName}" value="${formValue}" maxlength="28"/>
                         </div>
-                        
+
                         <div class="row addressline2">
                             <c:set var="formName" value="_05_billingAddressLine2"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <input ${billingAddressMarkup} type="text" class="${disableBillingAddress ? 'disabled' : '' } addressInput normalInput" name="${formName}" value="${formValue}" maxlength="28"/>
                         </div>
-                        
+
                         <div class="addreddWrapper">
                             <label class="smallLabel">City<span class="required">*</span> : </label>
                             <c:set var="formName" value="_05_billingCity"></c:set>
@@ -262,7 +262,7 @@
         </div>
         <!-- /.section -->
     </div>
-    
+
     <!-- /#primaryOffice -->
     <div class="clear"></div>
     <div class="tl"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -231,11 +231,30 @@
                     <span class="shrtFldInfo">MM/DD</span>
                 </div>
                 <div class="row">
-                    <label>EFT Vendor Number</label>
+                    <label>Do you accept <abbr title="Electronic Funds Transfer">EFT</abbr>?<span class="required">*</span></label>
                     <span class="floatL"><b>:</b></span>
-                    <c:set var="formName" value="_05_eftVendorNo"></c:set>
+                    <c:set var="formName" value="_05_eftAccepted"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <input ${disableLinkedFields} type="text" class="normalInput eftMasked" name="${formName}" value="${formValue}" maxlength="14"/>
+                    <div class="rowWrapper">
+                        <div class="row">
+                            <label class="span">
+                                <input type="radio"
+                                    value="true"
+                                    name="${formName}"
+                                    ${formValue ? 'checked' : ''}>
+                                Yes
+                            </label>
+                        </div>
+                        <div class="row">
+                            <label class="span">
+                                <input type="radio"
+                                    value="false"
+                                    name="${formName}"
+                                    ${empty formValue or formValue ? '' : 'checked'}>
+                                No
+                            </label>
+                        </div>
+                    </div>
                 </div>
                 <div class="row">
                     <label>Remittance Sequence<span class="required">*</span></label>

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -2411,7 +2411,7 @@ function copyPrimaryPracticeFields(namespace, row) {
   $('.practicePanel input[name="' + namespace + 'stateTaxId"]').val('');
   $('.practicePanel input[name="' + namespace + 'fye1"]').val('');
   $('.practicePanel input[name="' + namespace + 'fye2"]').val('');
-  $('.practicePanel input[name="' + namespace + 'eftVendorNo"]').val('');
+  $('.practicePanel input[name="' + namespace + 'eftAccepted"]').val('');
   $('.practicePanel input[name="' + namespace + 'remittanceSequence"]').val('');
 
   $('.practicePanel input[name="' + namespace + 'reimbursementSameAsPrimary"]').prop('checked', true);
@@ -2465,7 +2465,7 @@ function togglePrimaryPracticeFields(namespace, disabled) {
   $('.practicePanel input[name="' + namespace + 'stateTaxId"]').prop('disabled', disabled);
   $('.practicePanel input[name="' + namespace + 'fye1"]').prop('disabled', disabled);
   $('.practicePanel input[name="' + namespace + 'fye2"]').prop('disabled', disabled);
-  $('.practicePanel input[name="' + namespace + 'eftVendorNo"]').prop('disabled', disabled);
+  $('.practicePanel input[name="' + namespace + 'eftAccepted"]').prop('disabled', disabled);
   $('.practicePanel input[name="' + namespace + 'remittanceSequence"]').prop('disabled', disabled);
 
   $('.practicePanel input[name="' + namespace + 'reimbursementSameAsPrimary"]').prop('disabled', disabled);

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -991,7 +991,7 @@ CREATE TABLE organizations(
   state_medicaid_id TEXT,
   fiscal_year_end TEXT,
   remittance_sequence_order TEXT,
-  eft_vendor_number TEXT
+  eft_accepted BOOLEAN
 );
 CREATE TABLE people(
   entity_id BIGINT PRIMARY KEY

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -56,7 +56,6 @@ public class EnrollmentSteps {
     private static final String PRACTICE_FEIN = "12-3456789";
     private static final String PRACTICE_STATE_TAX_ID = "1234567";
     private static final String PRACTICE_YEAR_END = "12/31";
-    private static final String PRACTICE_EFT_VENDOR_NUMBER = "1234567890-123";
 
     private LoginPage loginPage;
     private DashboardPage dashboardPage;
@@ -197,7 +196,7 @@ public class EnrollmentSteps {
         practiceInfoPage.enterFein(PRACTICE_FEIN);
         practiceInfoPage.enterStateTaxId(PRACTICE_STATE_TAX_ID);
         practiceInfoPage.enterFiscalYearEnd(PRACTICE_YEAR_END);
-        practiceInfoPage.enterEftVendorNumber(PRACTICE_EFT_VENDOR_NUMBER);
+        practiceInfoPage.checkYesEftAccepted();
         practiceInfoPage.checkFirstRemittanceSequence();
     }
 
@@ -271,8 +270,8 @@ public class EnrollmentSteps {
                 .isEqualToIgnoringWhitespace(PRACTICE_STATE_TAX_ID);
         assertThat(individualSummaryPage.getFiscalYearEnd())
                 .isEqualToIgnoringWhitespace(PRACTICE_YEAR_END);
-        assertThat(individualSummaryPage.getEftVendorNumber())
-                .isEqualToIgnoringWhitespace(PRACTICE_EFT_VENDOR_NUMBER);
+        assertThat(individualSummaryPage.getEftAccepted())
+                .isTrue();
         assertThat(individualSummaryPage.getRemittanceSequence())
                 .isEqualToIgnoringWhitespace("Patient Account or Own Reference Number Order");
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
@@ -167,8 +167,8 @@ public class IndividualSummaryPage extends PageObject {
         return textOf("#fiscalYearEnd");
     }
 
-    public String getEftVendorNumber() {
-        return textOf("#eftVendorNumber");
+    public Boolean getEftAccepted() {
+        return parseYesNoField("#eftAccepted");
     }
 
     public String getRemittanceSequence() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -90,8 +90,8 @@ public class PracticeInfoPage extends PageObject {
         $("[name=_05_fye2]").type(day);
     }
 
-    public void enterEftVendorNumber(String eftVendorNumber) {
-        $("[name=_05_eftVendorNo]").type(eftVendorNumber);
+    public void checkYesEftAccepted() {
+        click(this, $("[name=_05_eftAccepted]"));
     }
 
     public void checkFirstRemittanceSequence() {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -296,6 +296,10 @@ public abstract class BaseFormBinder implements FormBinder {
         attr(mv, "county", i, address.getCounty());
     }
 
+    protected void attr(Map<String, Object> mv, String key, Boolean value) {
+        mv.put(name(key), value);
+    }
+
     /**
      * Instantiates the correct entity type based on the provider type.
      *

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -100,7 +100,11 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
             practice.setFEIN(param(request, "fein"));
             practice.setStateTaxId(param(request, "stateTaxId"));
             practice.setFiscalYearEnd(BinderUtils.concatFiscalYearEnd(param(request, "fye1"), param(request, "fye2")));
-            practice.setEFTVendorNumber(param(request, "eftVendorNo"));
+            if (param(request, "eftAccepted") != null) {
+                practice.setEftAccepted(
+                        Boolean.valueOf(param(request, "eftAccepted"))
+                );
+            }
             provider.setRemittanceSequenceNumber(param(request, "remittanceSequence"));
         } else {
             practice.setEffectiveDate(null);
@@ -109,7 +113,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
             practice.setFEIN(null);
             practice.setStateTaxId(null);
             practice.setFiscalYearEnd(null);
-            practice.setEFTVendorNumber(null);
+            practice.setEftAccepted(null);
             provider.setRemittanceSequenceNumber(null);
         }
 
@@ -145,7 +149,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
             String[] fye = BinderUtils.splitFiscalYear(practice.getFiscalYearEnd());
             attr(mv, "fye1", fye[0]);
             attr(mv, "fye2", fye[1]);
-            attr(mv, "eftVendorNo", practice.getEFTVendorNumber());
+            attr(mv, "eftAccepted", practice.isEftAccepted());
             attr(mv, "remittanceSequence", provider.getRemittanceSequenceNumber());
         }
     }
@@ -194,8 +198,8 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
                     errors.add(createError("stateTaxId", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/RemittanceSequenceNumber")) {
                     errors.add(createError("remittanceSequence", ruleError.getMessage()));
-                } else if (path.equals(PRACTICE_INFO + "EFTVendorNumber")) {
-                    errors.add(createError("eftVendorNo", ruleError.getMessage()));
+                } else if (path.equals(PRACTICE_INFO + "EftAccepted")) {
+                    errors.add(createError("EftAccepted", ruleError.getMessage()));
                 } else if (path.equals(PRACTICE_INFO + "FiscalYearEnd")) {
                     String[] fiscalYearGroup = new String[]{"fye1", "fye2"};
                     errors.add(createError(fiscalYearGroup, ruleError.getMessage()));
@@ -232,7 +236,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
         if (Util.isBlank(practice.getObjectId())) {
             Organization employer = (Organization) primary.getEntity();
             employer.setFein(practice.getFEIN());
-            employer.setEftVendorNumber(practice.getEFTVendorNumber());
+            employer.setEftAccepted(practice.isEftAccepted());
             employer.setStateTaxId(practice.getStateTaxId());
             employer.setFiscalYearEnd(practice.getFiscalYearEnd());
             if (Util.isNotBlank(provider.getRemittanceSequenceNumber())) {
@@ -269,7 +273,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
         if (!"Y".equals(employer.getEnrolled())) {
             // user owned employer record, show everything
             practice.setFEIN(employer.getFein());
-            practice.setEFTVendorNumber(employer.getEftVendorNumber());
+            practice.setEftAccepted(employer.isEftAccepted());
             practice.setStateTaxId(employer.getStateTaxId());
             practice.setFiscalYearEnd(employer.getFiscalYearEnd());
             if (employer.getRemittanceSequenceOrder() != null) {
@@ -310,7 +314,7 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
             PDFHelper.addLabelValueCell(practiceInfo, "FEIN", PDFHelper.value(model, ns, "fein"));
             PDFHelper.addLabelValueCell(practiceInfo, "State Tax ID", PDFHelper.value(model, ns, "stateTaxId"));
             PDFHelper.addLabelValueCell(practiceInfo, "Fiscal Year End", PDFHelper.getFiscalYear(model, ns));
-            PDFHelper.addLabelValueCell(practiceInfo, "EFT Vendor Number", PDFHelper.value(model, ns, "eftVendorNo"));
+            PDFHelper.addLabelValueCell(practiceInfo, "Accepts EFT", PDFHelper.getBoolean(model, ns, "eftAccepted"));
             PDFHelper.addLabelValueCell(practiceInfo, "Remittance Sequence", PDFHelper.value(model, ns, "remittanceSequence"));
         }
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
@@ -100,8 +100,8 @@ public class Organization extends Entity {
     @Column(name = "remittance_sequence_order")
     private RemittanceSequenceOrder remittanceSequenceOrder;
 
-    @Column(name = "eft_vendor_number")
-    private String eftVendorNumber;
+    @Column(name = "eft_accepted")
+    private Boolean eftAccepted;
 
     /**
      * Empty constructor.
@@ -173,14 +173,6 @@ public class Organization extends Entity {
         this.remittanceSequenceOrder = remittanceSequenceOrder;
     }
 
-    public String getEftVendorNumber() {
-        return eftVendorNumber;
-    }
-
-    public void setEftVendorNumber(String eftVendorNumber) {
-        this.eftVendorNumber = eftVendorNumber;
-    }
-
     public String getBillingSameAsPrimary() {
         return billingSameAsPrimary;
     }
@@ -211,5 +203,13 @@ public class Organization extends Entity {
 
     public void setAgencyId(String agencyId) {
         this.agencyId = agencyId;
+    }
+
+    public Boolean isEftAccepted() {
+        return eftAccepted;
+    }
+
+    public void setEftAccepted(Boolean eftAccepted) {
+        this.eftAccepted = eftAccepted;
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
@@ -152,7 +152,27 @@ public class PDFHelper {
     public static String formatBoolean(String val) {
         return "Y".equals(val) ? "Yes" : "N".equals(val) ? "No" : "";
     }
-    
+
+    /**
+     * Retrieves the namespaced attribute.
+     *
+     * @param model the view model
+     * @param ns    the namespace
+     * @param name  the attribute name
+     * @return the attribute value
+     */
+    public static String getBoolean(
+            Map<String, Object> model,
+            String ns,
+            String name
+    ) {
+        Object val = model.get(ns + name);
+        if (val == null) {
+            return "";
+        }
+        return (Boolean) val ? "Yes" : "No";
+    }
+
     /**
      * Formats the address as string.
      *


### PR DESCRIPTION
This involved a database change and setting up support for boolean values in several places.  Below are the commands for altering the database.  The first is needed for these changes to work, and the second one should not be run until this lands on master.
```
psql alter table organizations add column accepts_eft boolean;
psql alter table organizations drop column eft_vendor_number;
```
UPDATE: the first command should be:
```
psql alter table organizations add column eft_accepted boolean;
```
With the database changed... When creating or editing an enrollment/application, instead of EFT Vendor Number you will see a radio button toggle Yes/No for whether EFT is accepted.  (@jasonaowen and I thought the radio buttons were clearer than a checkbox.)  It starts as "No" by default.  The value of the radio button should remain the same when saving a draft or moving back and forth in the enrollment steps.  On the summary page for the application it should list "Yes" or "No" for this question.  Similarly, when exporting a PDF, the value should be "Yes" or "No".  The web UI tests should succeed; exercising this feature by switching it to "Yes".

This PR currently does not contain a new drools rule, but I wanted to go ahead and put it up.  I made a start on adding one ("EFT accepted should be true or false") but the other rules use "Y" and "N" so it is not clear to me yet how to get this to work for a boolean.  This PR can be WIP if we want to include a drools rule in it, or we can add that in a follow-up.

Issue #411 