### PR TITLE
16 commons version upgrade

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -20,7 +20,7 @@ def serenity_version = '1.5.5'
 // These libraries are known to be used, since they are required during compile
 // or on immediate deployment
 ext.libs = [
-    commons_codec: 'commons-codec:commons-codec:1.6',
+    commons_codec: 'commons-codec:commons-codec:1.11',
     commons_fileupload: 'commons-fileupload:commons-fileupload:1.3.3',
     commons_io: 'commons-io:commons-io:2.0.1',
     commons_lang: 'commons-lang:commons-lang:2.4',

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -22,7 +22,7 @@ def serenity_version = '1.5.5'
 ext.libs = [
     commons_codec: 'commons-codec:commons-codec:1.11',
     commons_fileupload: 'commons-fileupload:commons-fileupload:1.3.3',
-    commons_io: 'commons-io:commons-io:2.0.1',
+    commons_io: 'commons-io:commons-io:2.6',
     commons_lang: 'commons-lang:commons-lang:2.4',
     hapi_fhir: 'ca.uhn.hapi.fhir:hapi-fhir-client-okhttp:2.5',
     handlebars: 'com.github.jknack:handlebars:4.0.6',

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -23,7 +23,8 @@ ext.libs = [
     commons_codec: 'commons-codec:commons-codec:1.11',
     commons_fileupload: 'commons-fileupload:commons-fileupload:1.3.3',
     commons_io: 'commons-io:commons-io:2.6',
-    commons_lang: 'commons-lang:commons-lang:2.4',
+    commons_lang: 'commons-lang:commons-lang:2.6',
+    commons_lang3: 'org.apache.commons:commons-lang3:3.7',
     hapi_fhir: 'ca.uhn.hapi.fhir:hapi-fhir-client-okhttp:2.5',
     handlebars: 'com.github.jknack:handlebars:4.0.6',
     handlebars_springmvc: 'com.github.jknack:handlebars-springmvc:4.0.6',
@@ -100,6 +101,7 @@ project(':services') {
     dependencies {
         compile libs.commons_codec
         compile libs.commons_lang
+        compile libs.commons_lang3
         compile libs.itext
         compile libs.jasypt
         compile libs.jbpm_human_task_core
@@ -132,6 +134,7 @@ project(':cms-business-process') {
         compile libs.commons_codec
         compile libs.commons_io
         compile libs.commons_lang
+        compile libs.commons_lang3
         compile libs.hapi_fhir
         compile libs.itext
         compile libs.jbpm_human_task_core
@@ -236,6 +239,7 @@ project(':cms-portal-services') {
         earlib libs.commons_fileupload
         earlib libs.commons_io
         earlib libs.commons_lang
+        earlib libs.commons_lang3
         earlib libs.hapi_fhir
         earlib libs.itext
         earlib libs.jasypt


### PR DESCRIPTION
The three commons libraries identified in #16 were all pretty straightforward upgrades; no code needed to be changed for our tests to pass.