### PR TITLE
Abridge Travis logs of Wildfly download+extraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ cache:
 # We depend on a WildFly deployment for some of the production
 # .jar files. Download it and install just above our repo.
 before_script:
-  - wget http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz -O /tmp/wildfly-10.1.0.Final.tar.gz
+  - wget --no-verbose
+        http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz
+        -O /tmp/wildfly-10.1.0.Final.tar.gz
   - pushd ..
-  - tar -xvf /tmp/wildfly-10.1.0.Final.tar.gz
+  - tar -xf /tmp/wildfly-10.1.0.Final.tar.gz
   - popd
   - ./scripts/travis-start-wildfly.sh
 


### PR DESCRIPTION
Reduce the amount of extraneous information in the Travis logs so as to help us more easily diagnose problems.

Add the `--no-verbose` flag to [`wget(1)`](http://manpages.ubuntu.com/manpages/trusty/en/man1/wget.1.html), which will:

    Turn off verbose without being completely quiet (use -q for that),
    which means that error messages and basic information still get 
    printed.

Also remove the `-v` flag from [`tar(1)`](http://manpages.ubuntu.com/manpages/trusty/en/man1/tar.1.html), which was causing it to

    verbosely list files processed

Together, these two programs were creating thousands of log lines, which sometimes caused our log to be longer than Travis's limit of 10,000 lines, and I don't think these log lines were particularly useful.

Issue #533 Travis/Sauce Labs disconnection problem?