### PR TITLE
Use PBKDF2 to hash user passwords

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -47,6 +47,7 @@ ext.libs = [
     spring_security_acl: "org.springframework.security:spring-security-acl:${spring_security_version}",
     spring_security_aspects: "org.springframework.security:spring-security-aspects:${spring_security_version}",
     spring_security_config: "org.springframework.security:spring-security-config:${spring_security_version}",
+    spring_security_core: "org.springframework.security:spring-security-core:${spring_security_version}",
     spring_security_ldap: "org.springframework.security:spring-security-ldap:${spring_security_version}",
     spring_security_taglibs: "org.springframework.security:spring-security-taglibs:${spring_security_version}",
     spring_webmvc: "org.springframework:spring-webmvc:${spring_core_version}",
@@ -135,6 +136,7 @@ project(':cms-business-process') {
         compile libs.hapi_fhir
         compile libs.itext
         compile libs.jbpm_human_task_core
+        compile libs.spring_security_core
         compile libs.velocity
         compile fileTree(dir: '../cms-portal-services/lib', include: '*.jar')
         compile fileTree(dir: '../../../wildfly-10.1.0.Final/modules/system/layers/base/javax')

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
@@ -21,17 +21,14 @@ import gov.medicaid.entities.Authentication;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
-import gov.medicaid.services.impl.BaseService;
+import org.apache.commons.codec.binary.Base64;
 
+import javax.ejb.Local;
+import javax.ejb.Stateless;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.ejb.Local;
-import javax.ejb.Stateless;
-
-import org.apache.commons.codec.binary.Base64;
 
 /**
  * This is an EJB implementation for the {@link IdentityProviderDAO} which connects directly to the database

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2013 TopCoder, Inc.
  *
- * This code was developed under U.S. government contract NNH10CD71C. 
+ * This code was developed under U.S. government contract NNH10CD71C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ public class DBIdentityProviderDAOBean extends BaseService implements IdentityPr
         if (auth == null) {
             return false;
         }
-        
+
         return auth.getPassword().equals(hash(password));
     }
 }

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -107,9 +107,24 @@ CREATE TABLE cms_authentication(
   password TEXT NOT NULL
 );
 INSERT INTO cms_authentication (username, password) VALUES
-  ('admin', '{SHA}0DPiKuNIrrVmD8IUCuw1hQxNqZc='), -- password: admin
-  ('p1', '{SHA}t49XZhHsBvlq88plTCIXKl10bEA='), -- password: p1
-  ('system', '{SHA}MX8edh8vqo2ngaR2K53MLFytIJo='); -- password: system
+  (
+    'admin',
+    -- password: admin
+    '26cf59d323394cd4c9a9706de385347fb80189005d5e9e38574c2fed30093c6bdcb335' ||
+    'eee3d61198791b51940e3a99899c27e6e6109c1a7d65f78910bfdc41d2b885c3cf2767b0f6'
+  ),
+  (
+    'p1',
+    -- password: p1
+    'fdd4faeb765ba02721c61daffaf6df69e45a9a48252ffbbf522f7d73363c1e945d2c5c' ||
+    '88bc38fe17d374abcdaa87f6a218032bd1d93e9b9dd47e35ad6d7021bf3ffa7725ee1d801c'
+  ),
+  (
+    'system',
+    -- password: system
+    '17875afbd828d562a92dec2e287c425c9b844b298bb8d241adfcb893e937a8ac3e48f0' ||
+    '98181be881581e6edbe84e40cd48d42c4ce5959af990fab2e6644397deed0135a8e9aea50c'
+  );
 
 CREATE TABLE audit_records(
   audit_record_id BIGINT PRIMARY KEY,

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -377,4 +377,20 @@ public class CMSConfigurator {
     public String getInternalSecurityToken() {
         return globalSettings.getProperty("internalSecurityToken");
     }
+
+    public String getPasswordSecret() {
+        return globalSettings.getProperty("keys.password.secret");
+    }
+
+    public Integer getPasswordIterations() {
+        return Integer.valueOf(
+                globalSettings.getProperty("keys.password.iterations")
+        );
+    }
+
+    public Integer getPasswordHashWidth() {
+        return Integer.valueOf(
+                globalSettings.getProperty("keys.password.hashWidth")
+        );
+    }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -23,7 +23,15 @@ import gov.medicaid.entities.EmailTemplate;
 import gov.medicaid.entities.Role;
 import gov.medicaid.entities.SystemId;
 import gov.medicaid.services.util.Util;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -31,16 +39,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
-
-import org.apache.velocity.app.VelocityEngine;
-import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 
 /**
  * CMS configurator.

--- a/psm-app/services/src/main/resources/cms.properties
+++ b/psm-app/services/src/main/resources/cms.properties
@@ -212,6 +212,9 @@ binders.40.summaryjsp=pageTemplates/summary/physician_clinic_facility_qualificat
 # hashing keys
 keys.formhash=CHANGEIT
 keys.remembermehash=CHANGEIT
+keys.password.secret=CHANGEIT
+keys.password.iterations=360000
+keys.password.hashWidth=512
 
 # maximum upload size
 max.upload.size=512000000


### PR DESCRIPTION
Replace the password hashing algorithm for users whose password is stored in the database (as opposed to some external system, which is not currently implemented). Previously we were using SHA1, which is not appropriate for passwords; it is designed for speed, whereas password hashing algorithms should be as slow as we can tolerate.

Use PBKDF2 instead, as provided by Spring Security, and expose the tunable parameters (secret, iterations, and hash width) through `cms.properties`. Hash width probably won't need to change, but users should set the `secret` to something unique and the number of iterations high enough that it takes their server about half a second to generate a password.

---

This changes the form of passwords stored in the database. If you try to log in with a user with an old password, you will get an error. I don't think we need to support migrations at this stage of the project, so you will need to do some manual migrations. Your options include:
- Use "reset password" on your `system` account, and then use the system account to set each other account's password.
- If you only have the three accounts in `seed.sql`, you can `DELETE FROM cms_authentication;` and then run the `INSERT` statement updated in `seed.sql`.
- Re-run `seed.sql`, perhaps by running the script `rebuild-and-change-schema-for-testing.sh`.

---

To test this, I deployed, followed the migration instructions above, and verified that I could log in and that the contents of the `cms_authentication` table contained much longer values.

---

See also:
- https://docs.spring.io/spring-security/site/docs/4.2.3.RELEASE/reference/html/crypto.html#spring-security-crypto-passwordencoders
- https://docs.spring.io/spring-security/site/docs/4.2.3.RELEASE/apidocs/

Issue #34 Improve password handling
Issue #465 Use FIPS-approved encryption