### PR TITLE
Use `=true` instead of `=1` in handlebars templates for clarity

### DIFF
--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
@@ -8,7 +8,7 @@
         <div class="contentWidth">
           <div class="mainNav">
             {{> includes/logo }}
-            {{> includes/nav activeTab3=1 }}
+            {{> includes/nav activeTab3=true }}
           </div>
         <div class="breadCrumb">
           <a href="{{ctx}}/ops/getUser">My Profile</a>

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
@@ -8,7 +8,7 @@
         <div class="contentWidth">
           <div class="mainNav">
             {{> includes/logo }}
-            {{> includes/nav activeTab3=1 }}
+            {{> includes/nav activeTab3=true }}
           </div>
         <div class="breadCrumb">
           <span>My Profile</span>


### PR DESCRIPTION
This is just for clarity when reading the code and does not change any functionality.  When logging in as `admin`, clicking the MY PROFILE tab, and viewing or editing that profile, the MY PROFILE tab is the active tab and has a little arrow underneath it.

Issue #238 Templatize UI