### PR TITLE
Fix logout by using CSRF-protected logout form

### DIFF
--- a/psm-app/cms-web/WebContent/templates/includes/header.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/header.template.html
@@ -2,7 +2,11 @@
   <div class="contentWidth">
     <div class="userSection">
       Welcome, <strong>{{principalUser.username}}</strong>
-      | <a href="javascript:;">Help</a> | <a href="{{ctx}}/j_spring_security_logout">Logout</a>
+      | <a href="javascript:;">Help</a>
+      | <form action="{{ctx}}/logout" method="post" class="logoutForm">
+          <input type="submit" class="logoutButton" value="Logout"/>
+          <input type="hidden" name="{{csrf.parameterName}}" value="{{csrf.token}}"/>
+        </form>
     </div>
     <!-- /.userSection -->
     <div class="mastHead">


### PR DESCRIPTION
When enabling CSRF protection in 6374933a8d5d13749593b0fe92430034706a03be, I missed the handlebars version of the header. When we switched from using the JSP version to the handlebars version in 801ef005aa1a2b7b164785b7cdd480291e1aec50, logout broke.

Update the handlebars header template to use the CSRF-protected logout form introduced in 6374933a8d5d13749593b0fe92430034706a03be.

---

To test this, I logged in and back out as `p1`, `admin`, and `system`.

@cecilia-donnelly has volunteered to write an automated test to protect against future logout regressions.

---

Issue #219 Upgrade Spring
Issue #238 Templatize UI
PR #503 Enable CSRF Protection
PR #538 Use handlebars header, footer, logo, and nav templates